### PR TITLE
[samplecode][Prepare][2/2]Flattern the createVariableExpr wrapper 

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
@@ -44,7 +44,9 @@ public class ServiceClientSampleCodeComposer {
                 .setName("myCredentials")
                 .setPakkage(clientType.reference().pakkage())
                 .build());
-    VariableExpr settingsVarExpr = createVariableExpr(settingsName, settingsType);
+    VariableExpr settingsVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName(settingsName).setType(settingsType).build());
     MethodInvocationExpr newBuilderMethodExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(settingsType)
@@ -52,10 +54,13 @@ public class ServiceClientSampleCodeComposer {
             .build();
     TypeNode fixedCredentialProvideType =
         TypeNode.withReference(ConcreteReference.withClazz(FixedCredentialsProvider.class));
+    VariableExpr myCredentialVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName("myCredentials").setType(myCredentialsType).build());
     MethodInvocationExpr credentialArgExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(fixedCredentialProvideType)
-            .setArguments(createVariableExpr("myCredentials", myCredentialsType))
+            .setArguments(myCredentialVarExpr)
             .setMethodName("create")
             .build();
     MethodInvocationExpr credentialsMethodExpr =
@@ -78,7 +83,9 @@ public class ServiceClientSampleCodeComposer {
 
     // Initialized client with create() method.
     // e.g. EchoClient echoClient = EchoClient.create(echoSettings);
-    VariableExpr clientVarExpr = createVariableExpr(clientName, clientType);
+    VariableExpr clientVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName(clientName).setType(clientType).build());
     MethodInvocationExpr createMethodExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(clientType)
@@ -109,16 +116,21 @@ public class ServiceClientSampleCodeComposer {
                 .setName("myEndpoint")
                 .setPakkage(clientType.reference().pakkage())
                 .build());
-    VariableExpr settingsVarExpr = createVariableExpr(settingsName, settingsType);
+    VariableExpr settingsVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName(settingsName).setType(settingsType).build());
     MethodInvocationExpr newBuilderMethodExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(settingsType)
             .setMethodName("newBuilder")
             .build();
+    VariableExpr myEndpointVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName("myEndpoint").setType(myEndpointType).build());
     MethodInvocationExpr credentialsMethodExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(newBuilderMethodExpr)
-            .setArguments(createVariableExpr("myEndpoint", myEndpointType))
+            .setArguments(myEndpointVarExpr)
             .setMethodName("setEndpoint")
             .build();
     MethodInvocationExpr buildMethodExpr =
@@ -136,7 +148,9 @@ public class ServiceClientSampleCodeComposer {
 
     // Initialize client with create() method.
     // e.g. EchoClient echoClient = EchoClient.create(echoSettings);
-    VariableExpr clientVarExpr = createVariableExpr(clientName, clientType);
+    VariableExpr clientVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName(clientName).setType(clientType).build());
     MethodInvocationExpr createMethodExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(clientType)
@@ -154,12 +168,5 @@ public class ServiceClientSampleCodeComposer {
         Arrays.asList(
             ExprStatement.withExpr(initSettingsVarExpr),
             ExprStatement.withExpr(initClientVarExpr)));
-  }
-
-  // ======================================== Helpers ==========================================//
-
-  private static VariableExpr createVariableExpr(String variableName, TypeNode type) {
-    return VariableExpr.withVariable(
-        Variable.builder().setName(variableName).setType(type).build());
   }
 }


### PR DESCRIPTION
As we discuss in #573, no need wrapper `createVariableExpr`. Flatten the existing `createVariableExpr` and prepare for merge `MethodSampleCodeHelperComposer` merge into `ServiceClientSampleCodeComposer`.