### PR TITLE
build: integrate null type in Class Definition

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/ClassDefinition.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ClassDefinition.java
@@ -146,6 +146,8 @@ public abstract class ClassDefinition implements AstNode {
       // Check implemented interface types.
       for (TypeNode implType : classDef.implementsTypes()) {
         Preconditions.checkState(
+            !implType.equals(TypeNode.NULL), "Classes cannot implement null type");
+        Preconditions.checkState(
             TypeNode.isReferenceType(implType), "Classes cannot implement non-reference types");
       }
 

--- a/src/main/java/com/google/api/generator/engine/ast/ClassDefinition.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ClassDefinition.java
@@ -134,6 +134,8 @@ public abstract class ClassDefinition implements AstNode {
       // Check abstract extended type.
       if (classDef.extendsType() != null) {
         Preconditions.checkState(
+            !classDef.extendsType().equals(TypeNode.NULL), "Classes cannot extend null type.");
+        Preconditions.checkState(
             TypeNode.isReferenceType(classDef.extendsType()),
             "Classes cannot extend non-reference types");
         Preconditions.checkState(

--- a/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
-import javax.lang.model.type.NullType;
 import org.junit.Test;
 
 public class ClassDefinitionTest {
@@ -110,18 +109,6 @@ public class ClassDefinitionTest {
 
   @Test
   public void invalidClassDefinition_implementsNullType() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          ClassDefinition.builder()
-              .setPackageString("com.google.example.library.v1.stub")
-              .setName("LibraryServiceStub")
-              .setScope(ScopeNode.PUBLIC)
-              .setImplementsTypes(
-                  Arrays.asList(
-                      TypeNode.withReference(ConcreteReference.withClazz(NullType.class))))
-              .build();
-        });
     assertThrows(
         IllegalStateException.class,
         () -> {

--- a/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertThrows;
 import java.util.Arrays;
 import java.util.List;
 import javax.lang.model.type.NullType;
-import javax.lang.model.type.TypeKind;
-import javax.validation.constraints.Null;
 import org.junit.Test;
 
 public class ClassDefinitionTest {

--- a/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
@@ -70,19 +70,6 @@ public class ClassDefinitionTest {
   }
 
   @Test
-  public void validClassDefinition_implementsNullType() {
-    ClassDefinition.builder()
-        .setPackageString("com.google.example.library.v1.stub")
-        .setName("LibraryServiceStub")
-        .setScope(ScopeNode.PUBLIC)
-        .setImplementsTypes(
-            Arrays.asList(
-                TypeNode.withReference(ConcreteReference.withClazz(NullType.class)), TypeNode.NULL))
-        .build();
-    // No exception thrown, we're good.
-  }
-
-  @Test
   public void validClassDefinition_statementsAndMethods() {
     List<Statement> statements =
         Arrays.asList(
@@ -119,6 +106,32 @@ public class ClassDefinitionTest {
         .setMethods(methods)
         .build();
     // No exception thrown, we're good.
+  }
+
+  @Test
+  public void invalidClassDefinition_implementsNullType() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          ClassDefinition.builder()
+              .setPackageString("com.google.example.library.v1.stub")
+              .setName("LibraryServiceStub")
+              .setScope(ScopeNode.PUBLIC)
+              .setImplementsTypes(
+                  Arrays.asList(
+                      TypeNode.withReference(ConcreteReference.withClazz(NullType.class))))
+              .build();
+        });
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          ClassDefinition.builder()
+              .setPackageString("com.google.example.library.v1.stub")
+              .setName("LibraryServiceStub")
+              .setScope(ScopeNode.PUBLIC)
+              .setImplementsTypes(Arrays.asList(TypeNode.NULL))
+              .build();
+        });
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/ClassDefinitionTest.java
@@ -18,6 +18,9 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.TypeKind;
+import javax.validation.constraints.Null;
 import org.junit.Test;
 
 public class ClassDefinitionTest {
@@ -64,6 +67,19 @@ public class ClassDefinitionTest {
             Arrays.asList(
                 TypeNode.withReference(ConcreteReference.withClazz(Cloneable.class)),
                 TypeNode.withReference(ConcreteReference.withClazz(Readable.class))))
+        .build();
+    // No exception thrown, we're good.
+  }
+
+  @Test
+  public void validClassDefinition_implementsNullType() {
+    ClassDefinition.builder()
+        .setPackageString("com.google.example.library.v1.stub")
+        .setName("LibraryServiceStub")
+        .setScope(ScopeNode.PUBLIC)
+        .setImplementsTypes(
+            Arrays.asList(
+                TypeNode.withReference(ConcreteReference.withClazz(NullType.class)), TypeNode.NULL))
         .build();
     // No exception thrown, we're good.
   }
@@ -156,6 +172,20 @@ public class ClassDefinitionTest {
               .setName("LibraryServiceStub")
               .setScope(ScopeNode.PUBLIC)
               .setExtendsType(TypeNode.INT)
+              .build();
+        });
+  }
+
+  @Test
+  public void invalidClassDefinition_extendsNullType() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          ClassDefinition.builder()
+              .setPackageString("com.google.example.library.v1.stub")
+              .setName("LibraryServiceStub")
+              .setScope(ScopeNode.PUBLIC)
+              .setExtendsType(TypeNode.NULL)
               .build();
         });
   }


### PR DESCRIPTION
A class cannot extends NullType because it is an interface.

But a class can implements an NullType, so I put two cases in `classdefinitiontest`
Here is an example to implement NullType, where it is imported from `javax.lang.model.type.NullType`
```
class Summer implements NullType {

  @Override
  public TypeKind getKind() {
    return null;
  }

  @Override
  public <R, P> R accept(TypeVisitor<R, P> v, P p) {
    return null;
  }

  @Override
  public List<? extends AnnotationMirror> getAnnotationMirrors() {
    return null;
  }

  @Override
  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
    return null;
  }

  @Override
  public <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
    return null;
  }
}
```