### PR TITLE
[compose][samplecode][1/2]Implement sample code of set credentials in Service Client Class header comment

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientClassComposer.java
@@ -119,7 +119,7 @@ public class ServiceClientClassComposer implements ClassComposer {
     ClassDefinition classDef =
         ClassDefinition.builder()
             .setHeaderCommentStatements(
-                ServiceClientCommentComposer.createClassHeaderComments(service))
+                ServiceClientCommentComposer.createClassHeaderComments(service, types))
             .setPackageString(pakkage)
             .setAnnotations(createClassAnnotations(types))
             .setScope(ScopeNode.PUBLIC)

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import com.google.api.generator.engine.ast.CommentStatement;
 import com.google.api.generator.engine.ast.JavaDocComment;
 import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.gapic.composer.samplecode.ServiceClientCommentSampleCodeComposer;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.MethodArgument;
 import com.google.api.generator.gapic.model.Service;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Map;
 
 class ServiceClientCommentComposer {
   // Tokens.
@@ -103,7 +105,7 @@ class ServiceClientCommentComposer {
           "Returns the OperationsClient that can be used to query the status of a long-running"
               + " operation returned by another API method call.");
 
-  static List<CommentStatement> createClassHeaderComments(Service service) {
+  static List<CommentStatement> createClassHeaderComments(Service service, Map<String, TypeNode> types) {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
     if (service.hasDescription()) {
       classHeaderJavadocBuilder =
@@ -134,7 +136,7 @@ class ServiceClientCommentComposer {
             SERVICE_DESCRIPTION_CUSTOMIZE_SUMMARY_PATTERN,
             String.format("%sSettings", JavaStyle.toUpperCamelCase(service.name()))));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_CREDENTIALS_SUMMARY_STRING);
-    // TODO(summerji): Add credentials' customization sample code here.
+    classHeaderJavadocBuilder.addSampleCode(ServiceClientCommentSampleCodeComposer.composeClassHeaderCredentialsSampleCode(service, types));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
     // TODO(summerji): Add endpoint customization sample code here.
 

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -26,9 +26,9 @@ import com.google.common.base.Strings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.Map;
 
 class ServiceClientCommentComposer {
   // Tokens.
@@ -105,7 +105,8 @@ class ServiceClientCommentComposer {
           "Returns the OperationsClient that can be used to query the status of a long-running"
               + " operation returned by another API method call.");
 
-  static List<CommentStatement> createClassHeaderComments(Service service, Map<String, TypeNode> types) {
+  static List<CommentStatement> createClassHeaderComments(
+      Service service, Map<String, TypeNode> types) {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
     if (service.hasDescription()) {
       classHeaderJavadocBuilder =
@@ -136,7 +137,9 @@ class ServiceClientCommentComposer {
             SERVICE_DESCRIPTION_CUSTOMIZE_SUMMARY_PATTERN,
             String.format("%sSettings", JavaStyle.toUpperCamelCase(service.name()))));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_CREDENTIALS_SUMMARY_STRING);
-    classHeaderJavadocBuilder.addSampleCode(ServiceClientCommentSampleCodeComposer.composeClassHeaderCredentialsSampleCode(service, types));
+    classHeaderJavadocBuilder.addSampleCode(
+        ServiceClientCommentSampleCodeComposer.composeClassHeaderCredentialsSampleCode(
+            service, types));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
     // TODO(summerji): Add endpoint customization sample code here.
 

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/BUILD.bazel
@@ -18,5 +18,6 @@ java_library(
         "//src/main/java/com/google/api/generator/gapic/model",
         "//src/main/java/com/google/api/generator/gapic/utils",
         "@google_java_format_all_deps//jar",
+        "@com_google_api_gax_java//gax",
     ],
 )

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -26,11 +26,6 @@ public class ServiceClientCommentSampleCodeComposer {
   private static final String SETTINGS_NAME_PATTERN = "%sSettings";
   private static final String CLASS_NAME_PATTERN = "%sClient";
 
-  public static String composeClassHeaderMethodSampleCode() {
-    // TODO(summerji): implement class header rpc sample code.
-    return "";
-  }
-
   public static String composeClassHeaderCredentialsSampleCode(Service service, Map<String, TypeNode> types) {
     String settingsVarName = JavaStyle.toLowerCamelCase(getSettingsName(service.name()));
     TypeNode settingsVarType = types.get(getSettingsName(service.name()));

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -87,15 +87,15 @@ public class ServiceClientCommentSampleCodeComposer {
     return SampleCodeJavaFormatter.format(writeStatements(statements));
   }
 
-  private static String getClientClassName(String serviceName) {
+  private String getClientClassName(String serviceName) {
     return String.format(CLASS_NAME_PATTERN, serviceName);
   }
 
-  private static String getSettingsName(String serviceName) {
+  private String getSettingsName(String serviceName) {
     return String.format(SETTINGS_NAME_PATTERN, serviceName);
   }
 
-  private static String writeStatements(List<Statement> statements) {
+  private String writeStatements(List<Statement> statements) {
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     for (Statement statement : statements) {
       statement.accept(visitor);

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -27,7 +27,6 @@ import com.google.api.generator.engine.ast.ValueExpr;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
-import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import java.util.Arrays;
@@ -75,7 +74,7 @@ public class ServiceClientCommentSampleCodeComposer {
             .setMethodName("build")
             .build();
 
-    Expr initLocalSettingsVarExpr =
+    Expr initSettingsVarExpr =
         AssignmentExpr.builder()
             .setVariableExpr(settingsVarExpr.toBuilder().setIsDecl(true).build())
             .setValueExpr(buildMethodExpr)
@@ -90,15 +89,7 @@ public class ServiceClientCommentSampleCodeComposer {
         .setValueExpr(createMethodExpr)
         .build();
 
-    List<Statement> statements =
-        Arrays.asList(
-            initLocalSettingsVarExpr,
-            initClientVarExpr
-        )
-            .stream()
-            .map(e -> ExprStatement.withExpr(e))
-            .collect(Collectors.toList());
-    return SampleCodeJavaFormatter.format(writeStatements(statements));
+    return writeSampleCode(Arrays.asList(initSettingsVarExpr, initClientVarExpr));
   }
 
   private static String getClientClassName(String serviceName) {
@@ -109,11 +100,16 @@ public class ServiceClientCommentSampleCodeComposer {
     return String.format(SETTINGS_NAME_PATTERN, serviceName);
   }
 
-  private static String writeStatements(List<Statement> statements) {
+  private static String writeSampleCode(List<Expr> exprs) {
+    List<Statement> statements =
+        exprs
+            .stream()
+            .map(e -> ExprStatement.withExpr(e))
+            .collect(Collectors.toList());
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     for (Statement statement : statements) {
       statement.accept(visitor);
     }
-    return visitor.write();
+    return SampleCodeJavaFormatter.format(visitor.write());
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -1,0 +1,99 @@
+package com.google.api.generator.gapic.composer.samplecode;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.generator.engine.ast.AssignmentExpr;
+import com.google.api.generator.engine.ast.ConcreteReference;
+import com.google.api.generator.engine.ast.Expr;
+import com.google.api.generator.engine.ast.ExprStatement;
+import com.google.api.generator.engine.ast.MethodInvocationExpr;
+import com.google.api.generator.engine.ast.Statement;
+import com.google.api.generator.engine.ast.StringObjectValue;
+import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.engine.ast.ValueExpr;
+import com.google.api.generator.engine.ast.Variable;
+import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.model.Method;
+import com.google.api.generator.gapic.model.Service;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Map;
+
+public class ServiceClientCommentSampleCodeComposer {
+
+  private static final String SETTINGS_NAME_PATTERN = "%sSettings";
+  private static final String CLASS_NAME_PATTERN = "%sClient";
+
+  public static String composeClassHeaderMethodSampleCode() {
+    // TODO(summerji): implement class header rpc sample code.
+    return "string holder";
+  }
+
+  public static String composeClassHeaderCredentialsSampleCode(Service service, Map<String, TypeNode> types) {
+    String settingsVarName = getSettingsName(service.name());
+    TypeNode settingsVarType = types.get(settingsVarName);
+    VariableExpr settingsVarExpr = VariableExpr.withVariable(
+        Variable.builder()
+            .setName(settingsVarName)
+            .setType(settingsVarType)
+            .build());
+    MethodInvocationExpr newBuilderMethodExpr =
+        MethodInvocationExpr.builder()
+        .setStaticReferenceType(settingsVarType)
+        .setMethodName("newBuilder")
+        .build();
+    TypeNode fixedCredentialProvideType = TypeNode.withReference(
+        ConcreteReference.withClazz(FixedCredentialsProvider.class)
+    );
+    MethodInvocationExpr credentialArgExpr =
+        MethodInvocationExpr.builder()
+        .setStaticReferenceType(fixedCredentialProvideType)
+        .setArguments(ValueExpr.withValue(StringObjectValue.withValue("myCredentials")))
+        .setMethodName("create")
+        .build();
+    MethodInvocationExpr credentialsMethodExpr =
+        MethodInvocationExpr.builder()
+        .setExprReferenceExpr(newBuilderMethodExpr)
+        .setArguments(credentialArgExpr)
+        .setMethodName("setCredentialsProvider")
+        .build();
+    MethodInvocationExpr buildMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credentialsMethodExpr)
+            .setReturnType(settingsVarType)
+            .setMethodName("build")
+            .build();
+
+    Expr initLocalSettingsVarExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(settingsVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(buildMethodExpr)
+            .build();
+
+    List<Statement> statements =
+        Arrays.asList(
+            initLocalSettingsVarExpr
+        )
+            .stream()
+            .map(e -> ExprStatement.withExpr(e))
+            .collect(Collectors.toList());
+    return SampleCodeJavaFormatter.format(writeStatements(statements));
+  }
+
+  private static String getClientClassName(String serviceName) {
+    return String.format(CLASS_NAME_PATTERN, serviceName);
+  }
+
+  private static String getSettingsName(String serviceName) {
+    return String.format(SETTINGS_NAME_PATTERN, serviceName);
+  }
+
+  private static String writeStatements(List<Statement> statements) {
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    for (Statement statement : statements) {
+      statement.accept(visitor);
+    }
+    return visitor.write();
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.api.generator.gapic.composer.samplecode;
 
 import com.google.api.gax.core.FixedCredentialsProvider;

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -101,15 +101,15 @@ public class ServiceClientCommentSampleCodeComposer {
     return SampleCodeJavaFormatter.format(writeStatements(statements));
   }
 
-  private String getClientClassName(String serviceName) {
+  private static String getClientClassName(String serviceName) {
     return String.format(CLASS_NAME_PATTERN, serviceName);
   }
 
-  private String getSettingsName(String serviceName) {
+  private static String getSettingsName(String serviceName) {
     return String.format(SETTINGS_NAME_PATTERN, serviceName);
   }
 
-  private String writeStatements(List<Statement> statements) {
+  private static String writeStatements(List<Statement> statements) {
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     for (Statement statement : statements) {
       statement.accept(visitor);

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -15,6 +15,7 @@ import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.utils.JavaStyle;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,9 +72,19 @@ public class ServiceClientCommentSampleCodeComposer {
             .setValueExpr(buildMethodExpr)
             .build();
 
+    String className = getClientClassName(service.name());
+    TypeNode classType = types.get(className);
+    VariableExpr clientVarExpr = VariableExpr.withVariable(Variable.builder().setName(className).setType(classType).build());
+    MethodInvocationExpr createMethodExpr = MethodInvocationExpr.builder().setStaticReferenceType(classType).setArguments(settingsVarExpr).setMethodName("create").setReturnType(classType).build();
+    Expr initClientVarExpr = AssignmentExpr.builder()
+        .setVariableExpr(clientVarExpr.toBuilder().setIsDecl(true).build())
+        .setValueExpr(createMethodExpr)
+        .build();
+
     List<Statement> statements =
         Arrays.asList(
-            initLocalSettingsVarExpr
+            initLocalSettingsVarExpr,
+            initClientVarExpr
         )
             .stream()
             .map(e -> ExprStatement.withExpr(e))

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -28,12 +28,12 @@ public class ServiceClientCommentSampleCodeComposer {
 
   public static String composeClassHeaderMethodSampleCode() {
     // TODO(summerji): implement class header rpc sample code.
-    return "string holder";
+    return "";
   }
 
   public static String composeClassHeaderCredentialsSampleCode(Service service, Map<String, TypeNode> types) {
-    String settingsVarName = getSettingsName(service.name());
-    TypeNode settingsVarType = types.get(settingsVarName);
+    String settingsVarName = JavaStyle.toLowerCamelCase(getSettingsName(service.name()));
+    TypeNode settingsVarType = types.get(getSettingsName(service.name()));
     VariableExpr settingsVarExpr = VariableExpr.withVariable(
         Variable.builder()
             .setName(settingsVarName)
@@ -72,8 +72,8 @@ public class ServiceClientCommentSampleCodeComposer {
             .setValueExpr(buildMethodExpr)
             .build();
 
-    String className = getClientClassName(service.name());
-    TypeNode classType = types.get(className);
+    String className = JavaStyle.toLowerCamelCase(getClientClassName(service.name()));
+    TypeNode classType = types.get(getClientClassName(service.name()));
     VariableExpr clientVarExpr = VariableExpr.withVariable(Variable.builder().setName(className).setType(classType).build());
     MethodInvocationExpr createMethodExpr = MethodInvocationExpr.builder().setStaticReferenceType(classType).setArguments(settingsVarExpr).setMethodName("create").setReturnType(classType).build();
     Expr initClientVarExpr = AssignmentExpr.builder()

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/SettingsCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/SettingsCommentSampleCodeComposer.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public final class SettingsCommentSampleCodeComposer {
+public class SettingsCommentSampleCodeComposer {
 
   private static final String BUILDER_NAME_PATTERN = "%sBuilder";
   private static final String STUB = "Stub";

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -63,6 +63,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * EchoSettings echoSettings =
+ *     EchoSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -53,6 +53,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * IdentitySettings identitySettings =
+ *     IdentitySettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * IdentityClient identityClient = IdentityClient.create(identitySettings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -75,6 +75,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * AssetServiceSettings assetServiceSettings =
+ *     AssetServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * AssetServiceClient assetServiceClient = AssetServiceClient.create(assetServiceSettings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/logging/ConfigServiceV2Client.java
+++ b/test/integration/goldens/logging/ConfigServiceV2Client.java
@@ -73,6 +73,15 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * ConfigServiceV2Settings configServiceV2Settings =
+ *     ConfigServiceV2Settings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * ConfigServiceV2Client configServiceV2Client =
+ *     ConfigServiceV2Client.create(configServiceV2Settings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/logging/LoggingServiceV2Client.java
+++ b/test/integration/goldens/logging/LoggingServiceV2Client.java
@@ -75,6 +75,15 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * LoggingServiceV2Settings loggingServiceV2Settings =
+ *     LoggingServiceV2Settings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * LoggingServiceV2Client loggingServiceV2Client =
+ *     LoggingServiceV2Client.create(loggingServiceV2Settings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/logging/MetricsServiceV2Client.java
+++ b/test/integration/goldens/logging/MetricsServiceV2Client.java
@@ -72,6 +72,15 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * MetricsServiceV2Settings metricsServiceV2Settings =
+ *     MetricsServiceV2Settings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * MetricsServiceV2Client metricsServiceV2Client =
+ *     MetricsServiceV2Client.create(metricsServiceV2Settings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/redis/CloudRedisClient.java
+++ b/test/integration/goldens/redis/CloudRedisClient.java
@@ -95,6 +95,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre><code>
+ * CloudRedisSettings cloudRedisSettings =
+ *     CloudRedisSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * CloudRedisClient cloudRedisClient = CloudRedisClient.create(cloudRedisSettings);
+ * </code></pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi


### PR DESCRIPTION
Implement composing the sample code of setting credentials in service client class header comment.
Example in [logging](https://github.com/googleapis/java-logging/blob/master/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/LoggingClient.java#L101-L106), [pubsub](https://github.com/googleapis/java-pubsub/blob/master/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java#L125-L130)
```
FoobarSettings foobarSettings =
     FoobarSettings.newBuilder()
         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
         .build();
 FoobarClient echoClient =
     FoobarClient.create(echoSettings);
```