### PR TITLE
[ggj][bazel] fix: new repo bazel name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "com_google_api_generator")
+workspace(name = "gapic_generator_java")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -14,17 +14,17 @@ http_archive(
     ],
 )
 
-load("//:repository_rules.bzl", "com_google_api_generator_properties")
+load("//:repository_rules.bzl", "gapic_generator_java_properties")
 
-com_google_api_generator_properties(
-    name = "com_google_api_generator_properties",
+gapic_generator_java_properties(
+    name = "gapic_generator_java_properties",
     file = "//:dependencies.properties",
 )
 
-load("@com_google_api_generator_properties//:dependencies.properties.bzl", "PROPERTIES")
-load("//:repositories.bzl", "com_google_api_generator_repositories")
+load("@gapic_generator_java_properties//:dependencies.properties.bzl", "PROPERTIES")
+load("//:repositories.bzl", "gapic_generator_java_repositories")
 
-com_google_api_generator_repositories()
+gapic_generator_java_repositories()
 
 # protobuf
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,9 +15,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
-load("@com_google_api_generator_properties//:dependencies.properties.bzl", "PROPERTIES")
+load("@gapic_generator_java_properties//:dependencies.properties.bzl", "PROPERTIES")
 
-def com_google_api_generator_repositories():
+def gapic_generator_java_repositories():
     # Import dependencies shared between Gradle and Bazel (i.e. maven dependencies)
     for name, artifact in PROPERTIES.items():
         _maybe(

--- a/repository_rules.bzl
+++ b/repository_rules.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def _com_google_api_generator_properties_impl(ctx):
+def _gapic_generator_java_properties_impl(ctx):
     props_path = ctx.path(ctx.attr.file)
     result = ctx.execute(["cat", props_path])
 
@@ -40,8 +40,8 @@ PROPERTIES = {props_as_map}
     ctx.file("BUILD.bazel", "")
     ctx.file("%s.bzl" % props_name, dependencies_bzl)
 
-com_google_api_generator_properties = repository_rule(
-    implementation = _com_google_api_generator_properties_impl,
+gapic_generator_java_properties = repository_rule(
+    implementation = _gapic_generator_java_properties_impl,
     attrs = {
         "file": attr.label(),
     },

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -102,7 +102,7 @@ def java_gapic_library(
     proto_custom_library(
         name = raw_srcjar_name,
         deps = srcs,
-        plugin = Label("@com_google_api_generator//:protoc-gen-%s" % _java_generator_name),
+        plugin = Label("@gapic_generator_java//:protoc-gen-%s" % _java_generator_name),
         plugin_file_args = {},
         opt_file_args = file_args_dict,
         output_type = _java_generator_name,


### PR DESCRIPTION
Enables integration with the googleapis repo [here](https://github.com/googleapis/googleapis/pull/620).