### PR TITLE
[ggj] fix!: rename classes to make inheritance more obvious

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/AstNodeVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/ast/AstNodeVisitor.java
@@ -16,9 +16,9 @@ package com.google.api.generator.engine.ast;
 
 public interface AstNodeVisitor {
   /** Writes the syntatically-correct Java code representation of this node. */
-  public void visit(Identifier identifier);
+  public void visit(IdentifierNode identifier);
 
-  public void visit(Type type);
+  public void visit(TypeNode type);
 
-  public void visit(Reference reference);
+  public void visit(ReferenceTypeNode reference);
 }

--- a/src/main/java/com/google/api/generator/engine/ast/IdentifierNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/IdentifierNode.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import java.util.regex.Pattern;
 
 @AutoValue
-public abstract class Identifier implements AstNode {
+public abstract class IdentifierNode implements AstNode {
   static class InvalidIdentifierException extends RuntimeException {
     public InvalidIdentifierException(String errorMessage) {
       super(errorMessage);
@@ -36,7 +36,7 @@ public abstract class Identifier implements AstNode {
   public abstract String name();
 
   public static Builder builder() {
-    return new AutoValue_Identifier.Builder();
+    return new AutoValue_IdentifierNode.Builder();
   }
 
   @Override
@@ -53,10 +53,10 @@ public abstract class Identifier implements AstNode {
   public abstract static class Builder {
     public abstract Builder setName(String name);
 
-    abstract Identifier autoBuild();
+    abstract IdentifierNode autoBuild();
 
-    public Identifier build() throws InvalidIdentifierException {
-      Identifier identifier = autoBuild();
+    public IdentifierNode build() throws InvalidIdentifierException {
+      IdentifierNode identifier = autoBuild();
       String identifierName = identifier.name();
       Preconditions.checkNotNull(identifierName);
 

--- a/src/main/java/com/google/api/generator/engine/ast/ReferenceTypeNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ReferenceTypeNode.java
@@ -14,8 +14,8 @@
 
 package com.google.api.generator.engine.ast;
 
-public class Reference implements AstNode {
-  // TODO(miraleung): More logic here.
+public class ReferenceTypeNode implements AstNode {
+  // TODO(miraleung): More logic here. Make this extend TypeNode.
 
   @Override
   public void accept(AstNodeVisitor visitor) {

--- a/src/main/java/com/google/api/generator/engine/ast/TypeNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/TypeNode.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class Type implements AstNode {
+public abstract class TypeNode implements AstNode {
   public enum TypeKind {
     BYTE,
     SHORT,
@@ -37,10 +37,10 @@ public abstract class Type implements AstNode {
   public abstract boolean isArray();
 
   @Nullable
-  public abstract Reference reference();
+  public abstract ReferenceTypeNode reference();
 
   public static Builder builder() {
-    return new AutoValue_Type.Builder().setIsArray(false);
+    return new AutoValue_TypeNode.Builder().setIsArray(false);
   }
 
   @AutoValue.Builder
@@ -49,29 +49,29 @@ public abstract class Type implements AstNode {
 
     public abstract Builder setIsArray(boolean isArray);
 
-    public abstract Builder setReference(Reference reference);
+    public abstract Builder setReference(ReferenceTypeNode reference);
 
-    public abstract Type build();
+    public abstract TypeNode build();
   }
 
   // TODO(miraleung): More type creation helpers to come...
-  public static Type createReferenceType(Reference reference) {
-    return Type.builder().setTypeKind(TypeKind.OBJECT).setReference(reference).build();
+  public static TypeNode createReferenceType(ReferenceTypeNode reference) {
+    return TypeNode.builder().setTypeKind(TypeKind.OBJECT).setReference(reference).build();
   }
 
-  public static Type createReferenceArrayType(Reference reference) {
-    return Type.builder()
+  public static TypeNode createReferenceArrayType(ReferenceTypeNode reference) {
+    return TypeNode.builder()
         .setTypeKind(TypeKind.OBJECT)
         .setReference(reference)
         .setIsArray(true)
         .build();
   }
 
-  public static Type createIntType() {
+  public static TypeNode createIntType() {
     return createPrimitiveType(TypeKind.INT);
   }
 
-  public static Type createByteArrayType() {
+  public static TypeNode createByteArrayType() {
     return createPrimitiveArrayType(TypeKind.BYTE);
   }
 
@@ -87,28 +87,28 @@ public abstract class Type implements AstNode {
   // Java overrides.
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Type)) {
+    if (!(o instanceof TypeNode)) {
       return false;
     }
 
-    Type type = (Type) o;
+    TypeNode type = (TypeNode) o;
     return typeKind().equals(type.typeKind())
         && (isArray() == type.isArray())
         && Objects.equals(reference(), type.reference());
   }
 
-  private static Type createPrimitiveType(TypeKind typeKind) {
+  private static TypeNode createPrimitiveType(TypeKind typeKind) {
     if (!isPrimitiveType(typeKind)) {
       throw new IllegalArgumentException("Object is not a primitive type.");
     }
-    return Type.builder().setTypeKind(typeKind).build();
+    return TypeNode.builder().setTypeKind(typeKind).build();
   }
 
-  private static Type createPrimitiveArrayType(TypeKind typeKind) {
+  private static TypeNode createPrimitiveArrayType(TypeKind typeKind) {
     if (typeKind.equals(TypeKind.OBJECT)) {
       throw new IllegalArgumentException("Object is not a primitive type.");
     }
-    return Type.builder().setTypeKind(typeKind).setIsArray(true).build();
+    return TypeNode.builder().setTypeKind(typeKind).setIsArray(true).build();
   }
 
   private static boolean isPrimitiveType(TypeKind typeKind) {

--- a/src/main/java/com/google/api/generator/engine/ast/Variable.java
+++ b/src/main/java/com/google/api/generator/engine/ast/Variable.java
@@ -18,9 +18,9 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Variable {
-  public abstract Identifier identifier();
+  public abstract IdentifierNode identifier();
 
-  public abstract Type type();
+  public abstract TypeNode type();
 
   public static Builder builder() {
     return new AutoValue_Variable.Builder();
@@ -28,9 +28,9 @@ public abstract class Variable {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setType(Type type);
+    public abstract Builder setType(TypeNode type);
 
-    public abstract Builder setIdentifier(Identifier identifier);
+    public abstract Builder setIdentifier(IdentifierNode identifier);
 
     public abstract Variable build();
   }

--- a/src/main/java/com/google/api/generator/engine/writer/JavaWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/JavaWriterVisitor.java
@@ -15,10 +15,10 @@
 package com.google.api.generator.engine.writer;
 
 import com.google.api.generator.engine.ast.AstNodeVisitor;
-import com.google.api.generator.engine.ast.Identifier;
-import com.google.api.generator.engine.ast.Reference;
-import com.google.api.generator.engine.ast.Type;
-import com.google.api.generator.engine.ast.Type.TypeKind;
+import com.google.api.generator.engine.ast.IdentifierNode;
+import com.google.api.generator.engine.ast.ReferenceTypeNode;
+import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.engine.ast.TypeNode.TypeKind;
 
 public class JavaWriterVisitor implements AstNodeVisitor {
   private final StringBuffer buffer = new StringBuffer();
@@ -34,12 +34,12 @@ public class JavaWriterVisitor implements AstNodeVisitor {
   }
 
   @Override
-  public void visit(Identifier identifier) {
+  public void visit(IdentifierNode identifier) {
     buffer.append(identifier.name());
   }
 
   @Override
-  public void visit(Type type) {
+  public void visit(TypeNode type) {
     TypeKind typeKind = type.typeKind();
     StringBuilder generatedCodeBuilder = new StringBuilder();
     if (type.isPrimitiveType()) {
@@ -59,7 +59,7 @@ public class JavaWriterVisitor implements AstNodeVisitor {
   }
 
   @Override
-  public void visit(Reference reference) {
+  public void visit(ReferenceTypeNode reference) {
     throw new RuntimeException("Not yet implemented for reference types");
   }
 }

--- a/src/test/java/com/google/api/generator/engine/ast/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/engine/ast/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 TESTS = [
-    "IdentifierTest",
+    "IdentifierNodeTest",
 ]
 
 filegroup(

--- a/src/test/java/com/google/api/generator/engine/ast/IdentifierNodeTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/IdentifierNodeTest.java
@@ -17,10 +17,10 @@ package com.google.api.generator.engine.ast;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.api.generator.engine.ast.Identifier.InvalidIdentifierException;
+import com.google.api.generator.engine.ast.IdentifierNode.InvalidIdentifierException;
 import org.junit.Test;
 
-public class IdentifierTest {
+public class IdentifierNodeTest {
   @Test
   public void createIdentifier_basic() {
     assertValidIdentifier("foobar");
@@ -108,11 +108,11 @@ public class IdentifierTest {
     assertThrows(
         InvalidIdentifierException.class,
         () -> {
-          Identifier.builder().setName(idName).build();
+          IdentifierNode.builder().setName(idName).build();
         });
   }
 
   private static void assertValidIdentifier(String idName) {
-    assertThat(Identifier.builder().setName(idName).build().name()).isEqualTo(idName);
+    assertThat(IdentifierNode.builder().setName(idName).build().name()).isEqualTo(idName);
   }
 }

--- a/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
+++ b/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
@@ -16,8 +16,8 @@ package com.google.api.generator.engine.writer;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.api.generator.engine.ast.Identifier;
-import com.google.api.generator.engine.ast.Type;
+import com.google.api.generator.engine.ast.IdentifierNode;
+import com.google.api.generator.engine.ast.TypeNode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,13 +33,13 @@ public class JavaWriterVisitorTest {
   public void writeIdentifier() {
 
     String idName = "foobar";
-    Identifier.builder().setName(idName).build().accept(writerVisitor);
+    IdentifierNode.builder().setName(idName).build().accept(writerVisitor);
     assertThat(writerVisitor.write()).isEqualTo(idName);
   }
 
   @Test
   public void writePrimitiveType() {
-    Type intType = Type.createIntType();
+    TypeNode intType = TypeNode.createIntType();
     assertThat(intType).isNotNull();
     intType.accept(writerVisitor);
     assertThat(writerVisitor.write()).isEqualTo("int");
@@ -47,7 +47,7 @@ public class JavaWriterVisitorTest {
 
   @Test
   public void writePrimitiveArrayType() {
-    Type byteArrayType = Type.createByteArrayType();
+    TypeNode byteArrayType = TypeNode.createByteArrayType();
     assertThat(byteArrayType).isNotNull();
     byteArrayType.accept(writerVisitor);
     assertThat(writerVisitor.write()).isEqualTo("byte[]");


### PR DESCRIPTION
Java classes should typically adhere to the <Type><SuperType> naming convention. For example, devs will be able to quickly tell that TypeNode inherits from AstNode and Variable does not. The monolith generator seemed to use this naming convention as well.