### PR TITLE
[compose][samplecode][2/2]Implement sample code of set endpoint in service class comment header

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -15,9 +15,11 @@ java_library(
     deps = [
         "//:service_config_java_proto",
         "//src/main/java/com/google/api/generator/engine/ast",
+        "//src/main/java/com/google/api/generator/engine/writer",
         "//src/main/java/com/google/api/generator/gapic:status_java_proto",
         "//src/main/java/com/google/api/generator/gapic/model",
         "//src/main/java/com/google/api/generator/gapic/utils",
+        "//src/main/java/com/google/api/generator/gapic/composer/samplecode",
         "@com_google_api_api_common//jar",
         "@com_google_api_gax_java//gax",
         "@com_google_api_gax_java//gax-grpc:gax_grpc",

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientClassComposer.java
@@ -119,7 +119,7 @@ public class ServiceClientClassComposer implements ClassComposer {
     ClassDefinition classDef =
         ClassDefinition.builder()
             .setHeaderCommentStatements(
-                ServiceClientCommentComposer.createClassHeaderComments(service))
+                ServiceClientCommentComposer.createClassHeaderComments(service, types))
             .setPackageString(pakkage)
             .setAnnotations(createClassAnnotations(types))
             .setScope(ScopeNode.PUBLIC)

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -103,7 +104,8 @@ class ServiceClientCommentComposer {
           "Returns the OperationsClient that can be used to query the status of a long-running"
               + " operation returned by another API method call.");
 
-  static List<CommentStatement> createClassHeaderComments(Service service) {
+  static List<CommentStatement> createClassHeaderComments(
+      Service service, Map<String, TypeNode> types) {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
     if (service.hasDescription()) {
       classHeaderJavadocBuilder =
@@ -134,7 +136,8 @@ class ServiceClientCommentComposer {
             SERVICE_DESCRIPTION_CUSTOMIZE_SUMMARY_PATTERN,
             String.format("%sSettings", JavaStyle.toUpperCamelCase(service.name()))));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_CREDENTIALS_SUMMARY_STRING);
-    // TODO(summerji): Add credentials' customization sample code here.
+    classHeaderJavadocBuilder.addSampleCode(
+        ServiceClientSampleCodeComposer.composeClassHeaderCredentialsSampleCode(service, types));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
     // TODO(summerji): Add endpoint customization sample code here.
 

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -139,7 +139,8 @@ class ServiceClientCommentComposer {
     classHeaderJavadocBuilder.addSampleCode(
         ServiceClientSampleCodeComposer.composeClassHeaderCredentialsSampleCode(service, types));
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
-    // TODO(summerji): Add endpoint customization sample code here.
+    classHeaderJavadocBuilder.addSampleCode(
+        ServiceClientSampleCodeComposer.composeClassHeaderEndpointSampleCode(service, types));
 
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
@@ -94,6 +94,54 @@ public class ServiceClientSampleCodeComposer {
     return writeSampleCode(Arrays.asList(initSettingsVarExpr, initClientVarExpr));
   }
 
+  public static String composeClassHeaderEndpointSampleCode(
+      Service service, Map<String, TypeNode> types) {
+    String settingsVarName = JavaStyle.toLowerCamelCase(getSettingsName(service.name()));
+    TypeNode settingsVarType = types.get(getSettingsName(service.name()));
+    VariableExpr settingsVarExpr = createVariableExpr(settingsVarName, settingsVarType);
+    MethodInvocationExpr newBuilderMethodExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(settingsVarType)
+            .setMethodName("newBuilder")
+            .build();
+    MethodInvocationExpr credentialsMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(newBuilderMethodExpr)
+            .setArguments(ValueExpr.withValue(StringObjectValue.withValue("myEndpoint")))
+            .setMethodName("setEndpoint")
+            .build();
+    MethodInvocationExpr buildMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credentialsMethodExpr)
+            .setReturnType(settingsVarType)
+            .setMethodName("build")
+            .build();
+
+    Expr initSettingsVarExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(settingsVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(buildMethodExpr)
+            .build();
+
+    String clientName = JavaStyle.toLowerCamelCase(getClientClassName(service.name()));
+    TypeNode clientType = types.get(getClientClassName(service.name()));
+    VariableExpr clientVarExpr = createVariableExpr(clientName, clientType);
+    MethodInvocationExpr createMethodExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(clientType)
+            .setArguments(settingsVarExpr)
+            .setMethodName("create")
+            .setReturnType(clientType)
+            .build();
+    Expr initClientVarExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(clientVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(createMethodExpr)
+            .build();
+
+    return writeSampleCode(Arrays.asList(initSettingsVarExpr, initClientVarExpr));
+  }
+
   // ======================================== Helpers ==========================================//
 
   private static String getClientClassName(String serviceName) {

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.api.generator.gapic.composer;
 
 import com.google.api.gax.core.FixedCredentialsProvider;

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
@@ -1,0 +1,107 @@
+package com.google.api.generator.gapic.composer;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.generator.engine.ast.AssignmentExpr;
+import com.google.api.generator.engine.ast.ConcreteReference;
+import com.google.api.generator.engine.ast.Expr;
+import com.google.api.generator.engine.ast.ExprStatement;
+import com.google.api.generator.engine.ast.MethodInvocationExpr;
+import com.google.api.generator.engine.ast.Statement;
+import com.google.api.generator.engine.ast.StringObjectValue;
+import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.engine.ast.ValueExpr;
+import com.google.api.generator.engine.ast.Variable;
+import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.samplecode.SampleCodeJavaFormatter;
+import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.utils.JavaStyle;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ServiceClientSampleCodeComposer {
+  private static final String SETTINGS_NAME_PATTERN = "%sSettings";
+  private static final String CLASS_NAME_PATTERN = "%sClient";
+
+  public static String composeClassHeaderCredentialsSampleCode(
+      Service service, Map<String, TypeNode> types) {
+    String settingsVarName = JavaStyle.toLowerCamelCase(getSettingsName(service.name()));
+    TypeNode settingsVarType = types.get(getSettingsName(service.name()));
+    VariableExpr settingsVarExpr = createVariableExpr(settingsVarName, settingsVarType);
+    MethodInvocationExpr newBuilderMethodExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(settingsVarType)
+            .setMethodName("newBuilder")
+            .build();
+    TypeNode fixedCredentialProvideType =
+        TypeNode.withReference(ConcreteReference.withClazz(FixedCredentialsProvider.class));
+    MethodInvocationExpr credentialArgExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(fixedCredentialProvideType)
+            .setArguments(ValueExpr.withValue(StringObjectValue.withValue("myCredentials")))
+            .setMethodName("create")
+            .build();
+    MethodInvocationExpr credentialsMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(newBuilderMethodExpr)
+            .setArguments(credentialArgExpr)
+            .setMethodName("setCredentialsProvider")
+            .build();
+    MethodInvocationExpr buildMethodExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credentialsMethodExpr)
+            .setReturnType(settingsVarType)
+            .setMethodName("build")
+            .build();
+    Expr initSettingsVarExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(settingsVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(buildMethodExpr)
+            .build();
+
+    String clientName = JavaStyle.toLowerCamelCase(getClientClassName(service.name()));
+    TypeNode clientType = types.get(getClientClassName(service.name()));
+    VariableExpr clientVarExpr = createVariableExpr(clientName, clientType);
+    MethodInvocationExpr createMethodExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(clientType)
+            .setArguments(settingsVarExpr)
+            .setMethodName("create")
+            .setReturnType(clientType)
+            .build();
+    Expr initClientVarExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(clientVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(createMethodExpr)
+            .build();
+
+    return writeSampleCode(Arrays.asList(initSettingsVarExpr, initClientVarExpr));
+  }
+
+  // ======================================== Helpers ==========================================//
+
+  private static String getClientClassName(String serviceName) {
+    return String.format(CLASS_NAME_PATTERN, serviceName);
+  }
+
+  private static String getSettingsName(String serviceName) {
+    return String.format(SETTINGS_NAME_PATTERN, serviceName);
+  }
+
+  private static String writeSampleCode(List<Expr> exprs) {
+    List<Statement> statements =
+        exprs.stream().map(e -> ExprStatement.withExpr(e)).collect(Collectors.toList());
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    for (Statement statement : statements) {
+      statement.accept(visitor);
+    }
+    return SampleCodeJavaFormatter.format(visitor.write());
+  }
+
+  private static VariableExpr createVariableExpr(String variableName, TypeNode type) {
+    return VariableExpr.withVariable(
+        Variable.builder().setName(variableName).setType(type).build());
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -63,6 +63,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * EchoSettings echoSettings =
+ *     EchoSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -72,6 +72,11 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * EchoSettings echoSettings = EchoSettings.newBuilder().setEndpoint("myEndpoint").build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -62,6 +62,12 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * IdentitySettings identitySettings =
+ *     IdentitySettings.newBuilder().setEndpoint("myEndpoint").build();
+ * IdentityClient identityClient = IdentityClient.create(identitySettings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -53,6 +53,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * IdentitySettings identitySettings =
+ *     IdentitySettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * IdentityClient identityClient = IdentityClient.create(identitySettings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -84,6 +84,12 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * AssetServiceSettings assetServiceSettings =
+ *     AssetServiceSettings.newBuilder().setEndpoint("myEndpoint").build();
+ * AssetServiceClient assetServiceClient = AssetServiceClient.create(assetServiceSettings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -75,6 +75,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * AssetServiceSettings assetServiceSettings =
+ *     AssetServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * AssetServiceClient assetServiceClient = AssetServiceClient.create(assetServiceSettings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/logging/ConfigServiceV2Client.java
+++ b/test/integration/goldens/logging/ConfigServiceV2Client.java
@@ -73,6 +73,15 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * ConfigServiceV2Settings configServiceV2Settings =
+ *     ConfigServiceV2Settings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * ConfigServiceV2Client configServiceV2Client =
+ *     ConfigServiceV2Client.create(configServiceV2Settings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/logging/ConfigServiceV2Client.java
+++ b/test/integration/goldens/logging/ConfigServiceV2Client.java
@@ -83,6 +83,13 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * ConfigServiceV2Settings configServiceV2Settings =
+ *     ConfigServiceV2Settings.newBuilder().setEndpoint("myEndpoint").build();
+ * ConfigServiceV2Client configServiceV2Client =
+ *     ConfigServiceV2Client.create(configServiceV2Settings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/logging/LoggingServiceV2Client.java
+++ b/test/integration/goldens/logging/LoggingServiceV2Client.java
@@ -85,6 +85,13 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * LoggingServiceV2Settings loggingServiceV2Settings =
+ *     LoggingServiceV2Settings.newBuilder().setEndpoint("myEndpoint").build();
+ * LoggingServiceV2Client loggingServiceV2Client =
+ *     LoggingServiceV2Client.create(loggingServiceV2Settings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/logging/LoggingServiceV2Client.java
+++ b/test/integration/goldens/logging/LoggingServiceV2Client.java
@@ -75,6 +75,15 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * LoggingServiceV2Settings loggingServiceV2Settings =
+ *     LoggingServiceV2Settings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * LoggingServiceV2Client loggingServiceV2Client =
+ *     LoggingServiceV2Client.create(loggingServiceV2Settings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/logging/MetricsServiceV2Client.java
+++ b/test/integration/goldens/logging/MetricsServiceV2Client.java
@@ -82,6 +82,13 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * MetricsServiceV2Settings metricsServiceV2Settings =
+ *     MetricsServiceV2Settings.newBuilder().setEndpoint("myEndpoint").build();
+ * MetricsServiceV2Client metricsServiceV2Client =
+ *     MetricsServiceV2Client.create(metricsServiceV2Settings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/logging/MetricsServiceV2Client.java
+++ b/test/integration/goldens/logging/MetricsServiceV2Client.java
@@ -72,6 +72,15 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * MetricsServiceV2Settings metricsServiceV2Settings =
+ *     MetricsServiceV2Settings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * MetricsServiceV2Client metricsServiceV2Client =
+ *     MetricsServiceV2Client.create(metricsServiceV2Settings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi

--- a/test/integration/goldens/redis/CloudRedisClient.java
+++ b/test/integration/goldens/redis/CloudRedisClient.java
@@ -104,6 +104,12 @@ import javax.annotation.Generated;
  * }</pre>
  *
  * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * CloudRedisSettings cloudRedisSettings =
+ *     CloudRedisSettings.newBuilder().setEndpoint("myEndpoint").build();
+ * CloudRedisClient cloudRedisClient = CloudRedisClient.create(cloudRedisSettings);
+ * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator")

--- a/test/integration/goldens/redis/CloudRedisClient.java
+++ b/test/integration/goldens/redis/CloudRedisClient.java
@@ -95,6 +95,14 @@ import javax.annotation.Generated;
  *
  * <p>To customize credentials:
  *
+ * <pre>{@code
+ * CloudRedisSettings cloudRedisSettings =
+ *     CloudRedisSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create("myCredentials"))
+ *         .build();
+ * CloudRedisClient cloudRedisClient = CloudRedisClient.create(cloudRedisSettings);
+ * }</pre>
+ *
  * <p>To customize the endpoint:
  */
 @BetaApi


### PR DESCRIPTION
The example in client lib, [pubsub](https://github.com/googleapis/java-pubsub/blob/master/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java#L138-L141), [logging](https://github.com/googleapis/java-logging/blob/master/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/LoggingClient.java#L114-L117).

Sample looks like:
```
 * FoobarSettings foobarSettings =
 *     FoobarSettings.newBuilder().setEndpoint(myEndpoint).build();
 * FoobarClient foobarClient =
 *     FoobarClient.create(foobarSettings);
 ```