### PR TITLE
[ggj][engx] build: speed up CircleCI by removing build-everything job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,6 @@ jobs:
             mkdir -p ${TEST_REPORTS_DIR}
             echo "Test reports will be stored in ${TEST_REPORTS_DIR}"
       - run:
-          name: Build targets for gapic-generator-java
-          command: |
-            cd /tmp/gapic-generator-java
-            bazel --batch build //src/...
-      - run:
           name: Run unit tests for gapic-generator-java
           command: |
             cd /tmp/gapic-generator-java


### PR DESCRIPTION
Testing test targets should be sufficient, and will avoid building the golden update targets. This will hopefully speed up the build.