### PR TITLE
[samplecode] Implement rpc default method sample code

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientCommentComposer.java
@@ -199,9 +199,9 @@ class ServiceClientCommentComposer {
     return comments;
   }
 
-  static List<CommentStatement> createRpcMethodHeaderComment(Method method) {
-    // TODO(summerji): Refactor this method when implement default method sample code.
-    return createRpcMethodHeaderComment(method, Collections.emptyList(), Optional.empty());
+  static List<CommentStatement> createRpcMethodHeaderComment(
+      Method method, Optional<String> sampleCode) {
+    return createRpcMethodHeaderComment(method, Collections.emptyList(), sampleCode);
   }
 
   static CommentStatement createMethodNoArgComment(String serviceName) {

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposer.java
@@ -201,8 +201,6 @@ public class ServiceClientSampleCodeComposer {
                 .setType(clientType)
                 .build());
 
-    List<Expr> bodyExprs = new ArrayList<>();
-
     // Assign method's arguments variable with the default values.
     List<VariableExpr> rpcMethodArgVarExprs = createRpcMethodArgumentVariableExprs(arguments);
     List<Expr> rpcMethodArgDefaultValueExprs =
@@ -210,6 +208,8 @@ public class ServiceClientSampleCodeComposer {
     List<Expr> rpcMethodArgAssignmentExprs =
         createAssignmentsForVarExprsWithValueExprs(
             rpcMethodArgVarExprs, rpcMethodArgDefaultValueExprs);
+
+    List<Expr> bodyExprs = new ArrayList<>();
     bodyExprs.addAll(rpcMethodArgAssignmentExprs);
 
     List<Statement> bodyStatements = new ArrayList<>();
@@ -247,8 +247,7 @@ public class ServiceClientSampleCodeComposer {
                 .setType(clientType)
                 .build());
 
-    List<Expr> bodyExprs = new ArrayList<>();
-
+    // Create request variable expression and assign with its default value.
     VariableExpr requestVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("request").setType(method.inputType()).build());
@@ -264,6 +263,7 @@ public class ServiceClientSampleCodeComposer {
             .setValueExpr(requestBuilderExpr)
             .build();
 
+    List<Expr> bodyExprs = new ArrayList<>();
     bodyExprs.add(requestAssignmentExpr);
 
     List<Statement> bodyStatements = new ArrayList<>();

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposerTest.java
@@ -21,7 +21,6 @@ import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.Reference;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.VaporReference;
-import com.google.api.generator.gapic.composer.samplecode.SampleCodeWriter;
 import com.google.api.generator.gapic.model.Field;
 import com.google.api.generator.gapic.model.LongrunningOperation;
 import com.google.api.generator.gapic.model.Message;
@@ -44,7 +43,7 @@ public class ServiceClientSampleCodeComposerTest {
   private static final String LRO_PACKAGE_NAME = "com.google.longrunning";
   private static final String PROTO_PACKAGE_NAME = "com.google.protobuf";
 
-  // =======================================RPC Method Header Sample Code=======================//
+  // =======================================Unary RPC Method Sample Code=======================//
   @Test
   public void validComposeRpcMethodHeaderSampleCode_pureUnaryRpc() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
@@ -88,7 +87,7 @@ public class ServiceClientSampleCodeComposerTest {
   }
 
   @Test
-  public void validComposeRpcMethodHeaderSampleCode_pagedUnaryRpc() {
+  public void validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithResourceNameMethodArgument() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -101,38 +100,54 @@ public class ServiceClientSampleCodeComposerTest {
     TypeNode inputType =
         TypeNode.withReference(
             VaporReference.builder()
-                .setName("PagedExpandRequest")
+                .setName("EchoRequest")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
     TypeNode outputType =
         TypeNode.withReference(
             VaporReference.builder()
-                .setName("PagedExpandResponse")
+                .setName("EchoResponse")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
+    TypeNode resourceNameType =
+        TypeNode.withReference(
+            ConcreteReference.withClazz(com.google.api.resourcenames.ResourceName.class));
+    MethodArgument arg =
+        MethodArgument.builder()
+            .setName("parent")
+            .setType(resourceNameType)
+            .setField(
+                Field.builder()
+                    .setName("parent")
+                    .setType(TypeNode.STRING)
+                    .setResourceReference(
+                        ResourceReference.withType("showcase.googleapis.com/AnythingGoes"))
+                    .build())
+            .setIsResourceNameHelper(true)
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
     Method method =
         Method.builder()
-            .setName("SimplePagedExpand")
-            .setMethodSignatures(Collections.emptyList())
+            .setName("echo")
+            .setMethodSignatures(signatures)
             .setInputType(inputType)
             .setOutputType(outputType)
-            .setIsPaged(true)
             .build();
     String results =
         ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
-            method, clientType, Collections.emptyList(), resourceNames, messageTypes);
+            method, clientType, signatures.get(0), resourceNames, messageTypes);
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  for (EchoResponse element : echoClient.simplePagedExpand().iterateAll()) {\n",
-            "    // doThingsWith(element);\n",
-            "  }\n",
+            "  ResourceName parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\");\n",
+            "  EchoResponse response = echoClient.echo(parent);\n",
             "}");
     assertEquals(expected, results);
   }
 
   @Test
-  public void validComposeRpcMethodHeaderSampleCode_lroUnaryRpc() {
+  public void
+      validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithSuperReferenceIsResourceNameMethodArgument() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -145,49 +160,586 @@ public class ServiceClientSampleCodeComposerTest {
     TypeNode inputType =
         TypeNode.withReference(
             VaporReference.builder()
-                .setName("WaitRequest")
+                .setName("EchoRequest")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
     TypeNode outputType =
         TypeNode.withReference(
-            VaporReference.builder().setName("Operation").setPakkage(LRO_PACKAGE_NAME).build());
-    TypeNode responseType =
-        TypeNode.withReference(
             VaporReference.builder()
-                .setName("WaitResponse")
+                .setName("EchoResponse")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
-    TypeNode metadataType =
+    TypeNode methodArgType =
         TypeNode.withReference(
             VaporReference.builder()
-                .setName("WaitMetadata")
+                .setName("FoobarName")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .setSupertypeReference(
+                    ConcreteReference.withClazz(com.google.api.resourcenames.ResourceName.class))
                 .build());
-    LongrunningOperation lro = LongrunningOperation.withTypes(responseType, metadataType);
-    TypeNode ttlTypeNode =
-        TypeNode.withReference(
-            VaporReference.builder().setName("Duration").setPakkage(PROTO_PACKAGE_NAME).build());
-    MethodArgument ttl =
-        MethodArgument.builder()
-            .setName("ttl")
-            .setType(ttlTypeNode)
-            .setField(
-                Field.builder()
-                    .setName("ttl")
-                    .setType(ttlTypeNode)
-                    .setIsMessage(true)
-                    .setIsContainedInOneof(true)
-                    .build())
+    Field methodArgField =
+        Field.builder()
+            .setName("name")
+            .setType(TypeNode.STRING)
+            .setResourceReference(ResourceReference.withType("showcase.googleapis.com/Foobar"))
             .build();
-    List<MethodArgument> arguments = Arrays.asList(ttl);
-    Method method =
+    MethodArgument arg =
+        MethodArgument.builder()
+            .setName("name")
+            .setType(methodArgType)
+            .setField(methodArgField)
+            .setIsResourceNameHelper(true)
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
+    Method unaryMethod =
         Method.builder()
-            .setName("Wait")
+            .setName("echo")
+            .setMethodSignatures(signatures)
             .setInputType(inputType)
             .setOutputType(outputType)
-            .setLro(lro)
-            .setMethodSignatures(Arrays.asList(arguments))
             .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  FoobarName name = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\");\n",
+            "  EchoResponse response = echoClient.echo(name);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void
+      validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithStringWithResourceReferenceMethodArgument() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Field methodArgField =
+        Field.builder()
+            .setName("name")
+            .setType(TypeNode.STRING)
+            .setResourceReference(ResourceReference.withType("showcase.googleapis.com/Foobar"))
+            .build();
+    MethodArgument arg =
+        MethodArgument.builder()
+            .setName("name")
+            .setType(TypeNode.STRING)
+            .setField(methodArgField)
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  String name = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
+            "  EchoResponse response = echoClient.echo(name);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void
+      validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithStringWithParentResourceReferenceMethodArgument() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Field methodArgField =
+        Field.builder()
+            .setName("parent")
+            .setType(TypeNode.STRING)
+            .setResourceReference(
+                ResourceReference.withChildType("showcase.googleapis.com/AnythingGoes"))
+            .build();
+    MethodArgument arg =
+        MethodArgument.builder()
+            .setName("parent")
+            .setType(TypeNode.STRING)
+            .setField(methodArgField)
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  String parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
+            "  EchoResponse response = echoClient.echo(parent);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithIsMessageMethodArgument() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode methodArgType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Status").setPakkage("com.google.rpc").build());
+    Field methodArgField =
+        Field.builder()
+            .setName("error")
+            .setType(methodArgType)
+            .setIsMessage(true)
+            .setIsContainedInOneof(true)
+            .build();
+    MethodArgument arg =
+        MethodArgument.builder()
+            .setName("error")
+            .setType(methodArgType)
+            .setField(methodArgField)
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  Status error = Status.newBuilder().build();\n",
+            "  EchoResponse response = echoClient.echo(error);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void
+      validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithMultipleWordNameMethodArgument() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Field methodArgField =
+        Field.builder()
+            .setName("display_name")
+            .setType(TypeNode.STRING)
+            .setResourceReference(
+                ResourceReference.withChildType("showcase.googleapis.com/AnythingGoes"))
+            .build();
+    Reference userRef =
+        VaporReference.builder().setName("User").setPakkage(SHOWCASE_PACKAGE_NAME).build();
+    Field nestFiled =
+        Field.builder()
+            .setName("user")
+            .setType(TypeNode.withReference(userRef))
+            .setIsMessage(true)
+            .build();
+    MethodArgument argDisplayName =
+        MethodArgument.builder()
+            .setName("display_name")
+            .setType(TypeNode.STRING)
+            .setField(methodArgField)
+            .setNestedFields(Arrays.asList(nestFiled))
+            .build();
+    MethodArgument argOtherName =
+        MethodArgument.builder()
+            .setName("other_name")
+            .setType(TypeNode.STRING)
+            .setField(Field.builder().setName("other_name").setType(TypeNode.STRING).build())
+            .setNestedFields(Arrays.asList(nestFiled))
+            .build();
+    List<List<MethodArgument>> signatures =
+        Arrays.asList(Arrays.asList(argDisplayName, argOtherName));
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  String displayName = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
+            "  String otherName = \"otherName-1946065477\";\n",
+            "  EchoResponse response = echoClient.echo(displayName, otherName);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void
+      validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithStringIsContainedInOneOfMethodArgument() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Field methodArgField =
+        Field.builder()
+            .setName("content")
+            .setType(TypeNode.STRING)
+            .setIsContainedInOneof(true)
+            .build();
+    MethodArgument arg =
+        MethodArgument.builder()
+            .setName("content")
+            .setType(TypeNode.STRING)
+            .setField(methodArgField)
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  String content = \"content951530617\";\n",
+            "  EchoResponse response = echoClient.echo(content);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithMultipleMethodArguments() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    MethodArgument arg1 =
+        MethodArgument.builder()
+            .setName("content")
+            .setType(TypeNode.STRING)
+            .setField(Field.builder().setName("content").setType(TypeNode.STRING).build())
+            .build();
+    TypeNode severityType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Severity").setPakkage(SHOWCASE_PACKAGE_NAME).build());
+    MethodArgument arg2 =
+        MethodArgument.builder()
+            .setName("severity")
+            .setType(severityType)
+            .setField(
+                Field.builder().setName("severity").setType(severityType).setIsEnum(true).build())
+            .build();
+    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg1, arg2));
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  String content = \"content951530617\";\n",
+            "  Severity severity = Severity.forNumber(0);\n",
+            "  EchoResponse response = echoClient.echo(content, severity);\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithNoMethodArguments() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    List<List<MethodArgument>> signatures = Arrays.asList(Collections.emptyList());
+    Method unaryMethod =
+        Method.builder()
+            .setName("echo")
+            .setMethodSignatures(signatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, signatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  EchoResponse response = echoClient.echo();\n",
+            "}");
+    assertEquals(expected, results);
+  }
+
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_pureUnaryRpcWithMethodReturnVoid() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("DeleteUserRequest")
+                .setPakkage("com.google.showcase.v1beta1")
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Empty").setPakkage(PROTO_PACKAGE_NAME).build());
+    List<List<MethodArgument>> methodSignatures =
+        Arrays.asList(
+            Arrays.asList(
+                MethodArgument.builder()
+                    .setName("name")
+                    .setType(TypeNode.STRING)
+                    .setField(Field.builder().setName("name").setType(TypeNode.STRING).build())
+                    .build()));
+    Method unaryMethod =
+        Method.builder()
+            .setName("delete")
+            .setMethodSignatures(methodSignatures)
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            unaryMethod, clientType, methodSignatures.get(0), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  String name = \"name3373707\";\n",
+            "  echoClient.delete(name);\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  // ===================================Unary Paged RPC Method Sample Code ======================//
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_pagedRpcWithMultipleMethodArguments() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("ListContentRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("ListContentResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode resourceNameType =
+        TypeNode.withReference(
+            ConcreteReference.builder()
+                .setClazz(List.class)
+                .setGenerics(ConcreteReference.withClazz(String.class))
+                .build());
+    List<MethodArgument> arguments =
+        Arrays.asList(
+            MethodArgument.builder()
+                .setName("resourceName")
+                .setType(resourceNameType)
+                .setField(
+                    Field.builder()
+                        .setName("resourceName")
+                        .setType(resourceNameType)
+                        .setIsRepeated(true)
+                        .build())
+                .build(),
+            MethodArgument.builder()
+                .setName("filter")
+                .setType(TypeNode.STRING)
+                .setField(Field.builder().setName("filter").setType(TypeNode.STRING).build())
+                .build());
+    Method method =
+        Method.builder()
+            .setName("ListContent")
+            .setMethodSignatures(Arrays.asList(arguments))
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setIsPaged(true)
+            .build();
+    Reference repeatedResponseReference =
+        VaporReference.builder().setName("Content").setPakkage(SHOWCASE_PACKAGE_NAME).build();
+    Field repeatedField =
+        Field.builder()
+            .setName("responses")
+            .setType(
+                TypeNode.withReference(
+                    ConcreteReference.builder()
+                        .setClazz(List.class)
+                        .setGenerics(repeatedResponseReference)
+                        .build()))
+            .setIsMessage(true)
+            .setIsRepeated(true)
+            .build();
+    Field nextPagedTokenField =
+        Field.builder().setName("next_page_token").setType(TypeNode.STRING).build();
+    Message listContentResponseMessage =
+        Message.builder()
+            .setName("ListContentResponse")
+            .setType(outputType)
+            .setFields(Arrays.asList(repeatedField, nextPagedTokenField))
+            .build();
+    messageTypes.put("ListContentResponse", listContentResponseMessage);
 
     String results =
         ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
@@ -195,8 +747,80 @@ public class ServiceClientSampleCodeComposerTest {
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  Duration ttl = Duration.newBuilder().build();\n",
-            "  WaitResponse response = echoClient.waitAsync(ttl).get();\n",
+            "  List<String> resourceName = new ArrayList<>();\n",
+            "  String filter = \"filter-1274492040\";\n",
+            "  for (Content element : echoClient.listContent(resourceName, filter).iterateAll()) {\n",
+            "    // doThingsWith(element);\n",
+            "  }\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_pagedRpcWithNoMethodArguments() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("ListContentRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("ListContentResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    List<MethodArgument> arguments = Collections.emptyList();
+    Method method =
+        Method.builder()
+            .setName("ListContent")
+            .setMethodSignatures(Arrays.asList(arguments))
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setIsPaged(true)
+            .build();
+    Reference repeatedResponseReference =
+        VaporReference.builder().setName("Content").setPakkage(SHOWCASE_PACKAGE_NAME).build();
+    Field repeatedField =
+        Field.builder()
+            .setName("responses")
+            .setType(
+                TypeNode.withReference(
+                    ConcreteReference.builder()
+                        .setClazz(List.class)
+                        .setGenerics(repeatedResponseReference)
+                        .build()))
+            .setIsMessage(true)
+            .setIsRepeated(true)
+            .build();
+    Field nextPagedTokenField =
+        Field.builder().setName("next_page_token").setType(TypeNode.STRING).build();
+    Message listContentResponseMessage =
+        Message.builder()
+            .setName("ListContentResponse")
+            .setType(outputType)
+            .setFields(Arrays.asList(repeatedField, nextPagedTokenField))
+            .build();
+    messageTypes.put("ListContentResponse", listContentResponseMessage);
+
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            method, clientType, arguments, resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  for (Content element : echoClient.listContent().iterateAll()) {\n",
+            "    // doThingsWith(element);\n",
+            "  }\n",
             "}");
     assertEquals(results, expected);
   }
@@ -300,706 +924,65 @@ public class ServiceClientSampleCodeComposerTest {
                 method, clientType, methodArguments, resourceNames, messageTypes));
   }
 
-  // =======================================Unary RPC Method Sample Code=======================//
-  @Test
-  public void composeUnaryRpcMethodSampleCode_resourceNameMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode resourceNameType =
-        TypeNode.withReference(
-            ConcreteReference.withClazz(com.google.api.resourcenames.ResourceName.class));
-    MethodArgument arg =
-        MethodArgument.builder()
-            .setName("parent")
-            .setType(resourceNameType)
-            .setField(
-                Field.builder()
-                    .setName("parent")
-                    .setType(TypeNode.STRING)
-                    .setResourceReference(
-                        ResourceReference.withType("showcase.googleapis.com/AnythingGoes"))
-                    .build())
-            .setIsResourceNameHelper(true)
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  ResourceName parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\");\n",
-            "  EchoResponse response = echoClient.echo(parent);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_superReferenceIsResourceNameMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode methodArgType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("FoobarName")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .setSupertypeReference(
-                    ConcreteReference.withClazz(com.google.api.resourcenames.ResourceName.class))
-                .build());
-    Field methodArgField =
-        Field.builder()
-            .setName("name")
-            .setType(TypeNode.STRING)
-            .setResourceReference(ResourceReference.withType("showcase.googleapis.com/Foobar"))
-            .build();
-    MethodArgument arg =
-        MethodArgument.builder()
-            .setName("name")
-            .setType(methodArgType)
-            .setField(methodArgField)
-            .setIsResourceNameHelper(true)
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  FoobarName name = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\");\n",
-            "  EchoResponse response = echoClient.echo(name);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_stringWithResourceReferenceMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    Field methodArgField =
-        Field.builder()
-            .setName("name")
-            .setType(TypeNode.STRING)
-            .setResourceReference(ResourceReference.withType("showcase.googleapis.com/Foobar"))
-            .build();
-    MethodArgument arg =
-        MethodArgument.builder()
-            .setName("name")
-            .setType(TypeNode.STRING)
-            .setField(methodArgField)
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String name = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
-            "  EchoResponse response = echoClient.echo(name);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_stringWithParentResourceReferenceMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    Field methodArgField =
-        Field.builder()
-            .setName("parent")
-            .setType(TypeNode.STRING)
-            .setResourceReference(
-                ResourceReference.withChildType("showcase.googleapis.com/AnythingGoes"))
-            .build();
-    MethodArgument arg =
-        MethodArgument.builder()
-            .setName("parent")
-            .setType(TypeNode.STRING)
-            .setField(methodArgField)
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
-            "  EchoResponse response = echoClient.echo(parent);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_isMessageMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode methodArgType =
-        TypeNode.withReference(
-            VaporReference.builder().setName("Status").setPakkage("com.google.rpc").build());
-    Field methodArgField =
-        Field.builder()
-            .setName("error")
-            .setType(methodArgType)
-            .setIsMessage(true)
-            .setIsContainedInOneof(true)
-            .build();
-    MethodArgument arg =
-        MethodArgument.builder()
-            .setName("error")
-            .setType(methodArgType)
-            .setField(methodArgField)
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  Status error = Status.newBuilder().build();\n",
-            "  EchoResponse response = echoClient.echo(error);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_multipleWordNameMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    Field methodArgField =
-        Field.builder()
-            .setName("display_name")
-            .setType(TypeNode.STRING)
-            .setResourceReference(
-                ResourceReference.withChildType("showcase.googleapis.com/AnythingGoes"))
-            .build();
-    Reference userRef =
-        VaporReference.builder().setName("User").setPakkage(SHOWCASE_PACKAGE_NAME).build();
-    Field nestFiled =
-        Field.builder()
-            .setName("user")
-            .setType(TypeNode.withReference(userRef))
-            .setIsMessage(true)
-            .build();
-    MethodArgument argDisplayName =
-        MethodArgument.builder()
-            .setName("display_name")
-            .setType(TypeNode.STRING)
-            .setField(methodArgField)
-            .setNestedFields(Arrays.asList(nestFiled))
-            .build();
-    MethodArgument argOtherName =
-        MethodArgument.builder()
-            .setName("other_name")
-            .setType(TypeNode.STRING)
-            .setField(Field.builder().setName("other_name").setType(TypeNode.STRING).build())
-            .setNestedFields(Arrays.asList(nestFiled))
-            .build();
-    List<List<MethodArgument>> signatures =
-        Arrays.asList(Arrays.asList(argDisplayName, argOtherName));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String displayName = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
-            "  String otherName = \"otherName-1946065477\";\n",
-            "  EchoResponse response = echoClient.echo(displayName, otherName);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_stringIsContainedInOneOfMethodArgument() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    Field methodArgField =
-        Field.builder()
-            .setName("content")
-            .setType(TypeNode.STRING)
-            .setIsContainedInOneof(true)
-            .build();
-    MethodArgument arg =
-        MethodArgument.builder()
-            .setName("content")
-            .setType(TypeNode.STRING)
-            .setField(methodArgField)
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String content = \"content951530617\";\n",
-            "  EchoResponse response = echoClient.echo(content);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_multipleMethodArguments() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    MethodArgument arg1 =
-        MethodArgument.builder()
-            .setName("content")
-            .setType(TypeNode.STRING)
-            .setField(Field.builder().setName("content").setType(TypeNode.STRING).build())
-            .build();
-    TypeNode severityType =
-        TypeNode.withReference(
-            VaporReference.builder().setName("Severity").setPakkage(SHOWCASE_PACKAGE_NAME).build());
-    MethodArgument arg2 =
-        MethodArgument.builder()
-            .setName("severity")
-            .setType(severityType)
-            .setField(
-                Field.builder().setName("severity").setType(severityType).setIsEnum(true).build())
-            .build();
-    List<List<MethodArgument>> signatures = Arrays.asList(Arrays.asList(arg1, arg2));
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String content = \"content951530617\";\n",
-            "  Severity severity = Severity.forNumber(0);\n",
-            "  EchoResponse response = echoClient.echo(content, severity);\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_noMethodArguments() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    List<List<MethodArgument>> signatures = Arrays.asList(Collections.emptyList());
-    Method unaryMethod =
-        Method.builder()
-            .setName("echo")
-            .setMethodSignatures(signatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, signatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  EchoResponse response = echoClient.echo();\n",
-            "}");
-    assertEquals(expected, results);
-  }
-
-  @Test
-  public void composeUnaryRpcMethodSampleCode_methodReturnVoid() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("DeleteUserRequest")
-                .setPakkage("com.google.showcase.v1beta1")
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder().setName("Empty").setPakkage(PROTO_PACKAGE_NAME).build());
-    List<List<MethodArgument>> methodSignatures =
-        Arrays.asList(
-            Arrays.asList(
-                MethodArgument.builder()
-                    .setName("name")
-                    .setType(TypeNode.STRING)
-                    .setField(Field.builder().setName("name").setType(TypeNode.STRING).build())
-                    .build()));
-    Method unaryMethod =
-        Method.builder()
-            .setName("delete")
-            .setMethodSignatures(methodSignatures)
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryRpcMethodSampleCode(
-                unaryMethod, clientType, methodSignatures.get(0), resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String name = \"name3373707\";\n",
-            "  echoClient.delete(name);\n",
-            "}");
-    assertEquals(results, expected);
-  }
-
-  // ===================================Unary Paged RPC Method Sample Code ======================//
-  @Test
-  public void composeUnaryPagedRpcMethodSampleCode_multipleMethodArguments() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("ListContentRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("ListContentResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode resourceNameType =
-        TypeNode.withReference(
-            ConcreteReference.builder()
-                .setClazz(List.class)
-                .setGenerics(ConcreteReference.withClazz(String.class))
-                .build());
-    List<MethodArgument> arguments =
-        Arrays.asList(
-            MethodArgument.builder()
-                .setName("resourceName")
-                .setType(resourceNameType)
-                .setField(
-                    Field.builder()
-                        .setName("resourceName")
-                        .setType(resourceNameType)
-                        .setIsRepeated(true)
-                        .build())
-                .build(),
-            MethodArgument.builder()
-                .setName("filter")
-                .setType(TypeNode.STRING)
-                .setField(Field.builder().setName("filter").setType(TypeNode.STRING).build())
-                .build());
-    Method method =
-        Method.builder()
-            .setName("ListContent")
-            .setMethodSignatures(Arrays.asList(arguments))
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .setIsPaged(true)
-            .build();
-    TypeNode repeatedResponseType =
-        TypeNode.withReference(
-            VaporReference.builder().setName("Content").setPakkage(SHOWCASE_PACKAGE_NAME).build());
-
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryPagedRpcMethodSampleCode(
-                method, clientType, repeatedResponseType, arguments, resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  List<String> resourceName = new ArrayList<>();\n",
-            "  String filter = \"filter-1274492040\";\n",
-            "  for (Content element : echoClient.listContent(resourceName, filter).iterateAll()) {\n",
-            "    // doThingsWith(element);\n",
-            "  }\n",
-            "}");
-    assertEquals(results, expected);
-  }
-
-  @Test
-  public void composeUnaryPagedRpcMethodSampleCode_noMethodArguments() {
-    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
-    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
-    TypeNode clientType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("EchoClient")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode inputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("ListContentRequest")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    TypeNode outputType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName("ListContentResponse")
-                .setPakkage(SHOWCASE_PACKAGE_NAME)
-                .build());
-    List<MethodArgument> arguments = Collections.emptyList();
-    Method method =
-        Method.builder()
-            .setName("ListContent")
-            .setMethodSignatures(Arrays.asList(arguments))
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .setIsPaged(true)
-            .build();
-    TypeNode repeatedResponseType =
-        TypeNode.withReference(
-            VaporReference.builder().setName("Content").setPakkage(SHOWCASE_PACKAGE_NAME).build());
-
-    String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryPagedRpcMethodSampleCode(
-                method, clientType, repeatedResponseType, arguments, resourceNames));
-    String expected =
-        LineFormatter.lines(
-            "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  for (Content element : echoClient.listContent().iterateAll()) {\n",
-            "    // doThingsWith(element);\n",
-            "  }\n",
-            "}");
-    assertEquals(results, expected);
-  }
-
   // ===================================Unary LRO RPC Method Sample Code ======================//
   @Test
-  public void composeUnaryLroRpcMethodSampleCode_lroReturnResponseType() {
+  public void validComposeRpcMethodHeaderSampleCode_lroUnaryRpcWithNoMethodArgument() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Operation").setPakkage(LRO_PACKAGE_NAME).build());
+    TypeNode responseType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode metadataType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitMetadata")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    LongrunningOperation lro = LongrunningOperation.withTypes(responseType, metadataType);
+    Method method =
+        Method.builder()
+            .setName("Wait")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setLro(lro)
+            .setMethodSignatures(Collections.emptyList())
+            .build();
+
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            method, clientType, Collections.emptyList(), resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  WaitResponse response = echoClient.waitAsync().get();\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  @Test
+  public void validComposeRpcMethodHeaderSampleCode_lroRpcWithReturnResponseType() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1054,9 +1037,8 @@ public class ServiceClientSampleCodeComposerTest {
             .build();
 
     String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryLroRpcMethodSampleCode(
-                method, clientType, arguments, resourceNames));
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            method, clientType, arguments, resourceNames, messageTypes);
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
@@ -1067,9 +1049,10 @@ public class ServiceClientSampleCodeComposerTest {
   }
 
   @Test
-  public void composeUnaryLroRpcMethodSampleCode_lroReturnVoid() {
+  public void validComposeRpcMethodHeaderSampleCode_lroRpcWithReturnVoid() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -1121,9 +1104,8 @@ public class ServiceClientSampleCodeComposerTest {
             .build();
 
     String results =
-        SampleCodeWriter.write(
-            ServiceClientSampleCodeComposer.composeUnaryLroRpcMethodSampleCode(
-                method, clientType, arguments, resourceNames));
+        ServiceClientSampleCodeComposer.composeRpcMethodHeaderSampleCode(
+            method, clientType, arguments, resourceNames, messageTypes);
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
@@ -1135,7 +1117,7 @@ public class ServiceClientSampleCodeComposerTest {
 
   // ================================Unary RPC Default Method Sample Code ====================//
   @Test
-  public void composeRpcDefaultMethodHeaderSampleCode_isPagedMethod() {
+  public void validComposeRpcDefaultMethodHeaderSampleCode_isPagedMethod() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1185,7 +1167,45 @@ public class ServiceClientSampleCodeComposerTest {
   }
 
   @Test
-  public void composeRpcDefaultMethodHeaderSampleCode_hasLroMethodWithReturnResponse() {
+  public void invalidComposeRpcDefaultMethodHeaderSampleCode_isPagedMethod() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("NotExistRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("PagedExpandResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Method method =
+        Method.builder()
+            .setName("PagedExpand")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setMethodSignatures(Collections.emptyList())
+            .setIsPaged(true)
+            .build();
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            ServiceClientSampleCodeComposer.composeRpcDefaultMethodHeaderSampleCode(
+                method, clientType, resourceNames, messageTypes));
+  }
+
+  @Test
+  public void validComposeRpcDefaultMethodHeaderSampleCode_hasLroMethodWithReturnResponse() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1235,7 +1255,7 @@ public class ServiceClientSampleCodeComposerTest {
   }
 
   @Test
-  public void composeRpcDefaultMethodHeaderSampleCode_hasLroMethodWithReturnVoid() {
+  public void validComposeRpcDefaultMethodHeaderSampleCode_hasLroMethodWithReturnVoid() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1288,7 +1308,7 @@ public class ServiceClientSampleCodeComposerTest {
   }
 
   @Test
-  public void composeRpcDefaultMethodHeaderSampleCode_pureUnaryReturnVoid() {
+  public void validComposeRpcDefaultMethodHeaderSampleCode_pureUnaryReturnVoid() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
@@ -1332,7 +1352,7 @@ public class ServiceClientSampleCodeComposerTest {
   }
 
   @Test
-  public void composeRpcDefaultMethodHeaderSampleCode_pureUnaryReturnResponse() {
+  public void validComposeRpcDefaultMethodHeaderSampleCode_pureUnaryReturnResponse() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceClientSampleCodeComposerTest.java
@@ -1132,4 +1132,249 @@ public class ServiceClientSampleCodeComposerTest {
             "}");
     assertEquals(results, expected);
   }
+
+  // ================================Unary RPC Default Method Sample Code ====================//
+  @Test
+  public void composeRpcDefaultMethodHeaderSampleCode_isPagedMethod() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("PagedExpandRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("PagedExpandResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Method method =
+        Method.builder()
+            .setName("PagedExpand")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setMethodSignatures(Collections.emptyList())
+            .setIsPaged(true)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcDefaultMethodHeaderSampleCode(
+            method, clientType, resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  PagedExpandRequest request =\n",
+            "      PagedExpandRequest.newBuilder()\n",
+            "          .setContent(\"content951530617\")\n",
+            "          .setPageSize(883849137)\n",
+            "          .setPageToken(\"pageToken873572522\")\n",
+            "          .build();\n",
+            "  for (EchoResponse element : echoClient.pagedExpand(request).iterateAll()) {\n",
+            "    // doThingsWith(element);\n",
+            "  }\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  @Test
+  public void composeRpcDefaultMethodHeaderSampleCode_hasLroMethodWithReturnResponse() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Operation").setPakkage(LRO_PACKAGE_NAME).build());
+    TypeNode responseType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Empty").setPakkage(PROTO_PACKAGE_NAME).build());
+    TypeNode metadataType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitMetadata")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    LongrunningOperation lro = LongrunningOperation.withTypes(responseType, metadataType);
+    Method method =
+        Method.builder()
+            .setName("Wait")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setMethodSignatures(Collections.emptyList())
+            .setLro(lro)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcDefaultMethodHeaderSampleCode(
+            method, clientType, resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  WaitRequest request = WaitRequest.newBuilder().build();\n",
+            "  echoClient.waitAsync(request).get();\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  @Test
+  public void composeRpcDefaultMethodHeaderSampleCode_hasLroMethodWithReturnVoid() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Operation").setPakkage(LRO_PACKAGE_NAME).build());
+    TypeNode responseType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode metadataType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("WaitMetadata")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    LongrunningOperation lro = LongrunningOperation.withTypes(responseType, metadataType);
+    Method method =
+        Method.builder()
+            .setName("Wait")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setMethodSignatures(Collections.emptyList())
+            .setLro(lro)
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcDefaultMethodHeaderSampleCode(
+            method, clientType, resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  WaitRequest request = WaitRequest.newBuilder().build();\n",
+            "  WaitResponse response = echoClient.waitAsync(request).get();\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  @Test
+  public void composeRpcDefaultMethodHeaderSampleCode_pureUnaryReturnVoid() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("Empty").setPakkage(PROTO_PACKAGE_NAME).build());
+    Method method =
+        Method.builder()
+            .setName("Echo")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setMethodSignatures(Collections.emptyList())
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcDefaultMethodHeaderSampleCode(
+            method, clientType, resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  EchoRequest request =\n",
+            "      EchoRequest.newBuilder()\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setFoobar(Foobar.newBuilder().build())\n",
+            "          .build();\n",
+            "  echoClient.echo(request);\n",
+            "}");
+    assertEquals(results, expected);
+  }
+
+  @Test
+  public void composeRpcDefaultMethodHeaderSampleCode_pureUnaryReturnResponse() {
+    FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    TypeNode clientType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoClient")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode inputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoRequest")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    TypeNode outputType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
+    Method method =
+        Method.builder()
+            .setName("Echo")
+            .setInputType(inputType)
+            .setOutputType(outputType)
+            .setMethodSignatures(Collections.emptyList())
+            .build();
+    String results =
+        ServiceClientSampleCodeComposer.composeRpcDefaultMethodHeaderSampleCode(
+            method, clientType, resourceNames, messageTypes);
+    String expected =
+        LineFormatter.lines(
+            "try (EchoClient echoClient = EchoClient.create()) {\n",
+            "  EchoRequest request =\n",
+            "      EchoRequest.newBuilder()\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setFoobar(Foobar.newBuilder().build())\n",
+            "          .build();\n",
+            "  EchoResponse response = echoClient.echo(request);\n",
+            "}");
+    assertEquals(results, expected);
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -300,6 +300,20 @@ public class EchoClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setFoobar(Foobar.newBuilder().build())
+   *           .build();
+   *   EchoResponse response = echoClient.echo(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -339,6 +353,22 @@ public class EchoClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (EchoResponse element : echoClient.pagedExpand(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -381,6 +411,22 @@ public class EchoClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (EchoResponse element : echoClient.simplePagedExpand(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -441,6 +487,15 @@ public class EchoClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   WaitRequest request = WaitRequest.newBuilder().build();
+   *   WaitResponse response = echoClient.waitAsync(request).get();
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -462,6 +517,15 @@ public class EchoClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   BlockRequest request = BlockRequest.newBuilder().build();
+   *   BlockResponse response = echoClient.block(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/IdentityClient.golden
@@ -201,6 +201,19 @@ public class IdentityClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (IdentityClient identityClient = IdentityClient.create()) {
+   *   CreateUserRequest request =
+   *       CreateUserRequest.newBuilder()
+   *           .setParent(UserName.of("[USER]").toString())
+   *           .setUser(User.newBuilder().build())
+   *           .build();
+   *   User response = identityClient.createUser(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -255,6 +268,16 @@ public class IdentityClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (IdentityClient identityClient = IdentityClient.create()) {
+   *   GetUserRequest request =
+   *       GetUserRequest.newBuilder().setName(UserName.of("[USER]").toString()).build();
+   *   User response = identityClient.getUser(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -270,6 +293,16 @@ public class IdentityClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (IdentityClient identityClient = IdentityClient.create()) {
+   *   UpdateUserRequest request =
+   *       UpdateUserRequest.newBuilder().setUser(User.newBuilder().build()).build();
+   *   User response = identityClient.updateUser(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -324,6 +357,16 @@ public class IdentityClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (IdentityClient identityClient = IdentityClient.create()) {
+   *   DeleteUserRequest request =
+   *       DeleteUserRequest.newBuilder().setName(UserName.of("[USER]").toString()).build();
+   *   identityClient.deleteUser(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -339,6 +382,21 @@ public class IdentityClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (IdentityClient identityClient = IdentityClient.create()) {
+   *   ListUsersRequest request =
+   *       ListUsersRequest.newBuilder()
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (User element : identityClient.listUsers(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -167,6 +167,21 @@ public class AssetServiceClient implements BackgroundResource {
    * exponential retry to poll the export operation result. For regular-size resource parent, the
    * export operation usually finishes within 5 minutes.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   ExportAssetsRequest request =
+   *       ExportAssetsRequest.newBuilder()
+   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setReadTime(Timestamp.newBuilder().build())
+   *           .addAllAssetTypes(new ArrayList<String>())
+   *           .setOutputConfig(OutputConfig.newBuilder().build())
+   *           .build();
+   *   ExportAssetsResponse response = assetServiceClient.exportAssetsAsync(request).get();
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -218,6 +233,20 @@ public class AssetServiceClient implements BackgroundResource {
    * or deleted status. If a specified asset does not exist, this API returns an INVALID_ARGUMENT
    * error.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   BatchGetAssetsHistoryRequest request =
+   *       BatchGetAssetsHistoryRequest.newBuilder()
+   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .addAllAssetNames(new ArrayList<String>())
+   *           .setReadTimeWindow(TimeWindow.newBuilder().build())
+   *           .build();
+   *   BatchGetAssetsHistoryResponse response = assetServiceClient.batchGetAssetsHistory(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -268,6 +297,20 @@ public class AssetServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Creates a feed in a parent project/folder/organization to listen to its asset updates.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   CreateFeedRequest request =
+   *       CreateFeedRequest.newBuilder()
+   *           .setParent("parent-995424086")
+   *           .setFeedId("feedId-1278410919")
+   *           .setFeed(Feed.newBuilder().build())
+   *           .build();
+   *   Feed response = assetServiceClient.createFeed(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -337,6 +380,18 @@ public class AssetServiceClient implements BackgroundResource {
   /**
    * Gets details about an asset feed.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   GetFeedRequest request =
+   *       GetFeedRequest.newBuilder()
+   *           .setName(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .build();
+   *   Feed response = assetServiceClient.getFeed(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -381,6 +436,16 @@ public class AssetServiceClient implements BackgroundResource {
   /**
    * Lists all asset feeds in a parent project/folder/organization.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   ListFeedsRequest request =
+   *       ListFeedsRequest.newBuilder().setParent("parent-995424086").build();
+   *   ListFeedsResponse response = assetServiceClient.listFeeds(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -424,6 +489,19 @@ public class AssetServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Updates an asset feed configuration.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   UpdateFeedRequest request =
+   *       UpdateFeedRequest.newBuilder()
+   *           .setFeed(Feed.newBuilder().build())
+   *           .setUpdateMask(FieldMask.newBuilder().build())
+   *           .build();
+   *   Feed response = assetServiceClient.updateFeed(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -492,6 +570,18 @@ public class AssetServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Deletes an asset feed.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   DeleteFeedRequest request =
+   *       DeleteFeedRequest.newBuilder()
+   *           .setName(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .build();
+   *   assetServiceClient.deleteFeed(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -596,6 +686,26 @@ public class AssetServiceClient implements BackgroundResource {
    * organization. The caller must be granted the `cloudasset.assets.searchAllResources` permission
    * on the desired scope, otherwise the request will be rejected.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   SearchAllResourcesRequest request =
+   *       SearchAllResourcesRequest.newBuilder()
+   *           .setScope("scope109264468")
+   *           .setQuery("query107944136")
+   *           .addAllAssetTypes(new ArrayList<String>())
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .setOrderBy("orderBy-1207110587")
+   *           .build();
+   *   for (ResourceSearchResult element :
+   *       assetServiceClient.searchAllResources(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -698,6 +808,24 @@ public class AssetServiceClient implements BackgroundResource {
    * Searches all IAM policies within the specified scope, such as a project, folder, or
    * organization. The caller must be granted the `cloudasset.assets.searchAllIamPolicies`
    * permission on the desired scope, otherwise the request will be rejected.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
+   *   SearchAllIamPoliciesRequest request =
+   *       SearchAllIamPoliciesRequest.newBuilder()
+   *           .setScope("scope109264468")
+   *           .setQuery("query107944136")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (IamPolicySearchResult element :
+   *       assetServiceClient.searchAllIamPolicies(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails

--- a/test/integration/goldens/library/LibraryServiceClient.java
+++ b/test/integration/goldens/library/LibraryServiceClient.java
@@ -191,6 +191,16 @@ public class LibraryServiceClient implements BackgroundResource {
   /**
    * Creates a shelf, and returns the new Shelf.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   CreateShelfRequest request =
+   *       CreateShelfRequest.newBuilder().setShelf(Shelf.newBuilder().build()).build();
+   *   Shelf response = libraryServiceClient.createShelf(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -255,6 +265,15 @@ public class LibraryServiceClient implements BackgroundResource {
   /**
    * Gets a shelf. Returns NOT_FOUND if the shelf does not exist.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   GetShelfRequest request = GetShelfRequest.newBuilder().setName("name3373707").build();
+   *   Shelf response = libraryServiceClient.getShelf(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -276,6 +295,21 @@ public class LibraryServiceClient implements BackgroundResource {
   /**
    * Lists shelves. The order is unspecified but deterministic. Newly created shelves will not
    * necessarily be added to the end of this list.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ListShelvesRequest request =
+   *       ListShelvesRequest.newBuilder()
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (Shelf element : libraryServiceClient.listShelves(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -353,6 +387,15 @@ public class LibraryServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Deletes a shelf. Returns NOT_FOUND if the shelf does not exist.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   DeleteShelfRequest request = DeleteShelfRequest.newBuilder().setName("name3373707").build();
+   *   libraryServiceClient.deleteShelf(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -505,6 +548,19 @@ public class LibraryServiceClient implements BackgroundResource {
    * <p>Returns NOT_FOUND if either shelf does not exist. This call is a no-op if the specified
    * shelves are the same.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   MergeShelvesRequest request =
+   *       MergeShelvesRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setOtherShelfName("otherShelfName-1942963547")
+   *           .build();
+   *   Shelf response = libraryServiceClient.mergeShelves(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -581,6 +637,19 @@ public class LibraryServiceClient implements BackgroundResource {
   /**
    * Creates a book, and returns the new Book.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   CreateBookRequest request =
+   *       CreateBookRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setBook(Book.newBuilder().build())
+   *           .build();
+   *   Book response = libraryServiceClient.createBook(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -644,6 +713,15 @@ public class LibraryServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Gets a book. Returns NOT_FOUND if the book does not exist.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   GetBookRequest request = GetBookRequest.newBuilder().setName("name3373707").build();
+   *   Book response = libraryServiceClient.getBook(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -719,6 +797,22 @@ public class LibraryServiceClient implements BackgroundResource {
    * not necessarily be added to the end of this list. Returns NOT_FOUND if the shelf does not
    * exist.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   ListBooksRequest request =
+   *       ListBooksRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (Book element : libraryServiceClient.listBooks(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -753,6 +847,15 @@ public class LibraryServiceClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Deletes a book. Returns NOT_FOUND if the book does not exist.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   DeleteBookRequest request = DeleteBookRequest.newBuilder().setName("name3373707").build();
+   *   libraryServiceClient.deleteBook(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -797,6 +900,19 @@ public class LibraryServiceClient implements BackgroundResource {
   /**
    * Updates a book. Returns INVALID_ARGUMENT if the name of the book is non-empty and does not
    * equal the existing name.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   UpdateBookRequest request =
+   *       UpdateBookRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setBook(Book.newBuilder().build())
+   *           .build();
+   *   Book response = libraryServiceClient.updateBook(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -929,6 +1045,19 @@ public class LibraryServiceClient implements BackgroundResource {
   /**
    * Moves a book to another shelf, and returns the new book. The book id of the new book may not be
    * the same as the original book.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   MoveBookRequest request =
+   *       MoveBookRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setOtherShelfName("otherShelfName-1942963547")
+   *           .build();
+   *   Book response = libraryServiceClient.moveBook(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails

--- a/test/integration/goldens/logging/ConfigClient.java
+++ b/test/integration/goldens/logging/ConfigClient.java
@@ -336,6 +336,24 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Lists buckets (Beta).
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   ListBucketsRequest request =
+   *       ListBucketsRequest.newBuilder()
+   *           .setParent(
+   *               LogBucketName.ofProjectLocationBucketName("[PROJECT]", "[LOCATION]", "[BUCKET]")
+   *                   .toString())
+   *           .setPageToken("pageToken873572522")
+   *           .setPageSize(883849137)
+   *           .build();
+   *   for (LogBucket element : configClient.listBuckets(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -368,6 +386,20 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Gets a bucket (Beta).
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   GetBucketRequest request =
+   *       GetBucketRequest.newBuilder()
+   *           .setName(
+   *               LogBucketName.ofProjectLocationBucketName("[PROJECT]", "[LOCATION]", "[BUCKET]")
+   *                   .toString())
+   *           .build();
+   *   LogBucket response = configClient.getBucket(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -397,6 +429,22 @@ public class ConfigClient implements BackgroundResource {
    * returned.
    *
    * <p>A buckets region may not be modified after it is created. This method is in Beta.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   UpdateBucketRequest request =
+   *       UpdateBucketRequest.newBuilder()
+   *           .setName(
+   *               LogBucketName.ofProjectLocationBucketName("[PROJECT]", "[LOCATION]", "[BUCKET]")
+   *                   .toString())
+   *           .setBucket(LogBucket.newBuilder().build())
+   *           .setUpdateMask(FieldMask.newBuilder().build())
+   *           .build();
+   *   LogBucket response = configClient.updateBucket(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -557,6 +605,22 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Lists sinks.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   ListSinksRequest request =
+   *       ListSinksRequest.newBuilder()
+   *           .setParent(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
+   *           .setPageToken("pageToken873572522")
+   *           .setPageSize(883849137)
+   *           .build();
+   *   for (LogSink element : configClient.listSinks(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -642,6 +706,18 @@ public class ConfigClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Gets a sink.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   GetSinkRequest request =
+   *       GetSinkRequest.newBuilder()
+   *           .setSinkName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
+   *           .build();
+   *   LogSink response = configClient.getSink(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -833,6 +909,20 @@ public class ConfigClient implements BackgroundResource {
    * newly-ingested log entries begins immediately, unless the sink's `writer_identity` is not
    * permitted to write to the destination. A sink can export log entries only from the resource
    * owning the sink.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   CreateSinkRequest request =
+   *       CreateSinkRequest.newBuilder()
+   *           .setParent(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
+   *           .setSink(LogSink.newBuilder().build())
+   *           .setUniqueWriterIdentity(true)
+   *           .build();
+   *   LogSink response = configClient.createSink(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -1033,6 +1123,21 @@ public class ConfigClient implements BackgroundResource {
    * <p>The updated sink might also have a new `writer_identity`; see the `unique_writer_identity`
    * field.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   UpdateSinkRequest request =
+   *       UpdateSinkRequest.newBuilder()
+   *           .setSinkName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
+   *           .setSink(LogSink.newBuilder().build())
+   *           .setUniqueWriterIdentity(true)
+   *           .setUpdateMask(FieldMask.newBuilder().build())
+   *           .build();
+   *   LogSink response = configClient.updateSink(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1117,6 +1222,18 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Deletes a sink. If the sink has a unique `writer_identity`, then that service account is also
    * deleted.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   DeleteSinkRequest request =
+   *       DeleteSinkRequest.newBuilder()
+   *           .setSinkName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
+   *           .build();
+   *   configClient.deleteSink(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -1278,6 +1395,23 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Lists all the exclusions in a parent resource.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   ListExclusionsRequest request =
+   *       ListExclusionsRequest.newBuilder()
+   *           .setParent(
+   *               LogExclusionName.ofProjectExclusionName("[PROJECT]", "[EXCLUSION]").toString())
+   *           .setPageToken("pageToken873572522")
+   *           .setPageSize(883849137)
+   *           .build();
+   *   for (LogExclusion element : configClient.listExclusions(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1363,6 +1497,19 @@ public class ConfigClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Gets the description of an exclusion.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   GetExclusionRequest request =
+   *       GetExclusionRequest.newBuilder()
+   *           .setName(
+   *               LogExclusionName.ofProjectExclusionName("[PROJECT]", "[EXCLUSION]").toString())
+   *           .build();
+   *   LogExclusion response = configClient.getExclusion(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -1544,6 +1691,20 @@ public class ConfigClient implements BackgroundResource {
    * Creates a new exclusion in a specified parent resource. Only log entries belonging to that
    * resource can be excluded. You can have up to 10 exclusions in a resource.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   CreateExclusionRequest request =
+   *       CreateExclusionRequest.newBuilder()
+   *           .setParent(
+   *               LogExclusionName.ofProjectExclusionName("[PROJECT]", "[EXCLUSION]").toString())
+   *           .setExclusion(LogExclusion.newBuilder().build())
+   *           .build();
+   *   LogExclusion response = configClient.createExclusion(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1650,6 +1811,21 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Changes one or more properties of an existing exclusion.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   UpdateExclusionRequest request =
+   *       UpdateExclusionRequest.newBuilder()
+   *           .setName(
+   *               LogExclusionName.ofProjectExclusionName("[PROJECT]", "[EXCLUSION]").toString())
+   *           .setExclusion(LogExclusion.newBuilder().build())
+   *           .setUpdateMask(FieldMask.newBuilder().build())
+   *           .build();
+   *   LogExclusion response = configClient.updateExclusion(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1724,6 +1900,19 @@ public class ConfigClient implements BackgroundResource {
   /**
    * Deletes an exclusion.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   DeleteExclusionRequest request =
+   *       DeleteExclusionRequest.newBuilder()
+   *           .setName(
+   *               LogExclusionName.ofProjectExclusionName("[PROJECT]", "[EXCLUSION]").toString())
+   *           .build();
+   *   configClient.deleteExclusion(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1750,6 +1939,18 @@ public class ConfigClient implements BackgroundResource {
    *
    * <p>See [Enabling CMEK for Logs
    * Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   GetCmekSettingsRequest request =
+   *       GetCmekSettingsRequest.newBuilder()
+   *           .setName(CmekSettingsName.ofProjectName("[PROJECT]").toString())
+   *           .build();
+   *   CmekSettings response = configClient.getCmekSettings(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -1788,6 +1989,20 @@ public class ConfigClient implements BackgroundResource {
    *
    * <p>See [Enabling CMEK for Logs
    * Router](https://cloud.google.com/logging/docs/routing/managed-encryption) for more information.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (ConfigClient configClient = ConfigClient.create()) {
+   *   UpdateCmekSettingsRequest request =
+   *       UpdateCmekSettingsRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setCmekSettings(CmekSettings.newBuilder().build())
+   *           .setUpdateMask(FieldMask.newBuilder().build())
+   *           .build();
+   *   CmekSettings response = configClient.updateCmekSettings(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails

--- a/test/integration/goldens/logging/LoggingClient.java
+++ b/test/integration/goldens/logging/LoggingClient.java
@@ -222,6 +222,18 @@ public class LoggingClient implements BackgroundResource {
    * written shortly before the delete operation might not be deleted. Entries received after the
    * delete operation with a timestamp before the operation will be deleted.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LoggingClient loggingClient = LoggingClient.create()) {
+   *   DeleteLogRequest request =
+   *       DeleteLogRequest.newBuilder()
+   *           .setLogName(LogName.ofProjectLogName("[PROJECT]", "[LOG]").toString())
+   *           .build();
+   *   loggingClient.deleteLog(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -398,6 +410,23 @@ public class LoggingClient implements BackgroundResource {
    * libraries configured to use Logging. A single request may contain log entries for a maximum of
    * 1000 different resources (projects, organizations, billing accounts or folders)
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LoggingClient loggingClient = LoggingClient.create()) {
+   *   WriteLogEntriesRequest request =
+   *       WriteLogEntriesRequest.newBuilder()
+   *           .setLogName(LogName.ofProjectLogName("[PROJECT]", "[LOG]").toString())
+   *           .setResource(MonitoredResource.newBuilder().build())
+   *           .putAllLabels(new HashMap<String, String>())
+   *           .addAllEntries(new ArrayList<LogEntry>())
+   *           .setPartialSuccess(true)
+   *           .setDryRun(true)
+   *           .build();
+   *   WriteLogEntriesResponse response = loggingClient.writeLogEntries(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -474,6 +503,24 @@ public class LoggingClient implements BackgroundResource {
    * project/folder/organization/billing account. For ways to export log entries, see [Exporting
    * Logs](https://cloud.google.com/logging/docs/export).
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LoggingClient loggingClient = LoggingClient.create()) {
+   *   ListLogEntriesRequest request =
+   *       ListLogEntriesRequest.newBuilder()
+   *           .addAllResourceNames(new ArrayList<String>())
+   *           .setFilter("filter-1274492040")
+   *           .setOrderBy("orderBy-1207110587")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (LogEntry element : loggingClient.listLogEntries(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -510,6 +557,22 @@ public class LoggingClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Lists the descriptors for monitored resource types used by Logging.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LoggingClient loggingClient = LoggingClient.create()) {
+   *   ListMonitoredResourceDescriptorsRequest request =
+   *       ListMonitoredResourceDescriptorsRequest.newBuilder()
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (MonitoredResourceDescriptor element :
+   *       loggingClient.listMonitoredResourceDescriptors(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -681,6 +744,22 @@ public class LoggingClient implements BackgroundResource {
   /**
    * Lists the logs in projects, organizations, folders, or billing accounts. Only logs that have
    * entries are listed.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (LoggingClient loggingClient = LoggingClient.create()) {
+   *   ListLogsRequest request =
+   *       ListLogsRequest.newBuilder()
+   *           .setParent(LogName.ofProjectLogName("[PROJECT]", "[LOG]").toString())
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (String element : loggingClient.listLogs(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails

--- a/test/integration/goldens/logging/MetricsClient.java
+++ b/test/integration/goldens/logging/MetricsClient.java
@@ -203,6 +203,22 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Lists logs-based metrics.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (MetricsClient metricsClient = MetricsClient.create()) {
+   *   ListLogMetricsRequest request =
+   *       ListLogMetricsRequest.newBuilder()
+   *           .setParent(ProjectName.of("[PROJECT]").toString())
+   *           .setPageToken("pageToken873572522")
+   *           .setPageSize(883849137)
+   *           .build();
+   *   for (LogMetric element : metricsClient.listLogMetrics(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -284,6 +300,18 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Gets a logs-based metric.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (MetricsClient metricsClient = MetricsClient.create()) {
+   *   GetLogMetricRequest request =
+   *       GetLogMetricRequest.newBuilder()
+   *           .setMetricName(LogMetricName.of("[PROJECT]", "[METRIC]").toString())
+   *           .build();
+   *   LogMetric response = metricsClient.getLogMetric(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -361,6 +389,19 @@ public class MetricsClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Creates a logs-based metric.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (MetricsClient metricsClient = MetricsClient.create()) {
+   *   CreateLogMetricRequest request =
+   *       CreateLogMetricRequest.newBuilder()
+   *           .setParent(LogMetricName.of("[PROJECT]", "[METRIC]").toString())
+   *           .setMetric(LogMetric.newBuilder().build())
+   *           .build();
+   *   LogMetric response = metricsClient.createLogMetric(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -442,6 +483,19 @@ public class MetricsClient implements BackgroundResource {
   /**
    * Creates or updates a logs-based metric.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (MetricsClient metricsClient = MetricsClient.create()) {
+   *   UpdateLogMetricRequest request =
+   *       UpdateLogMetricRequest.newBuilder()
+   *           .setMetricName(LogMetricName.of("[PROJECT]", "[METRIC]").toString())
+   *           .setMetric(LogMetric.newBuilder().build())
+   *           .build();
+   *   LogMetric response = metricsClient.updateLogMetric(request);
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -510,6 +564,18 @@ public class MetricsClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Deletes a logs-based metric.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (MetricsClient metricsClient = MetricsClient.create()) {
+   *   DeleteLogMetricRequest request =
+   *       DeleteLogMetricRequest.newBuilder()
+   *           .setMetricName(LogMetricName.of("[PROJECT]", "[METRIC]").toString())
+   *           .build();
+   *   metricsClient.deleteLogMetric(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails

--- a/test/integration/goldens/redis/CloudRedisClient.java
+++ b/test/integration/goldens/redis/CloudRedisClient.java
@@ -260,6 +260,22 @@ public class CloudRedisClient implements BackgroundResource {
    * <p>If `location_id` is specified as `-` (wildcard), then all regions available to the project
    * are queried, and the results are aggregated.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   ListInstancesRequest request =
+   *       ListInstancesRequest.newBuilder()
+   *           .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (Instance element : cloudRedisClient.listInstances(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -358,6 +374,18 @@ public class CloudRedisClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Gets the details of a specific Redis instance.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   GetInstanceRequest request =
+   *       GetInstanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .build();
+   *   Instance response = cloudRedisClient.getInstance(request);
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -495,6 +523,20 @@ public class CloudRedisClient implements BackgroundResource {
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
    * call DeleteOperation.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   CreateInstanceRequest request =
+   *       CreateInstanceRequest.newBuilder()
+   *           .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+   *           .setInstanceId("instanceId902024336")
+   *           .setInstance(Instance.newBuilder().build())
+   *           .build();
+   *   Instance response = cloudRedisClient.createInstanceAsync(request).get();
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -585,6 +627,19 @@ public class CloudRedisClient implements BackgroundResource {
    * <p>Completed longrunning.Operation will contain the new instance object in the response field.
    * The returned operation is automatically deleted after a few hours, so there is no need to call
    * DeleteOperation.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   UpdateInstanceRequest request =
+   *       UpdateInstanceRequest.newBuilder()
+   *           .setUpdateMask(FieldMask.newBuilder().build())
+   *           .setInstance(Instance.newBuilder().build())
+   *           .build();
+   *   Instance response = cloudRedisClient.updateInstanceAsync(request).get();
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -684,6 +739,19 @@ public class CloudRedisClient implements BackgroundResource {
   /**
    * Upgrades Redis instance to the newer Redis version specified in the request.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   UpgradeInstanceRequest request =
+   *       UpgradeInstanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .setRedisVersion("redisVersion-1972584739")
+   *           .build();
+   *   Instance response = cloudRedisClient.upgradeInstanceAsync(request).get();
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -755,6 +823,19 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
    * call DeleteOperation.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   ImportInstanceRequest request =
+   *       ImportInstanceRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setInputConfig(InputConfig.newBuilder().build())
+   *           .build();
+   *   Instance response = cloudRedisClient.importInstanceAsync(request).get();
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -837,6 +918,19 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
    * call DeleteOperation.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   ExportInstanceRequest request =
+   *       ExportInstanceRequest.newBuilder()
+   *           .setName("name3373707")
+   *           .setOutputConfig(OutputConfig.newBuilder().build())
+   *           .build();
+   *   Instance response = cloudRedisClient.exportInstanceAsync(request).get();
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
@@ -948,6 +1042,18 @@ public class CloudRedisClient implements BackgroundResource {
    * Initiates a failover of the master node to current replica node for a specific STANDARD tier
    * Cloud Memorystore for Redis instance.
    *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   FailoverInstanceRequest request =
+   *       FailoverInstanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .build();
+   *   Instance response = cloudRedisClient.failoverInstanceAsync(request).get();
+   * }
+   * }</pre>
+   *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1029,6 +1135,18 @@ public class CloudRedisClient implements BackgroundResource {
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
    * Deletes a specific Redis instance. Instance stops serving and data is deleted.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   DeleteInstanceRequest request =
+   *       DeleteInstanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .build();
+   *   cloudRedisClient.deleteInstanceAsync(request).get();
+   * }
+   * }</pre>
    *
    * @param request The request object containing all of the parameters for the API call.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails


### PR DESCRIPTION
RPC default method has 3 types sample code for:
1. paged (gapic-generator [sample code](https://github.com/googleapis/java-redis/blob/master/google-cloud-redis/src/main/java/com/google/cloud/redis/v1/CloudRedisClient.java#L1202-L1212))
 ```
   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
   *   ListShelvesRequest request =
   *       ListShelvesRequest.newBuilder()
   *           .setPageSize(883849137)
   *           .setPageToken("pageToken873572522")
   *           .build();
   *   for (Shelf element : libraryServiceClient.listShelves(request).iterateAll()) {
   *     // doThingsWith(element);
   *   }
   * }
```
2. lro (gapic-generator [sample code](https://github.com/googleapis/java-redis/blob/master/google-cloud-redis/src/main/java/com/google/cloud/redis/v1/CloudRedisClient.java#L310-L327))
```
   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
   *   UpgradeInstanceRequest request =
   *       UpgradeInstanceRequest.newBuilder()
   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
   *           .setRedisVersion("redisVersion-1972584739")
   *           .build();
   *   Instance response = cloudRedisClient.upgradeInstanceAsync(request).get();
   * }
```
or if method return void, the last line is `cloudRedisClient.upgradeInstanceAsync(request).get();`
3. pure unary (gapic-generator [sample code](https://github.com/googleapis/java-logging/blob/master/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/LoggingClient.java#L243-L251))
```
   * try (MetricsClient metricsClient = MetricsClient.create()) {
   *   CreateLogMetricRequest request =
   *       CreateLogMetricRequest.newBuilder()
   *           .setParent(LogMetricName.of("[PROJECT]", "[METRIC]").toString())
   *           .setMetric(LogMetric.newBuilder().build())
   *           .build();
   *   LogMetric response = metricsClient.createLogMetric(request);
   * }
```
Or if the method return void, the last line is `metricsClient.createLogMetric(request);`


