### PR TITLE
[ggj][codegen] fix: support LRO package.name annotations

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 public class Parser {
   private static final String COMMA = ",";
   private static final String COLON = ":";
+  private static final String DOT = ".";
   private static final String DEFAULT_PORT = "443";
 
   // Allow other parsers to access this.
@@ -320,12 +321,23 @@ public class Parser {
 
     OperationInfo lroInfo =
         methodDescriptor.getOptions().getExtension(OperationsProto.operationInfo);
+
     String responseTypeName = lroInfo.getResponseType();
+    String responseTypePackage = "";
+    if (responseTypeName.contains(DOT)) {
+      responseTypeName = responseTypeName.substring(responseTypeName.lastIndexOf(DOT) + 1);
+    }
+
     String metadataTypeName = lroInfo.getMetadataType();
+    if (metadataTypeName.contains(DOT)) {
+      metadataTypeName = metadataTypeName.substring(metadataTypeName.lastIndexOf(DOT) + 1);
+    }
+
     Message responseMessage = messageTypes.get(responseTypeName);
     Message metadataMessage = messageTypes.get(metadataTypeName);
     Preconditions.checkNotNull(
         responseMessage, String.format("LRO response message %s not found", responseTypeName));
+    // TODO(miraleung): Check that the packages are equal if those strings are not empty.
     Preconditions.checkNotNull(
         metadataMessage, String.format("LRO metadata message %s not found", metadataTypeName));
 


### PR DESCRIPTION
Supports RPCs that use packages like `google.cloud.apiname.v999.TypeName` in LRO `response_type` and `metadata_type` annotations.