### PR TITLE
feat: add final keyword checking in post increment operation expr

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/UnaryOperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/UnaryOperationExpr.java
@@ -72,6 +72,18 @@ public abstract class UnaryOperationExpr implements OperationExpr {
       UnaryOperationExpr unaryOperationExpr = autoBuild();
       TypeNode exprType = unaryOperationExpr.expr().type();
       OperatorKind operator = unaryOperationExpr.operatorKind();
+
+      // TODO: (summerji) Add Decl Check for variable.
+      // Add final keyword checking for post/prefix ++, -- when needed.
+      if (operator.equals(OperatorKind.UNARY_POST_INCREMENT)
+          && unaryOperationExpr.expr() instanceof VariableExpr) {
+        Preconditions.checkState(
+            !((VariableExpr) unaryOperationExpr.expr()).isFinal(),
+            String.format(
+                "Cannot assign a value to final variable '%s'.",
+                ((VariableExpr) unaryOperationExpr.expr()).variable().name()));
+      }
+
       final String errorMsg =
           String.format(
               "Unary operator %s can not be applied to %s. ", operator, exprType.toString());

--- a/src/test/java/com/google/api/generator/engine/ast/UnaryOperationExprTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/UnaryOperationExprTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 public class UnaryOperationExprTest {
   /** =============================== Logic Not Operation Expr =============================== */
   @Test
-  public void logicalNotOperationExpr_validBasic() {
+  public void validLogicalNotOperationExpr_basic() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.BOOLEAN).build());
@@ -30,7 +30,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void logicalNot_validBoxedType() {
+  public void validLogicalNot_boxedType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.BOOLEAN_OBJECT).build());
@@ -39,7 +39,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void logicalNot_invalidNumericType() {
+  public void invalidLogicalNot_numericType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.INT).build());
     assertThrows(
@@ -47,7 +47,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void logicalNot_invalidReferenceType() {
+  public void invalidLogicalNot_referenceType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.STRING).build());
     assertThrows(
@@ -58,7 +58,7 @@ public class UnaryOperationExprTest {
    * =============================== Post Increment Operation Expr ===============================
    */
   @Test
-  public void postIncrement_validBasic() {
+  public void validPostIncrement_basic() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.INT).build());
     UnaryOperationExpr.postfixIncrementWithExpr(variableExpr);
@@ -66,7 +66,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void postIncrement_validBoxedType() {
+  public void validPostIncrement_boxedType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.FLOAT_OBJECT).build());
@@ -75,7 +75,7 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void postIncrement_invalidBoxedBooleanType() {
+  public void invalidPostIncrement_boxedBooleanType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("x").setType(TypeNode.BOOLEAN_OBJECT).build());
@@ -85,9 +85,18 @@ public class UnaryOperationExprTest {
   }
 
   @Test
-  public void postIncrement_invalidReferenceType() {
+  public void invalidPostIncrement_referenceType() {
     VariableExpr variableExpr =
         VariableExpr.withVariable(Variable.builder().setName("x").setType(TypeNode.STRING).build());
+    assertThrows(
+        IllegalStateException.class,
+        () -> UnaryOperationExpr.postfixIncrementWithExpr(variableExpr));
+  }
+
+  @Test
+  public void invalidPostIncrement_finalVariable() {
+    Variable var = Variable.builder().setName("i").setType(TypeNode.INT).build();
+    VariableExpr variableExpr = VariableExpr.builder().setIsFinal(true).setVariable(var).build();
     assertThrows(
         IllegalStateException.class,
         () -> UnaryOperationExpr.postfixIncrementWithExpr(variableExpr));


### PR DESCRIPTION
1. Add precondition check; Should not increment on a final variable.
2. Fix unit test naming.

<img width="577" alt="Screen Shot 2020-10-04 at 12 30 36 AM" src="https://user-images.githubusercontent.com/6378676/95009682-d801bf00-05d8-11eb-9c23-7a3bda75170b.png">

Next TODO: variable should not be declare here.


