### PR TITLE
[ggj][codegen] fix: refactor requestBuilder into separate method in ServiceClient

### DIFF
--- a/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -11,6 +11,8 @@ UPDATE_GOLDENS_TESTS = [
     "MockServiceClassComposerTest",
     "MockServiceImplClassComposerTest",
     "ResourceNameHelperClassComposerTest",
+    "ServiceClientClassComposerTest",
+    "ServiceClientTestClassComposerTest",
     "ServiceSettingsClassComposerTest",
     "ServiceStubSettingsClassComposerTest",
     "ServiceStubClassComposerTest",
@@ -20,8 +22,6 @@ TESTS = UPDATE_GOLDENS_TESTS + [
     "DefaultValueComposerTest",
     "ResourceNameTokenizerTest",
     "RetrySettingsComposerTest",
-    "ServiceClientClassComposerTest",
-    "ServiceClientTestClassComposerTest",
 ]
 
 TEST_DEPS = [

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -1,0 +1,407 @@
+package com.google.showcase.v1beta1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.paging.AbstractFixedSizeCollection;
+import com.google.api.gax.paging.AbstractPage;
+import com.google.api.gax.paging.AbstractPagedListResponse;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.Empty;
+import com.google.showcase.v1beta1.stub.IdentityStub;
+import com.google.showcase.v1beta1.stub.IdentityStubSettings;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <p>Note: close() needs to be called on the echoClient object to clean up resources such as
+ * threads. In the example above, try-with-resources is used, which automatically calls close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of IdentitySettings to create().
+ * For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <p>To customize the endpoint:
+ */
+@BetaApi
+@Generated("by gapic-generator")
+public class IdentityClient implements BackgroundResource {
+  private final IdentitySettings settings;
+  private final IdentityStub stub;
+
+  /** Constructs an instance of EchoClient with default settings. */
+  public static final IdentityClient create() throws IOException {
+    return create(IdentitySettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of EchoClient, using the given settings. The channels are created based
+   * on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final IdentityClient create(IdentitySettings settings) throws IOException {
+    return new IdentityClient(settings);
+  }
+
+  /**
+   * Constructs an instance of EchoClient, using the given stub for making calls. This is for
+   * advanced usage - prefer using create(IdentitySettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final IdentityClient create(IdentityStub stub) {
+    return new IdentityClient(stub);
+  }
+
+  /**
+   * Constructs an instance of EchoClient, using the given settings. This is protected so that it is
+   * easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected IdentityClient(IdentitySettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((IdentityStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected IdentityClient(IdentityStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final IdentitySettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public IdentityStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param parent
+   * @param display_name
+   * @param email
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User createUser(String parent, String displayName, String email) {
+    CreateUserRequest request =
+        CreateUserRequest.newBuilder()
+            .setParent(parent)
+            .setDisplayName(displayName)
+            .setEmail(email)
+            .build();
+    return createUser(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param parent
+   * @param display_name
+   * @param email
+   * @param age
+   * @param nickname
+   * @param enable_notifications
+   * @param height_feet
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User createUser(
+      String parent,
+      String displayName,
+      String email,
+      int age,
+      String nickname,
+      boolean enableNotifications,
+      double heightFeet) {
+    CreateUserRequest request =
+        CreateUserRequest.newBuilder()
+            .setParent(parent)
+            .setDisplayName(displayName)
+            .setEmail(email)
+            .setAge(age)
+            .setNickname(nickname)
+            .setEnableNotifications(enableNotifications)
+            .setHeightFeet(heightFeet)
+            .build();
+    return createUser(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User createUser(CreateUserRequest request) {
+    return createUserCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /** Sample code: */
+  public final UnaryCallable<CreateUserRequest, User> createUserCallable() {
+    return stub.createUserCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User getUser(UserName name) {
+    GetUserRequest request =
+        GetUserRequest.newBuilder().setName(Objects.isNull(name) ? null : name.toString()).build();
+    return getUser(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User getUser(String name) {
+    GetUserRequest request = GetUserRequest.newBuilder().setName(name).build();
+    return getUser(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User getUser(GetUserRequest request) {
+    return getUserCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /** Sample code: */
+  public final UnaryCallable<GetUserRequest, User> getUserCallable() {
+    return stub.getUserCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final User updateUser(UpdateUserRequest request) {
+    return updateUserCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /** Sample code: */
+  public final UnaryCallable<UpdateUserRequest, User> updateUserCallable() {
+    return stub.updateUserCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Empty deleteUser(UserName name) {
+    DeleteUserRequest request =
+        DeleteUserRequest.newBuilder()
+            .setName(Objects.isNull(name) ? null : name.toString())
+            .build();
+    return deleteUser(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Empty deleteUser(String name) {
+    DeleteUserRequest request = DeleteUserRequest.newBuilder().setName(name).build();
+    return deleteUser(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Empty deleteUser(DeleteUserRequest request) {
+    return deleteUserCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /** Sample code: */
+  public final UnaryCallable<DeleteUserRequest, Empty> deleteUserCallable() {
+    return stub.deleteUserCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ListUsersPagedResponse listUsers(ListUsersRequest request) {
+    return listUsersPagedCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /** Sample code: */
+  public final UnaryCallable<ListUsersRequest, ListUsersPagedResponse> listUsersPagedCallable() {
+    return stub.listUsersPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /** Sample code: */
+  public final UnaryCallable<ListUsersRequest, ListUsersResponse> listUsersCallable() {
+    return stub.listUsersCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+
+  public static class ListUsersPagedResponse
+      extends AbstractPagedListResponse<
+          ListUsersRequest, ListUsersResponse, User, ListUsersPage, ListUsersFixedSizeCollection> {
+
+    public static ApiFuture<ListUsersPagedResponse> createAsync(
+        PageContext<ListUsersRequest, ListUsersResponse, User> context,
+        ApiFuture<ListUsersResponse> futureResponse) {
+      ApiFuture<ListUsersPage> futurePage =
+          ListUsersPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<ListUsersPage, ListUsersPagedResponse>() {
+            @Override
+            public ListUsersPagedResponse apply(ListUsersPage input) {
+              return new ListUsersPagedResponse(input);
+            }
+          },
+          MoreExecutors.directExecutor());
+    }
+
+    private ListUsersPagedResponse(ListUsersPage page) {
+      super(page, ListUsersFixedSizeCollection.createEmptyCollection());
+    }
+  }
+
+  public static class ListUsersPage
+      extends AbstractPage<ListUsersRequest, ListUsersResponse, User, ListUsersPage> {
+
+    private ListUsersPage(
+        PageContext<ListUsersRequest, ListUsersResponse, User> context,
+        ListUsersResponse response) {
+      super(context, response);
+    }
+
+    private static ListUsersPage createEmptyPage() {
+      return new ListUsersPage(null, null);
+    }
+
+    @Override
+    protected ListUsersPage createPage(
+        PageContext<ListUsersRequest, ListUsersResponse, User> context,
+        ListUsersResponse response) {
+      return new ListUsersPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<ListUsersPage> createPageAsync(
+        PageContext<ListUsersRequest, ListUsersResponse, User> context,
+        ApiFuture<ListUsersResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+  }
+
+  public static class ListUsersFixedSizeCollection
+      extends AbstractFixedSizeCollection<
+          ListUsersRequest, ListUsersResponse, User, ListUsersPage, ListUsersFixedSizeCollection> {
+
+    private ListUsersFixedSizeCollection(List<ListUsersPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static ListUsersFixedSizeCollection createEmptyCollection() {
+      return new ListUsersFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected ListUsersFixedSizeCollection createCollection(
+        List<ListUsersPage> pages, int collectionSize) {
+      return new ListUsersFixedSizeCollection(pages, collectionSize);
+    }
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/testdata/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/testdata/BUILD.bazel
@@ -32,6 +32,7 @@ proto_library(
     name = "showcase_proto",
     srcs = [
         "echo.proto",
+        "identity.proto",
         "testing.proto",
     ],
     deps = [

--- a/src/test/java/com/google/api/generator/gapic/testdata/identity.proto
+++ b/src/test/java/com/google/api/generator/gapic/testdata/identity.proto
@@ -1,0 +1,192 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+
+package google.showcase.v1beta1;
+
+option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
+option java_package = "com.google.showcase.v1beta1";
+option java_multiple_files = true;
+
+// A simple identity service.
+service Identity {
+  // This service is meant to only run locally on the port 7469 (keypad digits
+  // for "show").
+  option (google.api.default_host) = "localhost:7469";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  // Creates a user.
+  rpc CreateUser(CreateUserRequest) returns (User) {
+    option (google.api.http) = {
+      post: "/v1beta1/{parent=users}"
+      body: "*"
+    };
+    option (google.api.method_signature) =
+        "parent,user.display_name,user.email";
+    option (google.api.method_signature) =
+        "parent,user.display_name,user.email,user.age,user.nickname,user.enable_notifications,user.height_feet";
+  }
+
+  // Retrieves the User with the given uri.
+  rpc GetUser(GetUserRequest) returns (User) {
+    option (google.api.http) = {
+      get: "/v1beta1/{name=users/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Updates a user.
+  rpc UpdateUser(UpdateUserRequest) returns (User) {
+    option (google.api.http) = {
+      patch: "/v1beta1/{user.name=users/*}"
+      body: "*"
+    };
+  }
+
+  // Deletes a user, their profile, and all of their authored messages.
+  rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1beta1/{name=users/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Lists all users.
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
+    option (google.api.http) = {
+      get: "/v1beta1/users"
+    };
+  }
+}
+
+// A user.
+message User {
+  option (google.api.resource) = {
+    type: "showcase.googleapis.com/User"
+    pattern: "users/{user}"
+  };
+
+  // The resource name of the user.
+  string name = 1;
+
+  // The display_name of the user.
+  string display_name = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The email address of the user.
+  string email = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The timestamp at which the user was created.
+  google.protobuf.Timestamp create_time = 4
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The latest timestamp at which the user was updated.
+  google.protobuf.Timestamp update_time = 5
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The age of the use in years.
+  optional int32 age = 6;
+
+  // The height of the user in feet.
+  optional double height_feet = 7;
+
+  // The nickname of the user.
+  //
+  // (-- aip.dev/not-precedent: An empty string is a valid nickname.
+  //     Ordinarily, proto3_optional should not be used on a `string` field. --)
+  optional string nickname = 8;
+
+  // Enables the receiving of notifications. The default is true if unset.
+  //
+  // (-- aip.dev/not-precedent: The default for the feature is true.
+  //     Ordinarily, the default for a `bool` field should be false. --)
+  optional bool enable_notifications = 9;
+}
+
+// The request message for the google.showcase.v1beta1.Identity\CreateUser
+// method.
+message CreateUserRequest {
+  string parent = 1 [
+    (google.api.resource_reference).child_type = "showcase.googleapis.com/User",
+    (google.api.field_behavior) = REQUIRED
+  ];
+  // The user to create.
+  User user = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The request message for the google.showcase.v1beta1.Identity\GetUser
+// method.
+message GetUserRequest {
+  // The resource name of the requested user.
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/User",
+    (google.api.field_behavior) = REQUIRED
+  ];
+}
+
+// The request message for the google.showcase.v1beta1.Identity\UpdateUser
+// method.
+message UpdateUserRequest {
+  // The user to update.
+  User user = 1;
+
+  // The field mask to determine wich fields are to be updated. If empty, the
+  // server will assume all fields are to be updated.
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// The request message for the google.showcase.v1beta1.Identity\DeleteUser
+// method.
+message DeleteUserRequest {
+  // The resource name of the user to delete.
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/User",
+    (google.api.field_behavior) = REQUIRED
+  ];
+}
+
+// The request message for the google.showcase.v1beta1.Identity\ListUsers
+// method.
+message ListUsersRequest {
+  // The maximum number of users to return. Server may return fewer users
+  // than requested. If unspecified, server will pick an appropriate default.
+  int32 page_size = 1;
+
+  // The value of google.showcase.v1beta1.ListUsersResponse.next_page_token
+  // returned from the previous call to
+  // `google.showcase.v1beta1.Identity\ListUsers` method.
+  string page_token = 2;
+}
+
+// The response message for the google.showcase.v1beta1.Identity\ListUsers
+// method.
+message ListUsersResponse {
+  // The list of users.
+  repeated User users = 1;
+
+  // A token to retrieve next page of results.
+  // Pass this value in ListUsersRequest.page_token field in the subsequent
+  // call to `google.showcase.v1beta1.Message\ListUsers` method to retrieve the
+  // next page of results.
+  string next_page_token = 2;
+}


### PR DESCRIPTION
This will help with the upcoming support for nested fields in `method_signature`.