### PR TITLE
[ggj]fix: update asset goldens for integration test

### DIFF
--- a/test/integration/goldens/asset/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/AssetServiceClientTest.java
@@ -46,10 +46,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class AssetServiceClientTest {
-  public static MockServiceHelper mockServiceHelper;
-  public AssetServiceClient client;
-  public LocalChannelProvider channelProvider;
-  public static MockAssetService mockAssetService;
+  private static MockServiceHelper mockServiceHelper;
+  private AssetServiceClient client;
+  private LocalChannelProvider channelProvider;
+  private static MockAssetService mockAssetService;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -96,17 +96,21 @@ public class AssetServiceClientTest {
             .setResponse(Any.pack(expectedResponse))
             .build();
     mockAssetService.addResponse(resultOperation);
+
     ExportAssetsRequest request =
         ExportAssetsRequest.newBuilder()
             .setParent(ProjectName.of("[PROJECT]").toString())
             .addAllAssetTypes(new ArrayList<>())
             .setOutputConfig(OutputConfig.newBuilder().build())
             .build();
+
     ExportAssetsResponse actualResponse = client.exportAssetsAsync(request).get();
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     ExportAssetsRequest actualRequest = ((ExportAssetsRequest) actualRequests.get(0));
+
     Assert.assertEquals(request.getParent(), actualRequest.getParent());
     Assert.assertEquals(request.getReadTime(), actualRequest.getReadTime());
     Assert.assertEquals(request.getAssetTypesList(), actualRequest.getAssetTypesList());
@@ -122,6 +126,7 @@ public class AssetServiceClientTest {
   public void exportAssetsExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       ExportAssetsRequest request =
           ExportAssetsRequest.newBuilder()
@@ -143,18 +148,22 @@ public class AssetServiceClientTest {
     BatchGetAssetsHistoryResponse expectedResponse =
         BatchGetAssetsHistoryResponse.newBuilder().addAllAssets(new ArrayList<>()).build();
     mockAssetService.addResponse(expectedResponse);
+
     BatchGetAssetsHistoryRequest request =
         BatchGetAssetsHistoryRequest.newBuilder()
             .setParent(ProjectName.of("[PROJECT]").toString())
             .addAllAssetNames(new ArrayList<>())
             .setReadTimeWindow(TimeWindow.newBuilder().build())
             .build();
+
     BatchGetAssetsHistoryResponse actualResponse = client.batchGetAssetsHistory(request);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     BatchGetAssetsHistoryRequest actualRequest =
         ((BatchGetAssetsHistoryRequest) actualRequests.get(0));
+
     Assert.assertEquals(request.getParent(), actualRequest.getParent());
     Assert.assertEquals(request.getAssetNamesList(), actualRequest.getAssetNamesList());
     Assert.assertEquals(request.getContentType(), actualRequest.getContentType());
@@ -169,6 +178,7 @@ public class AssetServiceClientTest {
   public void batchGetAssetsHistoryExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       BatchGetAssetsHistoryRequest request =
           BatchGetAssetsHistoryRequest.newBuilder()
@@ -193,12 +203,16 @@ public class AssetServiceClientTest {
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .build();
     mockAssetService.addResponse(expectedResponse);
+
     String parent = "parent-995424086";
+
     Feed actualResponse = client.createFeed(parent);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     CreateFeedRequest actualRequest = ((CreateFeedRequest) actualRequests.get(0));
+
     Assert.assertEquals(parent, actualRequest.getParent());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -210,6 +224,7 @@ public class AssetServiceClientTest {
   public void createFeedExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       String parent = "parent-995424086";
       client.createFeed(parent);
@@ -229,12 +244,16 @@ public class AssetServiceClientTest {
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .build();
     mockAssetService.addResponse(expectedResponse);
+
     FeedName name = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
+
     Feed actualResponse = client.getFeed(name);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     GetFeedRequest actualRequest = ((GetFeedRequest) actualRequests.get(0));
+
     Assert.assertEquals(name.toString(), actualRequest.getName());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -246,6 +265,7 @@ public class AssetServiceClientTest {
   public void getFeedExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       FeedName name = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
       client.getFeed(name);
@@ -265,12 +285,16 @@ public class AssetServiceClientTest {
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .build();
     mockAssetService.addResponse(expectedResponse);
+
     String name = "name3373707";
+
     Feed actualResponse = client.getFeed(name);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     GetFeedRequest actualRequest = ((GetFeedRequest) actualRequests.get(0));
+
     Assert.assertEquals(name, actualRequest.getName());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -282,6 +306,7 @@ public class AssetServiceClientTest {
   public void getFeedExceptionTest2() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       String name = "name3373707";
       client.getFeed(name);
@@ -296,12 +321,16 @@ public class AssetServiceClientTest {
     ListFeedsResponse expectedResponse =
         ListFeedsResponse.newBuilder().addAllFeeds(new ArrayList<>()).build();
     mockAssetService.addResponse(expectedResponse);
+
     String parent = "parent-995424086";
+
     ListFeedsResponse actualResponse = client.listFeeds(parent);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     ListFeedsRequest actualRequest = ((ListFeedsRequest) actualRequests.get(0));
+
     Assert.assertEquals(parent, actualRequest.getParent());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -313,6 +342,7 @@ public class AssetServiceClientTest {
   public void listFeedsExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       String parent = "parent-995424086";
       client.listFeeds(parent);
@@ -332,12 +362,16 @@ public class AssetServiceClientTest {
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .build();
     mockAssetService.addResponse(expectedResponse);
+
     Feed feed = Feed.newBuilder().build();
+
     Feed actualResponse = client.updateFeed(feed);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     UpdateFeedRequest actualRequest = ((UpdateFeedRequest) actualRequests.get(0));
+
     Assert.assertEquals(feed, actualRequest.getFeed());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -349,6 +383,7 @@ public class AssetServiceClientTest {
   public void updateFeedExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       Feed feed = Feed.newBuilder().build();
       client.updateFeed(feed);
@@ -362,12 +397,16 @@ public class AssetServiceClientTest {
   public void deleteFeedTest() {
     Empty expectedResponse = Empty.newBuilder().build();
     mockAssetService.addResponse(expectedResponse);
+
     FeedName name = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
+
     Empty actualResponse = client.deleteFeed(name);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     DeleteFeedRequest actualRequest = ((DeleteFeedRequest) actualRequests.get(0));
+
     Assert.assertEquals(name.toString(), actualRequest.getName());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -379,6 +418,7 @@ public class AssetServiceClientTest {
   public void deleteFeedExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       FeedName name = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
       client.deleteFeed(name);
@@ -392,12 +432,16 @@ public class AssetServiceClientTest {
   public void deleteFeedTest2() {
     Empty expectedResponse = Empty.newBuilder().build();
     mockAssetService.addResponse(expectedResponse);
+
     String name = "name3373707";
+
     Empty actualResponse = client.deleteFeed(name);
     Assert.assertEquals(expectedResponse, actualResponse);
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     DeleteFeedRequest actualRequest = ((DeleteFeedRequest) actualRequests.get(0));
+
     Assert.assertEquals(name, actualRequest.getName());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
@@ -409,6 +453,7 @@ public class AssetServiceClientTest {
   public void deleteFeedExceptionTest2() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       String name = "name3373707";
       client.deleteFeed(name);
@@ -427,17 +472,23 @@ public class AssetServiceClientTest {
             .addAllResponses(Arrays.asList(responsesElement))
             .build();
     mockAssetService.addResponse(expectedResponse);
+
     String scope = "scope109264468";
     String query = "query107944136";
     List<String> assetTypes = new ArrayList<>();
+
     SearchAllResourcesResponse pagedListResponse =
         client.searchAllResources(scope, query, assetTypes);
-    resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    List<ResourceSearchResult> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
     Assert.assertEquals(1, resources.size());
     Assert.assertEquals(expectedResponse.getResponsesList().get(0), resources.get(0));
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     SearchAllResourcesRequest actualRequest = ((SearchAllResourcesRequest) actualRequests.get(0));
+
     Assert.assertEquals(scope, actualRequest.getScope());
     Assert.assertEquals(query, actualRequest.getQuery());
     Assert.assertEquals(assetTypes, actualRequest.getAssetTypesList());
@@ -451,6 +502,7 @@ public class AssetServiceClientTest {
   public void searchAllResourcesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       String scope = "scope109264468";
       String query = "query107944136";
@@ -471,16 +523,22 @@ public class AssetServiceClientTest {
             .addAllResponses(Arrays.asList(responsesElement))
             .build();
     mockAssetService.addResponse(expectedResponse);
+
     String scope = "scope109264468";
     String query = "query107944136";
+
     SearchAllIamPoliciesResponse pagedListResponse = client.searchAllIamPolicies(scope, query);
-    resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    List<IamPolicySearchResult> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
     Assert.assertEquals(1, resources.size());
     Assert.assertEquals(expectedResponse.getResponsesList().get(0), resources.get(0));
+
     List<AbstractMessage> actualRequests = mockAssetService.getRequests();
     Assert.assertEquals(1, actualRequests.size());
     SearchAllIamPoliciesRequest actualRequest =
         ((SearchAllIamPoliciesRequest) actualRequests.get(0));
+
     Assert.assertEquals(scope, actualRequest.getScope());
     Assert.assertEquals(query, actualRequest.getQuery());
     Assert.assertTrue(
@@ -493,6 +551,7 @@ public class AssetServiceClientTest {
   public void searchAllIamPoliciesExceptionTest() throws Exception {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockAssetService.addException(exception);
+
     try {
       String scope = "scope109264468";
       String query = "query107944136";

--- a/test/integration/goldens/asset/AssetServiceStubSettings.java
+++ b/test/integration/goldens/asset/AssetServiceStubSettings.java
@@ -117,6 +117,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
           SearchAllIamPoliciesResponse,
           SearchAllIamPoliciesPagedResponse>
       searchAllIamPoliciesSettings;
+
   private static final PagedListDescriptor<
           SearchAllResourcesRequest, SearchAllResourcesResponse, ResourceSearchResult>
       SEARCH_ALL_RESOURCES_PAGE_STR_DESC =
@@ -157,6 +158,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
                   : payload.getResultsList();
             }
           };
+
   private static final PagedListDescriptor<
           SearchAllIamPoliciesRequest, SearchAllIamPoliciesResponse, IamPolicySearchResult>
       SEARCH_ALL_IAM_POLICIES_PAGE_STR_DESC =
@@ -197,6 +199,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
                   : payload.getResultsList();
             }
           };
+
   private static final PagedListResponseFactory<
           SearchAllResourcesRequest, SearchAllResourcesResponse, SearchAllResourcesPagedResponse>
       SEARCH_ALL_RESOURCES_PAGE_STR_FACT =
@@ -218,6 +221,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
               return SearchAllResourcesPagedResponse.createAsync(pageContext, futureResponse);
             }
           };
+
   private static final PagedListResponseFactory<
           SearchAllIamPoliciesRequest,
           SearchAllIamPoliciesResponse,
@@ -370,6 +374,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
 
   protected AssetServiceStubSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
+
     exportAssetsSettings = settingsBuilder.exportAssetsSettings().build();
     exportAssetsOperationSettings = settingsBuilder.exportAssetsOperationSettings().build();
     batchGetAssetsHistorySettings = settingsBuilder.batchGetAssetsHistorySettings().build();
@@ -470,6 +475,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
 
     protected Builder(ClientContext clientContext) {
       super(clientContext);
+
       exportAssetsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       exportAssetsOperationSettings = OperationCallSettings.newBuilder();
       batchGetAssetsHistorySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -481,6 +487,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
       searchAllResourcesSettings = PagedCallSettings.newBuilder(SEARCH_ALL_RESOURCES_PAGE_STR_FACT);
       searchAllIamPoliciesSettings =
           PagedCallSettings.newBuilder(SEARCH_ALL_IAM_POLICIES_PAGE_STR_FACT);
+
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               exportAssetsSettings,
@@ -497,6 +504,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
 
     protected Builder(AssetServiceStubSettings settings) {
       super(settings);
+
       exportAssetsSettings = settings.exportAssetsSettings.toBuilder();
       exportAssetsOperationSettings = settings.exportAssetsOperationSettings.toBuilder();
       batchGetAssetsHistorySettings = settings.batchGetAssetsHistorySettings.toBuilder();
@@ -507,6 +515,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
       deleteFeedSettings = settings.deleteFeedSettings.toBuilder();
       searchAllResourcesSettings = settings.searchAllResourcesSettings.toBuilder();
       searchAllIamPoliciesSettings = settings.searchAllIamPoliciesSettings.toBuilder();
+
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               exportAssetsSettings,
@@ -522,10 +531,12 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
 
     private static Builder createDefault() {
       Builder builder = new Builder(((ClientContext) null));
+
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
       builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
+
       return initDefaults(builder);
     }
 
@@ -534,38 +545,47 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
           .exportAssetsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
       builder
           .batchGetAssetsHistorySettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder
           .createFeedSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
       builder
           .getFeedSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder
           .listFeedsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder
           .updateFeedSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
       builder
           .deleteFeedSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
       builder
           .searchAllResourcesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_2_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_2_params"));
+
       builder
           .searchAllIamPoliciesSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_2_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_2_params"));
+
       builder
           .exportAssetsOperationSettings()
           .setInitialCallSettings(
@@ -589,6 +609,7 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
                       .setMaxRpcTimeout(Duration.ZERO)
                       .setTotalTimeout(Duration.ofMillis(300000L))
                       .build()));
+
       return builder;
     }
 

--- a/test/integration/goldens/asset/GrpcAssetServiceStub.java
+++ b/test/integration/goldens/asset/GrpcAssetServiceStub.java
@@ -66,6 +66,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
               .setRequestMarshaller(ProtoUtils.marshaller(ExportAssetsRequest.getDefaultInstance()))
               .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
               .build();
+
   private static final MethodDescriptor<BatchGetAssetsHistoryRequest, BatchGetAssetsHistoryResponse>
       batchGetAssetsHistoryMethodDescriptor =
           MethodDescriptor.<BatchGetAssetsHistoryRequest, BatchGetAssetsHistoryResponse>newBuilder()
@@ -76,6 +77,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
               .setResponseMarshaller(
                   ProtoUtils.marshaller(BatchGetAssetsHistoryResponse.getDefaultInstance()))
               .build();
+
   private static final MethodDescriptor<CreateFeedRequest, Feed> createFeedMethodDescriptor =
       MethodDescriptor.<CreateFeedRequest, Feed>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -83,6 +85,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(CreateFeedRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Feed.getDefaultInstance()))
           .build();
+
   private static final MethodDescriptor<GetFeedRequest, Feed> getFeedMethodDescriptor =
       MethodDescriptor.<GetFeedRequest, Feed>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -90,6 +93,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(GetFeedRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Feed.getDefaultInstance()))
           .build();
+
   private static final MethodDescriptor<ListFeedsRequest, ListFeedsResponse>
       listFeedsMethodDescriptor =
           MethodDescriptor.<ListFeedsRequest, ListFeedsResponse>newBuilder()
@@ -98,6 +102,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
               .setRequestMarshaller(ProtoUtils.marshaller(ListFeedsRequest.getDefaultInstance()))
               .setResponseMarshaller(ProtoUtils.marshaller(ListFeedsResponse.getDefaultInstance()))
               .build();
+
   private static final MethodDescriptor<UpdateFeedRequest, Feed> updateFeedMethodDescriptor =
       MethodDescriptor.<UpdateFeedRequest, Feed>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -105,6 +110,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(UpdateFeedRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Feed.getDefaultInstance()))
           .build();
+
   private static final MethodDescriptor<DeleteFeedRequest, Empty> deleteFeedMethodDescriptor =
       MethodDescriptor.<DeleteFeedRequest, Empty>newBuilder()
           .setType(MethodDescriptor.MethodType.UNARY)
@@ -112,6 +118,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(DeleteFeedRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
           .build();
+
   private static final MethodDescriptor<SearchAllResourcesRequest, SearchAllResourcesResponse>
       searchAllResourcesMethodDescriptor =
           MethodDescriptor.<SearchAllResourcesRequest, SearchAllResourcesResponse>newBuilder()
@@ -122,6 +129,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
               .setResponseMarshaller(
                   ProtoUtils.marshaller(SearchAllResourcesResponse.getDefaultInstance()))
               .build();
+
   private static final MethodDescriptor<SearchAllIamPoliciesRequest, SearchAllIamPoliciesResponse>
       searchAllIamPoliciesMethodDescriptor =
           MethodDescriptor.<SearchAllIamPoliciesRequest, SearchAllIamPoliciesResponse>newBuilder()
@@ -132,6 +140,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
               .setResponseMarshaller(
                   ProtoUtils.marshaller(SearchAllIamPoliciesResponse.getDefaultInstance()))
               .build();
+
   private final UnaryCallable<ExportAssetsRequest, Operation> exportAssetsCallable;
   private final OperationCallable<ExportAssetsRequest, ExportAssetsResponse, ExportAssetsRequest>
       exportAssetsOperationCallable;
@@ -150,6 +159,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
       searchAllIamPoliciesCallable;
   private final UnaryCallable<SearchAllIamPoliciesRequest, SearchAllIamPoliciesPagedResponse>
       searchAllIamPoliciesPagedCallable;
+
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
   private final GrpcStubCallableFactory callableFactory;
@@ -181,6 +191,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
       throws IOException {
     this.callableFactory = callableFactory;
     this.operationsStub = GrpcOperationsStub.create(clientContext, callableFactory);
+
     GrpcCallSettings<ExportAssetsRequest, Operation> exportAssetsTransportSettings =
         GrpcCallSettings.<ExportAssetsRequest, Operation>newBuilder()
             .setMethodDescriptor(exportAssetsMethodDescriptor)
@@ -221,6 +232,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
             GrpcCallSettings.<SearchAllIamPoliciesRequest, SearchAllIamPoliciesResponse>newBuilder()
                 .setMethodDescriptor(searchAllIamPoliciesMethodDescriptor)
                 .build();
+
     this.exportAssetsCallable =
         callableFactory.createUnaryCallable(
             exportAssetsTransportSettings, settings.exportAssetsSettings(), clientContext);
@@ -270,6 +282,7 @@ public class GrpcAssetServiceStub extends AssetServiceStub {
             searchAllIamPoliciesTransportSettings,
             settings.searchAllIamPoliciesSettings(),
             clientContext);
+
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }


### PR DESCRIPTION
Running bazel test against Asset API shows the code generation has some updates since last goldens addition. Update the goldens files for upcoming bazel rules for Asset API integration test.