### PR TITLE
[ggj][codgen] fix: add HTTP's additional_bindings to GrpcServiceStub call settings

### DIFF
--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -189,7 +189,7 @@ def java_gapic_library(
     )
 
     # General additional deps.
-    actual_deps = resource_name_deps + [
+    actual_deps = deps + resource_name_deps + [
         "@com_google_googleapis//google/rpc:rpc_java_proto",
         "@com_google_googleapis//google/longrunning:longrunning_java_proto",
         "@com_google_protobuf//:protobuf_java",
@@ -207,7 +207,6 @@ def java_gapic_library(
         "@com_google_http_client_google_http_client//jar",
         "@javax_annotation_javax_annotation_api//jar",
     ]
-    _append_dep_without_duplicates(actual_deps, deps)
 
     native.java_library(
         name = name,

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -20,6 +20,7 @@ import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.MethodArgument;
 import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -181,7 +182,7 @@ class ServiceClientCommentComposer {
         // TODO(miraleung): Remove the newline replacement when we support CommonMark.
         String description =
             argument.field().hasDescription() ? argument.field().description() : EMPTY_STRING;
-        methodJavadocBuilder.addParam(argument.name(), description);
+        methodJavadocBuilder.addParam(JavaStyle.toLowerCamelCase(argument.name()), description);
       }
     }
 

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -331,7 +331,7 @@ public class EchoClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * @param end_time
+   * @param endTime
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<WaitResponse, WaitMetadata> waitAsync(Timestamp endTime) {

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/GrpcTestingStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/GrpcTestingStub.golden
@@ -262,7 +262,11 @@ public class GrpcTestingStub extends TestingStub {
                   @Override
                   public Map<String, String> extract(VerifyTestRequest request) {
                     ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("answer", String.valueOf(request.getAnswer()));
+                    params.put("foo", String.valueOf(request.getFoo()));
                     params.put("name", String.valueOf(request.getName()));
+                    params.put(
+                        "test_to_verify.name", String.valueOf(request.getTestToVerify().getName()));
                     return params.build();
                   }
                 })

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -125,7 +125,7 @@ public class IdentityClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * @param parent
-   * @param display_name
+   * @param displayName
    * @param email
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -142,12 +142,12 @@ public class IdentityClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * @param parent
-   * @param display_name
+   * @param displayName
    * @param email
    * @param age
    * @param nickname
-   * @param enable_notifications
-   * @param height_feet
+   * @param enableNotifications
+   * @param heightFeet
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final User createUser(

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/TestingClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/TestingClientTest.golden
@@ -465,6 +465,8 @@ public class TestingClientTest {
             .setName(TestName.of("[SESSION]", "[SHARD_ID]", "[TEST_ID]").toString())
             .setAnswer(ByteString.EMPTY)
             .addAllAnswers(new ArrayList<ByteString>())
+            .setFoo("foo101574")
+            .setTestToVerify(com.google.showcase.v1beta1.Test.newBuilder().build())
             .build();
 
     VerifyTestResponse actualResponse = client.verifyTest(request);
@@ -477,6 +479,8 @@ public class TestingClientTest {
     Assert.assertEquals(request.getName(), actualRequest.getName());
     Assert.assertEquals(request.getAnswer(), actualRequest.getAnswer());
     Assert.assertEquals(request.getAnswersList(), actualRequest.getAnswersList());
+    Assert.assertEquals(request.getFoo(), actualRequest.getFoo());
+    Assert.assertEquals(request.getTestToVerify(), actualRequest.getTestToVerify());
     Assert.assertTrue(
         channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
@@ -494,6 +498,8 @@ public class TestingClientTest {
               .setName(TestName.of("[SESSION]", "[SHARD_ID]", "[TEST_ID]").toString())
               .setAnswer(ByteString.EMPTY)
               .addAllAnswers(new ArrayList<ByteString>())
+              .setFoo("foo101574")
+              .setTestToVerify(com.google.showcase.v1beta1.Test.newBuilder().build())
               .build();
       client.verifyTest(request);
       Assert.fail("No exception raised");

--- a/src/test/java/com/google/api/generator/gapic/protoparser/HttpRuleParserTest.java
+++ b/src/test/java/com/google/api/generator/gapic/protoparser/HttpRuleParserTest.java
@@ -46,12 +46,31 @@ public class HttpRuleParserTest {
         HttpRuleParser.parseHttpBindings(rpcMethod, inputMessage, messages);
     assertFalse(httpBindingsOpt.isPresent());
 
-    // VerityTest method.
-    rpcMethod = testingService.getMethods().get(testingService.getMethods().size() - 1);
-    inputMessage = messages.get("VerifyTestRequest");
+    // GetSession method.
+    rpcMethod = testingService.getMethods().get(1);
+    inputMessage = messages.get("GetSessionRequest");
     httpBindingsOpt = HttpRuleParser.parseHttpBindings(rpcMethod, inputMessage, messages);
     assertTrue(httpBindingsOpt.isPresent());
     assertThat(httpBindingsOpt.get()).containsExactly("name");
+  }
+
+  @Test
+  public void parseHttpAnnotation_multipleBindings() {
+    FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
+    ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
+    assertEquals("Testing", testingService.getName());
+
+    Map<String, Message> messages = Parser.parseMessages(testingFileDescriptor);
+
+    // VerityTest method.
+    MethodDescriptor rpcMethod =
+        testingService.getMethods().get(testingService.getMethods().size() - 1);
+    Message inputMessage = messages.get("VerifyTestRequest");
+    Optional<List<String>> httpBindingsOpt =
+        HttpRuleParser.parseHttpBindings(rpcMethod, inputMessage, messages);
+    assertTrue(httpBindingsOpt.isPresent());
+    assertThat(httpBindingsOpt.get())
+        .containsExactly("answer", "foo", "name", "test_to_verify.name");
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/gapic/testdata/testing.proto
+++ b/src/test/java/com/google/api/generator/gapic/testdata/testing.proto
@@ -107,6 +107,19 @@ service Testing {
   rpc VerifyTest(VerifyTestRequest) returns (VerifyTestResponse) {
     option (google.api.http) = {
       post: "/v1beta1/{name=sessions/*/tests/*}:check"
+      body: "*"
+      additional_bindings {
+        post: "/v1beta1/{foo=sessions/*/tests/*}:check"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v1beta1/{answer=sessions/*/tests/*}:check"
+        body: "*"
+      }
+      additional_bindings {
+        post: "/v1beta1/{test_to_verify.name=sessions/*/tests/*}:check"
+        body: "*"
+      }
     };
   }
 }
@@ -392,6 +405,11 @@ message VerifyTestRequest {
 
   // The answers from the test if multiple are to be checked
   repeated bytes answers = 3;
+
+  // Test fields for HTTP annotations.
+  string foo = 4;
+
+  Test test_to_verify = 5;
 }
 
 message VerifyTestResponse {

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -497,7 +497,7 @@ public class AssetServiceClient implements BackgroundResource {
    *           "us-west1" region or the "global" location.
    *     </ul>
    *
-   * @param asset_types Optional. A list of asset types that this request searches for. If empty, it
+   * @param assetTypes Optional. A list of asset types that this request searches for. If empty, it
    *     will search all the [searchable asset
    *     types](https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types).
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails

--- a/test/integration/goldens/library/LibraryServiceClient.java
+++ b/test/integration/goldens/library/LibraryServiceClient.java
@@ -336,7 +336,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * shelves are the same.
    *
    * @param name The name of the shelf we're adding books to.
-   * @param other_shelf_name The name of the shelf we're removing books from and deleting.
+   * @param otherShelfName The name of the shelf we're removing books from and deleting.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Shelf mergeShelves(ShelfName name, ShelfName otherShelfName) {
@@ -358,7 +358,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * shelves are the same.
    *
    * @param name The name of the shelf we're adding books to.
-   * @param other_shelf_name The name of the shelf we're removing books from and deleting.
+   * @param otherShelfName The name of the shelf we're removing books from and deleting.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Shelf mergeShelves(ShelfName name, String otherShelfName) {
@@ -380,7 +380,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * shelves are the same.
    *
    * @param name The name of the shelf we're adding books to.
-   * @param other_shelf_name The name of the shelf we're removing books from and deleting.
+   * @param otherShelfName The name of the shelf we're removing books from and deleting.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Shelf mergeShelves(String name, ShelfName otherShelfName) {
@@ -402,7 +402,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * shelves are the same.
    *
    * @param name The name of the shelf we're adding books to.
-   * @param other_shelf_name The name of the shelf we're removing books from and deleting.
+   * @param otherShelfName The name of the shelf we're removing books from and deleting.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Shelf mergeShelves(String name, String otherShelfName) {
@@ -668,7 +668,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * the same as the original book.
    *
    * @param name The name of the book to move.
-   * @param other_shelf_name The name of the destination shelf.
+   * @param otherShelfName The name of the destination shelf.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Book moveBook(BookName name, ShelfName otherShelfName) {
@@ -686,7 +686,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * the same as the original book.
    *
    * @param name The name of the book to move.
-   * @param other_shelf_name The name of the destination shelf.
+   * @param otherShelfName The name of the destination shelf.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Book moveBook(BookName name, String otherShelfName) {
@@ -704,7 +704,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * the same as the original book.
    *
    * @param name The name of the book to move.
-   * @param other_shelf_name The name of the destination shelf.
+   * @param otherShelfName The name of the destination shelf.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Book moveBook(String name, ShelfName otherShelfName) {
@@ -722,7 +722,7 @@ public class LibraryServiceClient implements BackgroundResource {
    * the same as the original book.
    *
    * @param name The name of the book to move.
-   * @param other_shelf_name The name of the destination shelf.
+   * @param otherShelfName The name of the destination shelf.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Book moveBook(String name, String otherShelfName) {

--- a/test/integration/goldens/logging/ConfigClient.java
+++ b/test/integration/goldens/logging/ConfigClient.java
@@ -475,7 +475,7 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Gets a sink.
    *
-   * @param sink_name Required. The resource name of the sink:
+   * @param sinkName Required. The resource name of the sink:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
@@ -495,7 +495,7 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Gets a sink.
    *
-   * @param sink_name Required. The resource name of the sink:
+   * @param sinkName Required. The resource name of the sink:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
@@ -681,7 +681,7 @@ public class ConfigClient implements BackgroundResource {
    * <p>The updated sink might also have a new `writer_identity`; see the `unique_writer_identity`
    * field.
    *
-   * @param sink_name Required. The full resource name of the sink to update, including the parent
+   * @param sinkName Required. The full resource name of the sink to update, including the parent
    *     resource and the sink identifier:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
@@ -709,7 +709,7 @@ public class ConfigClient implements BackgroundResource {
    * <p>The updated sink might also have a new `writer_identity`; see the `unique_writer_identity`
    * field.
    *
-   * @param sink_name Required. The full resource name of the sink to update, including the parent
+   * @param sinkName Required. The full resource name of the sink to update, including the parent
    *     resource and the sink identifier:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
@@ -734,7 +734,7 @@ public class ConfigClient implements BackgroundResource {
    * <p>The updated sink might also have a new `writer_identity`; see the `unique_writer_identity`
    * field.
    *
-   * @param sink_name Required. The full resource name of the sink to update, including the parent
+   * @param sinkName Required. The full resource name of the sink to update, including the parent
    *     resource and the sink identifier:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
@@ -743,9 +743,9 @@ public class ConfigClient implements BackgroundResource {
    *     <p>Example: `"projects/my-project-id/sinks/my-sink-id"`.
    * @param sink Required. The updated sink, whose name is the same identifier that appears as part
    *     of `sink_name`.
-   * @param update_mask Optional. Field mask that specifies the fields in `sink` that need an
-   *     update. A sink field will be overwritten if, and only if, it is in the update mask. `name`
-   *     and output only fields cannot be updated.
+   * @param updateMask Optional. Field mask that specifies the fields in `sink` that need an update.
+   *     A sink field will be overwritten if, and only if, it is in the update mask. `name` and
+   *     output only fields cannot be updated.
    *     <p>An empty updateMask is temporarily treated as using the following mask for backwards
    *     compatibility purposes: destination,filter,includeChildren At some point in the future,
    *     behavior will be removed and specifying an empty updateMask will be an error.
@@ -772,7 +772,7 @@ public class ConfigClient implements BackgroundResource {
    * <p>The updated sink might also have a new `writer_identity`; see the `unique_writer_identity`
    * field.
    *
-   * @param sink_name Required. The full resource name of the sink to update, including the parent
+   * @param sinkName Required. The full resource name of the sink to update, including the parent
    *     resource and the sink identifier:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
@@ -781,9 +781,9 @@ public class ConfigClient implements BackgroundResource {
    *     <p>Example: `"projects/my-project-id/sinks/my-sink-id"`.
    * @param sink Required. The updated sink, whose name is the same identifier that appears as part
    *     of `sink_name`.
-   * @param update_mask Optional. Field mask that specifies the fields in `sink` that need an
-   *     update. A sink field will be overwritten if, and only if, it is in the update mask. `name`
-   *     and output only fields cannot be updated.
+   * @param updateMask Optional. Field mask that specifies the fields in `sink` that need an update.
+   *     A sink field will be overwritten if, and only if, it is in the update mask. `name` and
+   *     output only fields cannot be updated.
    *     <p>An empty updateMask is temporarily treated as using the following mask for backwards
    *     compatibility purposes: destination,filter,includeChildren At some point in the future,
    *     behavior will be removed and specifying an empty updateMask will be an error.
@@ -836,7 +836,7 @@ public class ConfigClient implements BackgroundResource {
    * Deletes a sink. If the sink has a unique `writer_identity`, then that service account is also
    * deleted.
    *
-   * @param sink_name Required. The full resource name of the sink to delete, including the parent
+   * @param sinkName Required. The full resource name of the sink to delete, including the parent
    *     resource and the sink identifier:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
@@ -858,7 +858,7 @@ public class ConfigClient implements BackgroundResource {
    * Deletes a sink. If the sink has a unique `writer_identity`, then that service account is also
    * deleted.
    *
-   * @param sink_name Required. The full resource name of the sink to delete, including the parent
+   * @param sinkName Required. The full resource name of the sink to delete, including the parent
    *     resource and the sink identifier:
    *     <p>"projects/[PROJECT_ID]/sinks/[SINK_ID]"
    *     "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
@@ -1208,8 +1208,8 @@ public class ConfigClient implements BackgroundResource {
    *     <p>Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
    * @param exclusion Required. New values for the existing exclusion. Only the fields specified in
    *     `update_mask` are relevant.
-   * @param update_mask Required. A non-empty list of fields to change in the existing exclusion.
-   *     New values for the fields are taken from the corresponding fields in the
+   * @param updateMask Required. A non-empty list of fields to change in the existing exclusion. New
+   *     values for the fields are taken from the corresponding fields in the
    *     [LogExclusion][google.logging.v2.LogExclusion] included in this request. Fields not
    *     mentioned in `update_mask` are not changed and are ignored in the request.
    *     <p>For example, to change the filter and description of an exclusion, specify an
@@ -1239,8 +1239,8 @@ public class ConfigClient implements BackgroundResource {
    *     <p>Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
    * @param exclusion Required. New values for the existing exclusion. Only the fields specified in
    *     `update_mask` are relevant.
-   * @param update_mask Required. A non-empty list of fields to change in the existing exclusion.
-   *     New values for the fields are taken from the corresponding fields in the
+   * @param updateMask Required. A non-empty list of fields to change in the existing exclusion. New
+   *     values for the fields are taken from the corresponding fields in the
    *     [LogExclusion][google.logging.v2.LogExclusion] included in this request. Fields not
    *     mentioned in `update_mask` are not changed and are ignored in the request.
    *     <p>For example, to change the filter and description of an exclusion, specify an

--- a/test/integration/goldens/logging/LoggingClient.java
+++ b/test/integration/goldens/logging/LoggingClient.java
@@ -163,7 +163,7 @@ public class LoggingClient implements BackgroundResource {
    * written shortly before the delete operation might not be deleted. Entries received after the
    * delete operation with a timestamp before the operation will be deleted.
    *
-   * @param log_name Required. The resource name of the log to delete:
+   * @param logName Required. The resource name of the log to delete:
    *     <p>"projects/[PROJECT_ID]/logs/[LOG_ID]" "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]" "folders/[FOLDER_ID]/logs/[LOG_ID]"
    *     <p>`[LOG_ID]` must be URL-encoded. For example, `"projects/my-project-id/logs/syslog"`,
@@ -185,7 +185,7 @@ public class LoggingClient implements BackgroundResource {
    * written shortly before the delete operation might not be deleted. Entries received after the
    * delete operation with a timestamp before the operation will be deleted.
    *
-   * @param log_name Required. The resource name of the log to delete:
+   * @param logName Required. The resource name of the log to delete:
    *     <p>"projects/[PROJECT_ID]/logs/[LOG_ID]" "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]" "folders/[FOLDER_ID]/logs/[LOG_ID]"
    *     <p>`[LOG_ID]` must be URL-encoded. For example, `"projects/my-project-id/logs/syslog"`,
@@ -230,7 +230,7 @@ public class LoggingClient implements BackgroundResource {
    * libraries configured to use Logging. A single request may contain log entries for a maximum of
    * 1000 different resources (projects, organizations, billing accounts or folders)
    *
-   * @param log_name Optional. A default log resource name that is assigned to all log entries in
+   * @param logName Optional. A default log resource name that is assigned to all log entries in
    *     `entries` that do not specify a value for `log_name`:
    *     <p>"projects/[PROJECT_ID]/logs/[LOG_ID]" "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]" "folders/[FOLDER_ID]/logs/[LOG_ID]"
@@ -292,7 +292,7 @@ public class LoggingClient implements BackgroundResource {
    * libraries configured to use Logging. A single request may contain log entries for a maximum of
    * 1000 different resources (projects, organizations, billing accounts or folders)
    *
-   * @param log_name Optional. A default log resource name that is assigned to all log entries in
+   * @param logName Optional. A default log resource name that is assigned to all log entries in
    *     `entries` that do not specify a value for `log_name`:
    *     <p>"projects/[PROJECT_ID]/logs/[LOG_ID]" "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]" "folders/[FOLDER_ID]/logs/[LOG_ID]"
@@ -381,8 +381,8 @@ public class LoggingClient implements BackgroundResource {
    * project/folder/organization/billing account. For ways to export log entries, see [Exporting
    * Logs](https://cloud.google.com/logging/docs/export).
    *
-   * @param resource_names Required. Names of one or more parent resources from which to retrieve
-   *     log entries:
+   * @param resourceNames Required. Names of one or more parent resources from which to retrieve log
+   *     entries:
    *     <p>"projects/[PROJECT_ID]" "organizations/[ORGANIZATION_ID]"
    *     "billingAccounts/[BILLING_ACCOUNT_ID]" "folders/[FOLDER_ID]"
    *     <p>Projects listed in the `project_ids` field are added to this list.
@@ -392,11 +392,11 @@ public class LoggingClient implements BackgroundResource {
    *     resources listed in `resource_names`. Referencing a parent resource that is not listed in
    *     `resource_names` will cause the filter to return no results. The maximum length of the
    *     filter is 20000 characters.
-   * @param order_by Optional. How the results should be sorted. Presently, the only permitted
-   *     values are `"timestamp asc"` (default) and `"timestamp desc"`. The first option returns
-   *     entries in order of increasing values of `LogEntry.timestamp` (oldest first), and the
-   *     second option returns entries in order of decreasing timestamps (newest first). Entries
-   *     with equal timestamps are returned in order of their `insert_id` values.
+   * @param orderBy Optional. How the results should be sorted. Presently, the only permitted values
+   *     are `"timestamp asc"` (default) and `"timestamp desc"`. The first option returns entries in
+   *     order of increasing values of `LogEntry.timestamp` (oldest first), and the second option
+   *     returns entries in order of decreasing timestamps (newest first). Entries with equal
+   *     timestamps are returned in order of their `insert_id` values.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final ListLogEntriesPagedResponse listLogEntries(

--- a/test/integration/goldens/logging/MetricsClient.java
+++ b/test/integration/goldens/logging/MetricsClient.java
@@ -214,7 +214,7 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Gets a logs-based metric.
    *
-   * @param metric_name Required. The resource name of the desired metric:
+   * @param metricName Required. The resource name of the desired metric:
    *     <p>"projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -230,7 +230,7 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Gets a logs-based metric.
    *
-   * @param metric_name Required. The resource name of the desired metric:
+   * @param metricName Required. The resource name of the desired metric:
    *     <p>"projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -323,7 +323,7 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Creates or updates a logs-based metric.
    *
-   * @param metric_name Required. The resource name of the metric to update:
+   * @param metricName Required. The resource name of the metric to update:
    *     <p>"projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    *     <p>The updated metric must be provided in the request and it's `name` field must be the
    *     same as `[METRIC_ID]` If the metric does not exist in `[PROJECT_ID]`, then a new metric is
@@ -344,7 +344,7 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Creates or updates a logs-based metric.
    *
-   * @param metric_name Required. The resource name of the metric to update:
+   * @param metricName Required. The resource name of the metric to update:
    *     <p>"projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    *     <p>The updated metric must be provided in the request and it's `name` field must be the
    *     same as `[METRIC_ID]` If the metric does not exist in `[PROJECT_ID]`, then a new metric is
@@ -383,7 +383,7 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Deletes a logs-based metric.
    *
-   * @param metric_name Required. The resource name of the metric to delete:
+   * @param metricName Required. The resource name of the metric to delete:
    *     <p>"projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -399,7 +399,7 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Deletes a logs-based metric.
    *
-   * @param metric_name Required. The resource name of the metric to delete:
+   * @param metricName Required. The resource name of the metric to delete:
    *     <p>"projects/[PROJECT_ID]/metrics/[METRIC_ID]"
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */

--- a/test/integration/goldens/redis/CloudRedisClient.java
+++ b/test/integration/goldens/redis/CloudRedisClient.java
@@ -353,8 +353,8 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * @param parent Required. The resource name of the instance location using the form:
    *     `projects/{project_id}/locations/{location_id}` where `location_id` refers to a GCP region.
-   * @param instance_id Required. The logical name of the Redis instance in the customer project
-   *     with the following restrictions:
+   * @param instanceId Required. The logical name of the Redis instance in the customer project with
+   *     the following restrictions:
    *     <ul>
    *       <li>Must contain only lowercase letters, numbers, and hyphens.
    *       <li>Must start with a letter.
@@ -394,8 +394,8 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * @param parent Required. The resource name of the instance location using the form:
    *     `projects/{project_id}/locations/{location_id}` where `location_id` refers to a GCP region.
-   * @param instance_id Required. The logical name of the Redis instance in the customer project
-   *     with the following restrictions:
+   * @param instanceId Required. The logical name of the Redis instance in the customer project with
+   *     the following restrictions:
    *     <ul>
    *       <li>Must contain only lowercase letters, numbers, and hyphens.
    *       <li>Must start with a letter.
@@ -492,7 +492,7 @@ public class CloudRedisClient implements BackgroundResource {
    * The returned operation is automatically deleted after a few hours, so there is no need to call
    * DeleteOperation.
    *
-   * @param update_mask Required. Mask of fields to update. At least one path must be supplied in
+   * @param updateMask Required. Mask of fields to update. At least one path must be supplied in
    *     this field. The elements of the repeated paths field may only include these fields from
    *     [Instance][google.cloud.redis.v1.Instance]:
    *     <p>&#42; `displayName` &#42; `labels` &#42; `memorySizeGb` &#42; `redisConfig`
@@ -558,7 +558,7 @@ public class CloudRedisClient implements BackgroundResource {
    * @param name Required. Redis instance resource name using the form:
    *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
    *     refers to a GCP region.
-   * @param redis_version Required. Specifies the target version of Redis software to upgrade to.
+   * @param redisVersion Required. Specifies the target version of Redis software to upgrade to.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<Instance, OperationMetadata> upgradeInstanceAsync(
@@ -578,7 +578,7 @@ public class CloudRedisClient implements BackgroundResource {
    * @param name Required. Redis instance resource name using the form:
    *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
    *     refers to a GCP region.
-   * @param redis_version Required. Specifies the target version of Redis software to upgrade to.
+   * @param redisVersion Required. Specifies the target version of Redis software to upgrade to.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<Instance, OperationMetadata> upgradeInstanceAsync(
@@ -634,7 +634,7 @@ public class CloudRedisClient implements BackgroundResource {
    * @param name Required. Redis instance resource name using the form:
    *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
    *     refers to a GCP region.
-   * @param input_config Required. Specify data to be imported.
+   * @param inputConfig Required. Specify data to be imported.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<Instance, OperationMetadata> importInstanceAsync(
@@ -707,7 +707,7 @@ public class CloudRedisClient implements BackgroundResource {
    * @param name Required. Redis instance resource name using the form:
    *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
    *     refers to a GCP region.
-   * @param output_config Required. Specify data to be exported.
+   * @param outputConfig Required. Specify data to be exported.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final OperationFuture<Instance, OperationMetadata> exportInstanceAsync(
@@ -773,7 +773,7 @@ public class CloudRedisClient implements BackgroundResource {
    * @param name Required. Redis instance resource name using the form:
    *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
    *     refers to a GCP region.
-   * @param data_protection_mode Optional. Available data protection modes that the user can choose.
+   * @param dataProtectionMode Optional. Available data protection modes that the user can choose.
    *     If it's unspecified, data protection mode will be LIMITED_DATA_LOSS by default.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -795,7 +795,7 @@ public class CloudRedisClient implements BackgroundResource {
    * @param name Required. Redis instance resource name using the form:
    *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
    *     refers to a GCP region.
-   * @param data_protection_mode Optional. Available data protection modes that the user can choose.
+   * @param dataProtectionMode Optional. Available data protection modes that the user can choose.
    *     If it's unspecified, data protection mode will be LIMITED_DATA_LOSS by default.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */


### PR DESCRIPTION
Handles the case where different bindings may be used in the `additional_bindings` field of the HTTP proto annotation.