### PR TITLE
[ggj] feat: add VaporReference

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
@@ -15,13 +15,16 @@
 package com.google.api.generator.engine.ast;
 
 import com.google.auto.value.AutoValue;
-import java.util.Collections;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @AutoValue
 public abstract class ConcreteReference implements Reference {
   @Override
-  public abstract List<Reference> generics();
+  public abstract ImmutableList<Reference> generics();
+
+  // Private.
+  abstract Class clazz();
 
   @Override
   public String name() {
@@ -85,17 +88,6 @@ public abstract class ConcreteReference implements Reference {
     return clazz().isAssignableFrom(((ConcreteReference) other).clazz());
   }
 
-  public static ConcreteReference withClazz(Class clazz) {
-    return builder().setClazz(clazz).build();
-  }
-
-  // Private.
-  abstract Class clazz();
-
-  public static Builder builder() {
-    return new AutoValue_ConcreteReference.Builder().setGenerics(Collections.emptyList());
-  }
-
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof ConcreteReference)) {
@@ -109,6 +101,14 @@ public abstract class ConcreteReference implements Reference {
   @Override
   public int hashCode() {
     return 17 * clazz().hashCode() + 31 * generics().hashCode();
+  }
+
+  public static ConcreteReference withClazz(Class clazz) {
+    return builder().setClazz(clazz).build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_ConcreteReference.Builder().setGenerics(ImmutableList.of());
   }
 
   @AutoValue.Builder

--- a/src/main/java/com/google/api/generator/engine/ast/Reference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/Reference.java
@@ -14,10 +14,10 @@
 
 package com.google.api.generator.engine.ast;
 
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 public interface Reference {
-  List<Reference> generics();
+  ImmutableList<Reference> generics();
 
   String name();
 

--- a/src/main/java/com/google/api/generator/engine/ast/VaporReference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/VaporReference.java
@@ -1,0 +1,140 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.engine.ast;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class VaporReference implements Reference {
+  @Override
+  public abstract ImmutableList<Reference> generics();
+
+  @Override
+  public abstract String name();
+
+  @Override
+  public String fullName() {
+    if (hasEnclosingClass()) {
+      return String.format("%s.%s.%s", pakkage(), enclosingClassName(), plainName());
+    }
+    return String.format("%s.%s", pakkage(), plainName());
+  }
+
+  @Override
+  public boolean hasEnclosingClass() {
+    return !Strings.isNullOrEmpty(enclosingClassName());
+  }
+
+  @Override
+  public boolean isFromPackage(String pkg) {
+    return pakkage().equals(pkg);
+  }
+
+  @Override
+  public boolean isSupertypeOrEquals(Reference other) {
+    // Not handling this for VaporReference.
+    return false;
+  }
+
+  @Override
+  public boolean isAssignableFrom(Reference other) {
+    // Not handling this for VaporReference.
+    return false;
+  }
+
+  // Private.
+  abstract String pakkage();
+
+  abstract String plainName();
+
+  @Nullable
+  abstract String enclosingClassName();
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof VaporReference)) {
+      return false;
+    }
+
+    VaporReference ref = (VaporReference) o;
+    return pakkage().equals(ref.pakkage())
+        && name().equals(ref.name())
+        && generics().equals(ref.generics())
+        && Objects.equals(enclosingClassName(), ref.enclosingClassName());
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 17 * pakkage().hashCode() + 19 * name().hashCode() + 23 * generics().hashCode();
+    if (!Strings.isNullOrEmpty(enclosingClassName())) {
+      hash += 29 * enclosingClassName().hashCode();
+    }
+    return hash;
+  }
+
+  public static Builder builder() {
+    return new AutoValue_VaporReference.Builder().setGenerics(ImmutableList.of());
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setName(String name);
+
+    public abstract Builder setPakkage(String pakkage);
+
+    public abstract Builder setGenerics(List<Reference> clazzes);
+
+    public abstract Builder setEnclosingClassName(String enclosingClassName);
+
+    // Private.
+    abstract Builder setPlainName(String plainName);
+
+    abstract String name();
+
+    abstract ImmutableList<Reference> generics();
+
+    abstract VaporReference autoBuild();
+
+    public VaporReference build() {
+      // Validate the name.
+      IdentifierNode.builder().setName(name()).build();
+      // No exception thrown, so we can proceed.
+
+      setPlainName(name());
+
+      StringBuilder sb = new StringBuilder();
+      sb.append(name());
+      if (!generics().isEmpty()) {
+        sb.append("<");
+        for (int i = 0; i < generics().size(); i++) {
+          Reference r = generics().get(i);
+          sb.append(r.name());
+          if (i < generics().size() - 1) {
+            sb.append(", ");
+          }
+        }
+        sb.append(">");
+      }
+      setName(sb.toString());
+
+      return autoBuild();
+    }
+  }
+}

--- a/src/test/java/com/google/api/generator/engine/ast/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/engine/ast/BUILD.bazel
@@ -10,10 +10,12 @@ TESTS = [
     "MethodDefinitionTest",
     "NullObjectValueTest",
     "PrimitiveValueTest",
+    "ReferenceTest",
     "TernaryExprTest",
     "TryCatchStatementTest",
     "VariableExprTest",
     "VariableTest",
+    "VaporReferenceTest",
 ]
 
 filegroup(

--- a/src/test/java/com/google/api/generator/engine/ast/ReferenceTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/ReferenceTest.java
@@ -1,0 +1,130 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.engine.ast;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.Test;
+
+public class ReferenceTest {
+  @Test
+  public void nestedGenerics_concreteReferenceOuter() {
+    Reference mapReference =
+        VaporReference.builder()
+            .setName("HashMap")
+            .setPakkage("java.util")
+            .setGenerics(
+                Arrays.asList(
+                    ConcreteReference.withClazz(String.class),
+                    ConcreteReference.withClazz(Integer.class)))
+            .build();
+    Reference outerMapReference =
+        ConcreteReference.builder()
+            .setClazz(HashMap.class)
+            .setGenerics(Arrays.asList(mapReference, mapReference))
+            .build();
+    Reference listReference =
+        ConcreteReference.builder()
+            .setClazz(List.class)
+            .setGenerics(Arrays.asList(outerMapReference))
+            .build();
+    assertEquals(
+        listReference.name(), "List<HashMap<HashMap<String, Integer>, HashMap<String, Integer>>>");
+    assertEquals(listReference.fullName(), "java.util.List");
+  }
+
+  @Test
+  public void nestedGenerics_vaporReferenceOuter() {
+    Reference mapReference =
+        ConcreteReference.builder()
+            .setClazz(HashMap.class)
+            .setGenerics(
+                Arrays.asList(
+                    VaporReference.builder().setName("String").setPakkage("java.lang").build(),
+                    ConcreteReference.withClazz(Integer.class)))
+            .build();
+    Reference outerMapReference =
+        VaporReference.builder()
+            .setName("HashMap")
+            .setPakkage("java.util")
+            .setGenerics(Arrays.asList(mapReference, mapReference))
+            .build();
+    Reference listReference =
+        VaporReference.builder()
+            .setName("List")
+            .setPakkage("java.util")
+            .setGenerics(Arrays.asList(outerMapReference))
+            .build();
+    assertEquals(
+        listReference.name(), "List<HashMap<HashMap<String, Integer>, HashMap<String, Integer>>>");
+    assertEquals(listReference.fullName(), "java.util.List");
+  }
+
+  @Test
+  public void mixedConcreteVaporReferenceEquals() {
+    Reference mapReferenceVaporOuter =
+        ConcreteReference.builder()
+            .setClazz(HashMap.class)
+            .setGenerics(
+                Arrays.asList(
+                    VaporReference.builder().setName("String").setPakkage("java.lang").build(),
+                    ConcreteReference.withClazz(Integer.class)))
+            .build();
+    Reference outerMapReferenceVaporOuter =
+        VaporReference.builder()
+            .setName("HashMap")
+            .setPakkage("java.util")
+            .setGenerics(Arrays.asList(mapReferenceVaporOuter, mapReferenceVaporOuter))
+            .build();
+    Reference listReferenceVaporOuter =
+        VaporReference.builder()
+            .setName("List")
+            .setPakkage("java.util")
+            .setGenerics(Arrays.asList(outerMapReferenceVaporOuter))
+            .build();
+
+    Reference mapReferenceConcreteOuter =
+        VaporReference.builder()
+            .setName("HashMap")
+            .setPakkage("java.util")
+            .setGenerics(
+                Arrays.asList(
+                    ConcreteReference.withClazz(String.class),
+                    ConcreteReference.withClazz(Integer.class)))
+            .build();
+    Reference outerMapReferenceConcreteOuter =
+        ConcreteReference.builder()
+            .setClazz(HashMap.class)
+            .setGenerics(Arrays.asList(mapReferenceConcreteOuter, mapReferenceConcreteOuter))
+            .build();
+    Reference listReferenceConcreteOuter =
+        ConcreteReference.builder()
+            .setClazz(List.class)
+            .setGenerics(Arrays.asList(outerMapReferenceConcreteOuter))
+            .build();
+
+    assertEquals(listReferenceConcreteOuter, listReferenceConcreteOuter);
+
+    assertFalse(listReferenceConcreteOuter.equals(listReferenceVaporOuter));
+    assertFalse(listReferenceVaporOuter.equals(listReferenceConcreteOuter));
+
+    assertFalse(listReferenceConcreteOuter.isAssignableFrom(listReferenceVaporOuter));
+    assertFalse(listReferenceVaporOuter.isAssignableFrom(listReferenceConcreteOuter));
+  }
+}

--- a/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.engine.ast;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class VaporReferenceTest {
+  @Test
+  public void basic() {
+    String pkg = "com.google.example.examples.library.v1";
+    String name = "Babbage";
+    Reference ref = VaporReference.builder().setName(name).setPakkage(pkg).build();
+    assertEquals(ref.name(), name);
+    assertEquals(ref.fullName(), String.format("%s.%s", pkg, name));
+    assertFalse(ref.hasEnclosingClass());
+    assertTrue(ref.isFromPackage(pkg));
+    assertFalse(ref.isFromPackage("com.google.example.library"));
+  }
+
+  @Test
+  public void concreteHierarchiesNotHandled() {
+    String pkg = "java.io";
+    String name = "IOException";
+    Reference ref = VaporReference.builder().setName(name).setPakkage(pkg).build();
+
+    Reference exceptionRef = ConcreteReference.withClazz(Exception.class);
+    assertFalse(ref.isAssignableFrom(exceptionRef));
+    assertFalse(exceptionRef.isAssignableFrom(ref));
+    assertFalse(exceptionRef.isSupertypeOrEquals(ref));
+  }
+
+  @Test
+  public void enclosingClass() {
+    String pkg = "java.util";
+    String enclosingName = "Map";
+    String name = "Entry";
+
+    Reference ref =
+        VaporReference.builder()
+            .setName(name)
+            .setPakkage(pkg)
+            .setEnclosingClassName(enclosingName)
+            .build();
+    assertTrue(ref.hasEnclosingClass());
+    assertEquals(ref.fullName(), String.format("%s.%s.%s", pkg, enclosingName, name));
+  }
+}


### PR DESCRIPTION
Provides a way to use `Reference` for types that don't exist at runtime.