### PR TITLE
[ggj]fix: include composer files in bazel format rules

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/BUILD.bazel
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "gapic_files",
     srcs = glob(["*.java"]) + [
+        "//src/test/java/com/google/api/generator/gapic/composer:composer_files",
         "//src/main/java/com/google/api/generator/gapic/model:model_files",
         "//src/main/java/com/google/api/generator/gapic/protoparser:protoparser_files",
     ],

--- a/src/test/java/com/google/api/generator/gapic/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/BUILD.bazel
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "gapic_files",
     srcs = [
+        "//src/test/java/com/google/api/generator/gapic/composer:composer_files",
         "//src/test/java/com/google/api/generator/gapic/model:model_files",
         "//src/test/java/com/google/api/generator/gapic/protoparser:protoparser_files",
     ],

--- a/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -7,6 +7,7 @@ TESTS = [
     "MockServiceImplClassComposerTest",
     "ServiceClientClassComposerTest",
     "ServiceClientTestClassComposerTest",
+    "ServiceSettingsClassComposerTest",
     "ServiceStubClassComposerTest",
 ]
 


### PR DESCRIPTION
1. include composer files in bazel format rules.
2. add `ServiceSettingsClassComposerTest` to bazel rules.