### PR TITLE
[ggj][engx] fix: remove service_yaml parsing from Bazel rules

### DIFF
--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -14,7 +14,6 @@
 
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library", "unzipped_srcjar")
 
-SERVICE_YAML_ALLOWLIST = ["googleads"]
 NO_GRPC_CONFIG_ALLOWLIST = ["library"]
 
 def _java_gapic_postprocess_srcjar_impl(ctx):
@@ -123,7 +122,6 @@ def java_gapic_library(
         name,
         srcs,
         package = None,
-        service_yaml = None,
         grpc_service_config = None,
         gapic_yaml = None,
         deps = [],
@@ -140,18 +138,6 @@ def java_gapic_library(
 
     if gapic_yaml:
         file_args_dict[gapic_yaml] = "gapic-config"
-
-    # Check the allow-list.
-    if service_yaml:
-        service_yaml_in_allowlist = False
-        for keyword in SERVICE_YAML_ALLOWLIST:
-            if keyword in service_yaml:
-                service_yaml_in_allowlist = True
-                break
-        if service_yaml_in_allowlist:
-            file_args_dict[service_yaml] = "gapic-service-config"
-        else:
-            fail("Service.yaml is no longer supported in the Java microgenerator")
 
     srcjar_name = name + "_srcjar"
     raw_srcjar_name = srcjar_name + "_raw"


### PR DESCRIPTION
We've migrated Ads off this file, so we no longer need to support it.