### PR TITLE
[compose][samplecode][2/2]Implement sample code of set endpoint in service class comment header

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -141,7 +141,9 @@ class ServiceClientCommentComposer {
         ServiceClientCommentSampleCodeComposer.composeClassHeaderCredentialsSampleCode(
             service, types));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
-    // TODO(summerji): Add endpoint customization sample code here.
+    classHeaderJavadocBuilder.addSampleCode(
+        ServiceClientCommentSampleCodeComposer.composeClassHeaderEndpointSampleCode(service, types)
+    );
 
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -142,8 +142,8 @@ class ServiceClientCommentComposer {
             service, types));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
     classHeaderJavadocBuilder.addSampleCode(
-        ServiceClientCommentSampleCodeComposer.composeClassHeaderEndpointSampleCode(service, types)
-    );
+        ServiceClientCommentSampleCodeComposer.composeClassHeaderEndpointSampleCode(
+            service, types));
 
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCommentSampleCodeComposer.java
@@ -92,6 +92,52 @@ public class ServiceClientCommentSampleCodeComposer {
     return writeSampleCode(Arrays.asList(initSettingsVarExpr, initClientVarExpr));
   }
 
+  public static String composeClassHeaderEndpointSampleCode(Service service, Map<String, TypeNode> types) {
+    String settingsVarName = JavaStyle.toLowerCamelCase(getSettingsName(service.name()));
+    TypeNode settingsVarType = types.get(getSettingsName(service.name()));
+    VariableExpr settingsVarExpr = VariableExpr.withVariable(
+        Variable.builder()
+            .setName(settingsVarName)
+            .setType(settingsVarType)
+            .build());
+    MethodInvocationExpr newBuilderMethodExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(settingsVarType)
+            .setMethodName("newBuilder")
+            .build();
+    MethodInvocationExpr credentialsMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(newBuilderMethodExpr)
+            .setArguments(ValueExpr.withValue(StringObjectValue.withValue("myEndpoint")))
+            .setMethodName("setEndpoint")
+            .build();
+    MethodInvocationExpr buildMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credentialsMethodExpr)
+            .setReturnType(settingsVarType)
+            .setMethodName("build")
+            .build();
+
+    Expr initSettingsVarExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(settingsVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(buildMethodExpr)
+            .build();
+
+    String className = JavaStyle.toLowerCamelCase(getClientClassName(service.name()));
+    TypeNode classType = types.get(getClientClassName(service.name()));
+    VariableExpr clientVarExpr = VariableExpr.withVariable(Variable.builder().setName(className).setType(classType).build());
+    MethodInvocationExpr createMethodExpr = MethodInvocationExpr.builder().setStaticReferenceType(classType).setArguments(settingsVarExpr).setMethodName("create").setReturnType(classType).build();
+    Expr initClientVarExpr = AssignmentExpr.builder()
+        .setVariableExpr(clientVarExpr.toBuilder().setIsDecl(true).build())
+        .setValueExpr(createMethodExpr)
+        .build();
+
+    return writeSampleCode(Arrays.asList(
+        initSettingsVarExpr, initClientVarExpr
+    ));
+  }
+
   private static String getClientClassName(String serviceName) {
     return String.format(CLASS_NAME_PATTERN, serviceName);
   }

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -72,6 +72,11 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * EchoSettings echoSettings = EchoSettings.newBuilder().setEndpoint("myEndpoint").build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -62,6 +62,12 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * IdentitySettings identitySettings =
+ *     IdentitySettings.newBuilder().setEndpoint("myEndpoint").build();
+ * IdentityClient identityClient = IdentityClient.create(identitySettings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -84,6 +84,12 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * AssetServiceSettings assetServiceSettings =
+ *     AssetServiceSettings.newBuilder().setEndpoint("myEndpoint").build();
+ * AssetServiceClient assetServiceClient = AssetServiceClient.create(assetServiceSettings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/logging/ConfigServiceV2Client.java
+++ b/test/integration/goldens/logging/ConfigServiceV2Client.java
@@ -83,6 +83,13 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * ConfigServiceV2Settings configServiceV2Settings =
+ *     ConfigServiceV2Settings.newBuilder().setEndpoint("myEndpoint").build();
+ * ConfigServiceV2Client configServiceV2Client =
+ *     ConfigServiceV2Client.create(configServiceV2Settings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/logging/LoggingServiceV2Client.java
+++ b/test/integration/goldens/logging/LoggingServiceV2Client.java
@@ -85,6 +85,13 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * LoggingServiceV2Settings loggingServiceV2Settings =
+ *     LoggingServiceV2Settings.newBuilder().setEndpoint("myEndpoint").build();
+ * LoggingServiceV2Client loggingServiceV2Client =
+ *     LoggingServiceV2Client.create(loggingServiceV2Settings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/logging/MetricsServiceV2Client.java
+++ b/test/integration/goldens/logging/MetricsServiceV2Client.java
@@ -82,6 +82,13 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * MetricsServiceV2Settings metricsServiceV2Settings =
+ *     MetricsServiceV2Settings.newBuilder().setEndpoint("myEndpoint").build();
+ * MetricsServiceV2Client metricsServiceV2Client =
+ *     MetricsServiceV2Client.create(metricsServiceV2Settings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/redis/CloudRedisClient.java
+++ b/test/integration/goldens/redis/CloudRedisClient.java
@@ -104,6 +104,12 @@ import javax.annotation.Generated;
  * </code></pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre><code>
+ * CloudRedisSettings cloudRedisSettings =
+ *     CloudRedisSettings.newBuilder().setEndpoint("myEndpoint").build();
+ * CloudRedisClient cloudRedisClient = CloudRedisClient.create(cloudRedisSettings);
+ * </code></pre>
  */
 @BetaApi
 @Generated("by gapic-generator")


### PR DESCRIPTION
The example in client lib, [pubsub](https://github.com/googleapis/java-pubsub/blob/master/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java#L138-L141), [logging](https://github.com/googleapis/java-logging/blob/master/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/LoggingClient.java#L114-L117).

Sample looks like:
```
 * FoobarSettings foobarSettings =
 *     FoobarSettings.newBuilder().setEndpoint(myEndpoint).build();
 * FoobarClient foobarClient =
 *     FoobarClient.create(foobarSettings);
 ```