### PR TITLE
feat: generate resname classes for all refs, message res defs

### DIFF
--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -189,7 +189,7 @@ def java_gapic_library(
     )
 
     # General additional deps.
-    actual_deps = resource_name_deps + [
+    actual_deps = deps + resource_name_deps + [
         "@com_google_googleapis//google/rpc:rpc_java_proto",
         "@com_google_googleapis//google/longrunning:longrunning_java_proto",
         "@com_google_protobuf//:protobuf_java",
@@ -207,7 +207,6 @@ def java_gapic_library(
         "@com_google_http_client_google_http_client//jar",
         "@javax_annotation_javax_annotation_api//jar",
     ]
-    _append_dep_without_duplicates(actual_deps, deps)
 
     native.java_library(
         name = name,

--- a/src/main/java/com/google/api/generator/gapic/protoparser/MethodSignatureParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/MethodSignatureParser.java
@@ -55,7 +55,8 @@ public class MethodSignatureParser {
       return signatures;
     }
 
-    Map<String, ResourceName> patternsToResourceNames = createPatternResourceNameMap(resourceNames);
+    Map<String, ResourceName> patternsToResourceNames =
+        ResourceParserHelpers.createPatternResourceNameMap(resourceNames);
     Message inputMessage = messageTypes.get(methodInputType.reference().simpleName());
 
     // Example from Expand in echo.proto:

--- a/src/main/java/com/google/api/generator/gapic/protoparser/ResourceParserHelpers.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/ResourceParserHelpers.java
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.protoparser;
+
+import com.google.api.generator.gapic.model.ResourceName;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResourceParserHelpers {
+  public static Map<String, ResourceName> createPatternResourceNameMap(
+      Map<String, ResourceName> resourceNames) {
+    Map<String, ResourceName> patternsToResourceNames = new HashMap<>();
+    for (ResourceName resourceName : resourceNames.values()) {
+      for (String pattern : resourceName.patterns()) {
+        patternsToResourceNames.put(pattern, resourceName);
+      }
+    }
+    return patternsToResourceNames;
+  }
+}

--- a/test/integration/goldens/logging/ConfigClientTest.java
+++ b/test/integration/goldens/logging/ConfigClientTest.java
@@ -678,7 +678,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -724,7 +724,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -770,7 +770,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -819,7 +819,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -868,7 +868,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -917,7 +917,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -966,7 +966,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -1015,7 +1015,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -1064,7 +1064,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -1113,7 +1113,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)
@@ -1165,7 +1165,7 @@ public class ConfigClientTest {
     LogSink expectedResponse =
         LogSink.newBuilder()
             .setName(LogSinkName.ofProjectSinkName("[PROJECT]", "[SINK]").toString())
-            .setDestination("destination-1429847026")
+            .setDestination(FolderLocationName.of("[FOLDER]", "[LOCATION]").toString())
             .setFilter("filter-1274492040")
             .setDescription("description-1724546052")
             .setDisabled(true)


### PR DESCRIPTION
Required for backwards-compatibility with the monolith. Affects a few selected repos like java-bigquerystorage and java-cloudbuild.