### PR TITLE
feat: add static import toggling

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
@@ -20,28 +20,55 @@ import java.util.List;
 
 @AutoValue
 public abstract class ConcreteReference implements Reference {
-  @Override
-  public abstract ImmutableList<Reference> generics();
+  private static final String DOT = ".";
+  private static final String LEFT_ANGLE = "<";
+  private static final String RIGHT_ANGLE = ">";
+  private static final String COMMA = ", ";
 
   // Private.
   abstract Class clazz();
 
   @Override
+  public abstract ImmutableList<Reference> generics();
+
+  @Override
+  public abstract boolean isStaticImport();
+
+  @Override
   public String name() {
     StringBuilder sb = new StringBuilder();
+
+    if (hasEnclosingClass() && !isStaticImport()) {
+      sb.append(clazz().getEnclosingClass().getSimpleName());
+      sb.append(DOT);
+    }
+
     sb.append(clazz().getSimpleName());
     if (!generics().isEmpty()) {
-      sb.append("<");
+      sb.append(LEFT_ANGLE);
       for (int i = 0; i < generics().size(); i++) {
         Reference r = generics().get(i);
         sb.append(r.name());
         if (i < generics().size() - 1) {
-          sb.append(", ");
+          sb.append(COMMA);
         }
       }
-      sb.append(">");
+      sb.append(RIGHT_ANGLE);
     }
     return sb.toString();
+  }
+
+  @Override
+  public String pakkage() {
+    return clazz().getPackage().getName();
+  }
+
+  @Override
+  public String enclosingClassName() {
+    if (!hasEnclosingClass()) {
+      return null;
+    }
+    return clazz().getEnclosingClass().getSimpleName();
   }
 
   @Override
@@ -108,7 +135,9 @@ public abstract class ConcreteReference implements Reference {
   }
 
   public static Builder builder() {
-    return new AutoValue_ConcreteReference.Builder().setGenerics(ImmutableList.of());
+    return new AutoValue_ConcreteReference.Builder()
+        .setGenerics(ImmutableList.of())
+        .setIsStaticImport(false);
   }
 
   @AutoValue.Builder
@@ -117,6 +146,18 @@ public abstract class ConcreteReference implements Reference {
 
     public abstract Builder setGenerics(List<Reference> clazzes);
 
-    public abstract ConcreteReference build();
+    public abstract Builder setIsStaticImport(boolean isStaticImport);
+
+    public abstract ConcreteReference autoBuild();
+
+    // Private.
+    abstract Class clazz();
+
+    abstract boolean isStaticImport();
+
+    public ConcreteReference build() {
+      setIsStaticImport(clazz().getEnclosingClass() != null && isStaticImport());
+      return autoBuild();
+    }
   }
 }

--- a/src/main/java/com/google/api/generator/engine/ast/Reference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/Reference.java
@@ -15,6 +15,7 @@
 package com.google.api.generator.engine.ast;
 
 import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
 
 public interface Reference {
   ImmutableList<Reference> generics();
@@ -22,6 +23,14 @@ public interface Reference {
   String name();
 
   String fullName();
+
+  String pakkage();
+
+  @Nullable
+  String enclosingClassName();
+
+  // Valid only for nested classes.
+  boolean isStaticImport();
 
   boolean hasEnclosingClass();
 

--- a/src/main/java/com/google/api/generator/engine/ast/VaporReference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/VaporReference.java
@@ -23,6 +23,11 @@ import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class VaporReference implements Reference {
+  private static final String DOT = ".";
+  private static final String LEFT_ANGLE = "<";
+  private static final String RIGHT_ANGLE = ">";
+  private static final String COMMA = ", ";
+
   @Override
   public abstract ImmutableList<Reference> generics();
 
@@ -30,12 +35,23 @@ public abstract class VaporReference implements Reference {
   public abstract String name();
 
   @Override
+  public abstract String pakkage();
+
+  @Nullable
+  @Override
+  public abstract String enclosingClassName();
+
+  @Override
   public String fullName() {
+    // TODO(unsupported): Nested classes with depth greater than 1.
     if (hasEnclosingClass()) {
       return String.format("%s.%s.%s", pakkage(), enclosingClassName(), plainName());
     }
     return String.format("%s.%s", pakkage(), plainName());
   }
+
+  @Override
+  public abstract boolean isStaticImport();
 
   @Override
   public boolean hasEnclosingClass() {
@@ -59,13 +75,7 @@ public abstract class VaporReference implements Reference {
     return false;
   }
 
-  // Private.
-  abstract String pakkage();
-
   abstract String plainName();
-
-  @Nullable
-  abstract String enclosingClassName();
 
   @Override
   public boolean equals(Object o) {
@@ -90,7 +100,9 @@ public abstract class VaporReference implements Reference {
   }
 
   public static Builder builder() {
-    return new AutoValue_VaporReference.Builder().setGenerics(ImmutableList.of());
+    return new AutoValue_VaporReference.Builder()
+        .setGenerics(ImmutableList.of())
+        .setIsStaticImport(false);
   }
 
   @AutoValue.Builder
@@ -103,12 +115,19 @@ public abstract class VaporReference implements Reference {
 
     public abstract Builder setEnclosingClassName(String enclosingClassName);
 
+    public abstract Builder setIsStaticImport(boolean isStaticImport);
+
     // Private.
     abstract Builder setPlainName(String plainName);
 
     abstract String name();
 
     abstract ImmutableList<Reference> generics();
+
+    @Nullable
+    abstract String enclosingClassName();
+
+    abstract boolean isStaticImport();
 
     abstract VaporReference autoBuild();
 
@@ -119,18 +138,25 @@ public abstract class VaporReference implements Reference {
 
       setPlainName(name());
 
+      setIsStaticImport(enclosingClassName() != null && isStaticImport());
+
       StringBuilder sb = new StringBuilder();
+      if (enclosingClassName() != null && !isStaticImport()) {
+        sb.append(enclosingClassName());
+        sb.append(DOT);
+      }
+
       sb.append(name());
       if (!generics().isEmpty()) {
-        sb.append("<");
+        sb.append(LEFT_ANGLE);
         for (int i = 0; i < generics().size(); i++) {
           Reference r = generics().get(i);
           sb.append(r.name());
           if (i < generics().size() - 1) {
-            sb.append(", ");
+            sb.append(COMMA);
           }
         }
-        sb.append(">");
+        sb.append(RIGHT_ANGLE);
       }
       setName(sb.toString());
 

--- a/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
@@ -61,6 +61,9 @@ public class ImportWriterVisitor implements AstNodeVisitor {
   }
 
   public String write() {
+    // Clear out any imports duplicated across the static and non-static sets.
+    staticImports.stream().forEach(i -> imports.remove(i));
+
     StringBuffer sb = new StringBuffer();
     if (!staticImports.isEmpty()) {
       sb.append(
@@ -236,11 +239,15 @@ public class ImportWriterVisitor implements AstNodeVisitor {
         continue;
       }
 
-      if (ref.hasEnclosingClass()) {
+      if (ref.isStaticImport()) {
         // This is a static import.
         staticImports.add(ref.fullName());
       } else {
-        imports.add(ref.fullName());
+        if (ref.hasEnclosingClass()) {
+          imports.add(String.format("%s.%s", ref.pakkage(), ref.enclosingClassName()));
+        } else {
+          imports.add(ref.fullName());
+        }
       }
 
       references(ref.generics());

--- a/src/main/java/com/google/api/generator/engine/writer/JavaWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/JavaWriterVisitor.java
@@ -160,7 +160,7 @@ public class JavaWriterVisitor implements AstNodeVisitor {
   }
 
   @Override
-  public void visit(TernaryExpr ternaryExpr){
+  public void visit(TernaryExpr ternaryExpr) {
     ternaryExpr.conditionExpr().accept(this);
     space();
     buffer.append(QUESTION_MARK);

--- a/src/test/java/com/google/api/generator/engine/ast/ConcreteReferenceTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/ConcreteReferenceTest.java
@@ -30,6 +30,30 @@ public class ConcreteReferenceTest {
   public void basicConcreteReference() {
     Reference reference = ConcreteReference.builder().setClazz(Integer.class).build();
     assertEquals(reference.name(), Integer.class.getSimpleName());
+    assertFalse(reference.isStaticImport());
+  }
+
+  @Test
+  public void basicConcreteReference_setIsStaticImport() {
+    Reference reference =
+        ConcreteReference.builder().setClazz(Integer.class).setIsStaticImport(true).build();
+    assertEquals(reference.name(), Integer.class.getSimpleName());
+    assertFalse(reference.isStaticImport());
+  }
+
+  @Test
+  public void basicConcreteReference_nested() {
+    Reference reference = ConcreteReference.builder().setClazz(Map.Entry.class).build();
+    assertEquals(reference.name(), "Map.Entry");
+    assertFalse(reference.isStaticImport());
+  }
+
+  @Test
+  public void basicConcreteReference_nestedAndStaticImport() {
+    Reference reference =
+        ConcreteReference.builder().setClazz(Map.Entry.class).setIsStaticImport(true).build();
+    assertEquals(reference.name(), Map.Entry.class.getSimpleName());
+    assertTrue(reference.isStaticImport());
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
@@ -43,6 +43,7 @@ public class VaporReferenceTest {
     assertEquals(ref.fullName(), String.format("%s.%s", pkg, name));
     assertFalse(ref.hasEnclosingClass());
     assertTrue(ref.isFromPackage(pkg));
+    // isStaticImport is automatically false for non-nested classes.
     assertFalse(ref.isFromPackage("com.google.example.library"));
     assertFalse(ref.isStaticImport());
   }

--- a/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/VaporReferenceTest.java
@@ -34,6 +34,59 @@ public class VaporReferenceTest {
   }
 
   @Test
+  public void basic_isStaticImport() {
+    String pkg = "com.google.example.examples.library.v1";
+    String name = "Babbage";
+    Reference ref =
+        VaporReference.builder().setName(name).setPakkage(pkg).setIsStaticImport(true).build();
+    assertEquals(ref.name(), name);
+    assertEquals(ref.fullName(), String.format("%s.%s", pkg, name));
+    assertFalse(ref.hasEnclosingClass());
+    assertTrue(ref.isFromPackage(pkg));
+    assertFalse(ref.isFromPackage("com.google.example.library"));
+    assertFalse(ref.isStaticImport());
+  }
+
+  @Test
+  public void basic_nested() {
+    String pkg = "com.google.example.examples.library.v1";
+    String name = "Charles";
+    String enclosingClassName = "Babbage";
+    Reference ref =
+        VaporReference.builder()
+            .setEnclosingClassName(enclosingClassName)
+            .setName(name)
+            .setPakkage(pkg)
+            .build();
+    assertEquals(ref.name(), String.format("%s.%s", enclosingClassName, name));
+    assertEquals(ref.fullName(), String.format("%s.%s.%s", pkg, enclosingClassName, name));
+    assertTrue(ref.hasEnclosingClass());
+    assertTrue(ref.isFromPackage(pkg));
+    assertFalse(ref.isFromPackage("com.google.example.library"));
+    assertFalse(ref.isStaticImport());
+  }
+
+  @Test
+  public void basic_nestedAndStaticImport() {
+    String pkg = "com.google.example.examples.library.v1";
+    String name = "Charles";
+    String enclosingClassName = "Babbage";
+    Reference ref =
+        VaporReference.builder()
+            .setEnclosingClassName(enclosingClassName)
+            .setName(name)
+            .setPakkage(pkg)
+            .setIsStaticImport(true)
+            .build();
+    assertEquals(ref.name(), name);
+    assertEquals(ref.fullName(), String.format("%s.%s.%s", pkg, enclosingClassName, name));
+    assertTrue(ref.hasEnclosingClass());
+    assertTrue(ref.isFromPackage(pkg));
+    assertFalse(ref.isFromPackage("com.google.example.library"));
+    assertTrue(ref.isStaticImport());
+  }
+
+  @Test
   public void concreteHierarchiesNotHandled() {
     String pkg = "java.io";
     String name = "IOException";

--- a/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
+++ b/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
@@ -1016,10 +1016,8 @@ public class JavaWriterVisitorTest {
     assertEquals(
         writerVisitor.write(),
         String.format(
-            createLines(25),
+            createLines(23),
             "package com.google.example.library.v1.stub;\n",
-            "\n",
-            "import static java.util.Map.Entry;\n",
             "\n",
             "import com.google.api.generator.engine.ast.AssignmentExpr;\n",
             "import com.google.api.generator.engine.ast.ClassDefinition;\n",
@@ -1028,7 +1026,7 @@ public class JavaWriterVisitorTest {
             "\n",
             "public class LibraryServiceStub {\n",
             "private AssignmentExpr x;\n",
-            "protected Map<ClassDefinition, Entry<String, MethodDefinition>> y;\n",
+            "protected Map<ClassDefinition, Map.Entry<String, MethodDefinition>> y;\n",
             "public boolean open() {\n",
             "return true;\n",
             "}\n",


### PR DESCRIPTION
This will allow us to distinguish between static imports or nested references. 
- Static import case: `import java.util.Map.Entry` and references will use only `Entry`.
- Non-static: `import java.util.Map` and references will use `Map.Entry`.