### PR TITLE
[ggj] fix: enable super/sub type assignments

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/AssignmentExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/AssignmentExpr.java
@@ -38,10 +38,19 @@ public abstract class AssignmentExpr implements Expr {
       AssignmentExpr assignmentExpr = autoBuild();
       TypeNode lhsType = assignmentExpr.variableExpr().variable().type();
       TypeNode rhsType = assignmentExpr.valueExpr().type();
-      if (!lhsType.equals(rhsType)) {
-        throw new TypeMismatchException(
-            String.format(
-                "LHS type %s must match RHS type %s", lhsType.toString(), rhsType.toString()));
+      if (lhsType.isPrimitiveType()) {
+        if (!lhsType.equals(rhsType)) {
+          throw new TypeMismatchException(
+              String.format(
+                  "LHS type %s must match RHS type %s", lhsType.toString(), rhsType.toString()));
+        }
+      } else {
+        if (!lhsType.reference().clazz().isAssignableFrom(rhsType.reference().clazz())) {
+          throw new TypeMismatchException(
+              String.format(
+                  "LHS type %s must be a supertype of the RHS type %s",
+                  lhsType.reference().name(), rhsType.reference().name()));
+        }
       }
 
       return assignmentExpr;

--- a/src/test/java/com/google/api/generator/engine/ast/AssignmentExprTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/AssignmentExprTest.java
@@ -17,6 +17,8 @@ package com.google.api.generator.engine.ast;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 
 public class AssignmentExprTest {
@@ -45,6 +47,26 @@ public class AssignmentExprTest {
     Expr valueExpr = ValueExpr.builder().setValue(value).build();
 
     assertInvalidAssignmentExpr(variableExpr, valueExpr);
+  }
+
+  @Test
+  public void assignSubtypeValue() {
+    IdentifierNode identifier = IdentifierNode.builder().setName("x").build();
+    Variable variable =
+        Variable.builder()
+            .setIdentifier(identifier)
+            .setType(TypeNode.withReference(Reference.withClazz(List.class)))
+            .build();
+    VariableExpr variableExpr =
+        VariableExpr.builder().setVariable(variable).setIsDecl(true).build();
+
+    MethodInvocationExpr valueExpr =
+        MethodInvocationExpr.builder()
+            .setMethodName("getAList")
+            .setReturnType(TypeNode.withReference(Reference.withClazz(ArrayList.class)))
+            .build();
+
+    assertValidAssignmentExpr(variableExpr, valueExpr);
   }
 
   @Test


### PR DESCRIPTION
This will allow us to have assignment statements such as:
```java
Map<String, Integer> aMap = methodThatReturnsAHashMap();
```