### PR TITLE
[composer][engx] seperate default value related files and same to resource name

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -18,6 +18,8 @@ java_library(
         "//src/main/java/com/google/api/generator/engine/writer",
         "//src/main/java/com/google/api/generator/gapic:status_java_proto",
         "//src/main/java/com/google/api/generator/gapic/composer/comment",
+        "//src/main/java/com/google/api/generator/gapic/composer/defaultvalue",
+        "//src/main/java/com/google/api/generator/gapic/composer/resourcename",
         "//src/main/java/com/google/api/generator/gapic/composer/samplecode",
         "//src/main/java/com/google/api/generator/gapic/composer/store",
         "//src/main/java/com/google/api/generator/gapic/composer/utils",

--- a/src/main/java/com/google/api/generator/gapic/composer/Composer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/Composer.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import com.google.api.generator.engine.ast.ClassDefinition;
 import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.gapic.composer.comment.CommentComposer;
+import com.google.api.generator.gapic.composer.resourcename.ResourceNameHelperClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicClass.Kind;
 import com.google.api.generator.gapic.model.GapicContext;

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientTestClassComposer.java
@@ -57,6 +57,7 @@ import com.google.api.generator.engine.ast.ValueExpr;
 import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.gapic.composer.defaultvalue.DefaultValueComposer;
 import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.model.Field;

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "defaultvalue_files",
+    srcs = glob(["*.java"]),
+)
+
+java_library(
+    name = "defaultvalue",
+    srcs = [
+        ":defaultvalue_files",
+    ],
+    deps = [
+        "//src/main/java/com/google/api/generator/engine/ast",
+        "//src/main/java/com/google/api/generator/gapic/composer/resourcename",
+        "//src/main/java/com/google/api/generator/gapic/model",
+        "//src/main/java/com/google/api/generator/gapic/utils",
+        "@com_google_googleapis//google/longrunning:longrunning_java_proto",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//java/core",
+        "@google_java_format_all_deps//jar",
+    ],
+)

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.defaultvalue;
 
 import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.Expr;
@@ -24,6 +24,7 @@ import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.ValueExpr;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.gapic.composer.resourcename.ResourceNameTokenizer;
 import com.google.api.generator.gapic.model.Field;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.MethodArgument;
@@ -49,7 +50,7 @@ public class DefaultValueComposer {
   private static TypeNode BYTESTRING_TYPE =
       TypeNode.withReference(ConcreteReference.withClazz(ByteString.class));
 
-  static Expr createDefaultValue(
+  public static Expr createDefaultValue(
       MethodArgument methodArg, Map<String, ResourceName> resourceNames) {
     if (methodArg.isResourceNameHelper()) {
       Preconditions.checkState(
@@ -78,7 +79,7 @@ public class DefaultValueComposer {
         Field.builder().setName(methodArg.name()).setType(methodArg.type()).build());
   }
 
-  static Expr createDefaultValue(Field f) {
+  public static Expr createDefaultValue(Field f) {
     return createDefaultValue(f, false);
   }
 
@@ -154,7 +155,7 @@ public class DefaultValueComposer {
             "Default value for field %s with type %s not implemented yet.", f.name(), f.type()));
   }
 
-  static Expr createDefaultValue(
+  public static Expr createDefaultValue(
       ResourceName resourceName, List<ResourceName> resnames, String fieldOrMessageName) {
     boolean hasOnePattern = resourceName.patterns().size() == 1;
     if (resourceName.isOnlyWildcard()) {
@@ -224,7 +225,7 @@ public class DefaultValueComposer {
         .build();
   }
 
-  static Expr createSimpleMessageBuilderExpr(
+  public static Expr createSimpleMessageBuilderExpr(
       Message message, Map<String, ResourceName> resourceNames, Map<String, Message> messageTypes) {
     MethodInvocationExpr builderExpr =
         MethodInvocationExpr.builder()
@@ -275,7 +276,7 @@ public class DefaultValueComposer {
         .build();
   }
 
-  static Expr createSimpleOperationBuilderExpr(String name, VariableExpr responseExpr) {
+  public static Expr createSimpleOperationBuilderExpr(String name, VariableExpr responseExpr) {
     Expr operationExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(OPERATION_TYPE)
@@ -313,7 +314,7 @@ public class DefaultValueComposer {
         .build();
   }
 
-  static Expr createSimplePagedResponse(
+  public static Expr createSimplePagedResponse(
       TypeNode responseType, String repeatedFieldName, Expr responseElementVarExpr) {
     Expr pagedResponseExpr =
         MethodInvocationExpr.builder()

--- a/src/main/java/com/google/api/generator/gapic/composer/resourcename/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/resourcename/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "resourcename_files",
+    srcs = glob(["*.java"]),
+)
+
+java_library(
+    name = "resourcename",
+    srcs = [
+        ":resourcename_files",
+    ],
+    deps = [
+        "//src/main/java/com/google/api/generator/engine/ast",
+        "//src/main/java/com/google/api/generator/gapic/composer/comment",
+        "//src/main/java/com/google/api/generator/gapic/composer/store",
+        "//src/main/java/com/google/api/generator/gapic/model",
+        "//src/main/java/com/google/api/generator/gapic/utils",
+        "@com_google_api_api_common",
+        "@com_google_guava_guava",
+        "@javax_annotation_javax_annotation_api",
+    ],
+)

--- a/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.resourcename;
 
 import com.google.api.core.BetaApi;
 import com.google.api.generator.engine.ast.AnnotationNode;

--- a/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameTokenizer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameTokenizer.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.resourcename;
 
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Preconditions;
@@ -32,7 +32,7 @@ public class ResourceNameTokenizer {
 
   private static final String NON_SLASH_SEP_REGEX = "\\}(_|\\-|\\.|~)\\{";
 
-  static List<List<String>> parseTokenHierarchy(List<String> patterns) {
+  public static List<List<String>> parseTokenHierarchy(List<String> patterns) {
     List<List<String>> tokenHierachies = new ArrayList<>();
     for (String pattern : patterns) {
       List<String> hierarchy = new ArrayList<>();

--- a/src/test/java/com/google/api/generator/engine/writer/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/engine/writer/BUILD.bazel
@@ -22,6 +22,7 @@ filegroup(
         "//src/test/java/com/google/api/generator/testutils",
         "@com_google_guava_guava//jar",
         "@com_google_truth_truth//jar",
+        "@javax_annotation_javax_annotation_api",
         "@junit_junit//jar",
     ],
 ) for test_name in TESTS]

--- a/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -10,7 +10,6 @@ UPDATE_GOLDENS_TESTS = [
     "GrpcServiceStubClassComposerTest",
     "MockServiceClassComposerTest",
     "MockServiceImplClassComposerTest",
-    "ResourceNameHelperClassComposerTest",
     "ServiceClientClassComposerTest",
     "ServiceClientTestClassComposerTest",
     "ServiceSettingsClassComposerTest",
@@ -19,8 +18,6 @@ UPDATE_GOLDENS_TESTS = [
 ]
 
 TESTS = UPDATE_GOLDENS_TESTS + [
-    "DefaultValueComposerTest",
-    "ResourceNameTokenizerTest",
     "RetrySettingsComposerTest",
 ]
 
@@ -36,8 +33,10 @@ TEST_DEPS = [
     "//src/test/java/com/google/api/generator/testutils",
     "//src/main/java/com/google/api/generator/gapic/model",
     "//src/main/java/com/google/api/generator/gapic/protoparser",
+    "//src/main/java/com/google/api/generator/gapic/composer/defaultvalue",
     "//src/test/java/com/google/api/generator/gapic/testdata:showcase_java_proto",
     "//src/test/java/com/google/api/generator/gapic/testdata:testgapic_java_proto",
+    "//src/test/java/com/google/api/generator/gapic/composer/constants",
     "@com_google_api_gax_java//gax",
     "@com_google_googleapis//google/logging/v2:logging_java_proto",
     "@com_google_googleapis//google/pubsub/v1:pubsub_java_proto",
@@ -71,7 +70,6 @@ java_proto_library(
     name = test_name,
     srcs = [
         "{0}.java".format(test_name),
-        "ComposerConstants.java",
     ],
     data = [
         "//src/test/java/com/google/api/generator/gapic/composer/goldens:goldens_files",
@@ -91,7 +89,6 @@ TEST_CLASS_DIR = "com.google.api.generator.gapic.composer."
     name = "{0}_update".format(test_name),
     srcs = [
         "{0}.java".format(test_name),
-        "ComposerConstants.java",
     ],
     data = [
         "//src/test/java/com/google/api/generator/gapic/composer/goldens:goldens_files",

--- a/src/test/java/com/google/api/generator/gapic/composer/BatchingDescriptorComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/BatchingDescriptorComposerTest.java
@@ -19,6 +19,7 @@ import static junit.framework.Assert.assertTrue;
 
 import com.google.api.generator.engine.ast.Expr;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicBatchingSettings;
 import com.google.api.generator.gapic.model.GapicServiceConfig;
 import com.google.api.generator.gapic.model.Message;

--- a/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import com.google.api.generator.engine.ast.ClassDefinition;
 import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicClass.Kind;
 import com.google.api.generator.test.framework.Assert;

--- a/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceCallableFactoryClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceCallableFactoryClassComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceStubClassComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/MockServiceClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/MockServiceClassComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/MockServiceImplClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/MockServiceImplClassComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/RetrySettingsComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/RetrySettingsComposerTest.java
@@ -27,6 +27,7 @@ import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicBatchingSettings;
 import com.google.api.generator.gapic.model.GapicServiceConfig;
 import com.google.api.generator.gapic.model.Message;

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceClientClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceClientClassComposerTest.java
@@ -18,6 +18,7 @@ import static com.google.api.generator.test.framework.Assert.assertCodeEquals;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceClientTestClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceClientTestClassComposerTest.java
@@ -18,6 +18,7 @@ import static com.google.api.generator.test.framework.Assert.assertCodeEquals;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceSettingsClassComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceStubClassComposerTest.java
@@ -17,6 +17,7 @@ package com.google.api.generator.gapic.composer;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceStubSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceStubSettingsClassComposerTest.java
@@ -18,6 +18,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicBatchingSettings;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicServiceConfig;

--- a/src/test/java/com/google/api/generator/gapic/composer/constants/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/constants/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "constants_files",
+    srcs = glob(["*.java"]),
+)
+
+java_binary(
+    name = "constants",
+    srcs = ["constants_files"],
+)

--- a/src/test/java/com/google/api/generator/gapic/composer/constants/ComposerConstants.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/constants/ComposerConstants.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.constants;
 
 public class ComposerConstants {
   public static final String GOLDENFILES_DIRECTORY =

--- a/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(default_visibility = ["//visibility:public"])
+
+TESTS = [
+    "DefaultValueComposerTest",
+]
+
+filegroup(
+    name = "defaultvalue_files",
+    srcs = ["{0}.java".format(f) for f in TESTS],
+)
+
+[java_test(
+    name = test_name,
+    srcs = ["{0}.java".format(test_name)],
+    test_class = "com.google.api.generator.gapic.composer.defaultvalue.{0}".format(test_name),
+    deps = [
+        ":common_resources_java_proto",
+        "//src/main/java/com/google/api/generator/engine/ast",
+        "//src/main/java/com/google/api/generator/engine/writer",
+        "//src/main/java/com/google/api/generator/gapic/composer/defaultvalue",
+        "//src/main/java/com/google/api/generator/gapic/model",
+        "//src/main/java/com/google/api/generator/gapic/protoparser",
+        "//src/test/java/com/google/api/generator/gapic/testdata:showcase_java_proto",
+        "//src/test/java/com/google/api/generator/gapic/testdata:testgapic_java_proto",
+        "//src/test/java/com/google/api/generator/test/framework:asserts",
+        "//src/test/java/com/google/api/generator/test/framework:utils",
+        "//src/test/java/com/google/api/generator/testutils",
+        "@com_google_api_api_common//jar",
+        "@com_google_api_gax_java//gax",
+        "@com_google_googleapis//google/rpc:rpc_java_proto",
+        "@com_google_guava_guava",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_truth_truth//jar",
+        "@junit_junit//jar",
+    ],
+) for test_name in TESTS]
+
+java_proto_library(
+    name = "common_resources_java_proto",
+    deps = [
+        "@com_google_googleapis//google/cloud:common_resources_proto",
+    ],
+)

--- a/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.defaultvalue;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -20,6 +20,7 @@ import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.Expr;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.defaultvalue.DefaultValueComposer;
 import com.google.api.generator.gapic.model.Field;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/resourcename/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/resourcename/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(default_visibility = ["//visibility:public"])
+
+TESTS = [
+    "ResourceNameHelperClassComposerTest",
+    "ResourceNameTokenizerTest",
+]
+
+filegroup(
+    name = "resourcename_files",
+    srcs = ["{0}.java".format(f) for f in TESTS],
+)
+
+[java_test(
+    name = test_name,
+    srcs = ["{0}.java".format(test_name)],
+    data = [
+        "//src/test/java/com/google/api/generator/gapic/composer/goldens:goldens_files",
+        "//src/test/java/com/google/api/generator/gapic/testdata:gapic_config_files",
+        "//src/test/java/com/google/api/generator/gapic/testdata:service_config_files",
+    ],
+    test_class = "com.google.api.generator.gapic.composer.resourcename.{0}".format(test_name),
+    deps = [
+        ":common_resources_java_proto",
+        "//src/main/java/com/google/api/generator/engine/ast",
+        "//src/main/java/com/google/api/generator/engine/writer",
+        "//src/main/java/com/google/api/generator/gapic/composer/resourcename",
+        "//src/main/java/com/google/api/generator/gapic/model",
+        "//src/main/java/com/google/api/generator/gapic/protoparser",
+        "//src/test/java/com/google/api/generator/gapic/composer/constants",
+        "//src/test/java/com/google/api/generator/gapic/testdata:showcase_java_proto",
+        "//src/test/java/com/google/api/generator/test/framework:asserts",
+        "//src/test/java/com/google/api/generator/test/framework:utils",
+        "//src/test/java/com/google/api/generator/testutils",
+        "@com_google_api_api_common//jar",
+        "@com_google_api_gax_java//gax",
+        "@com_google_googleapis//google/logging/v2:logging_java_proto",
+        "@com_google_googleapis//google/rpc:rpc_java_proto",
+        "@com_google_guava_guava",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_truth_truth//jar",
+        "@junit_junit//jar",
+    ],
+) for test_name in TESTS]
+
+java_proto_library(
+    name = "common_resources_java_proto",
+    deps = [
+        "@com_google_googleapis//google/cloud:common_resources_proto",
+    ],
+)

--- a/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposerTest.java
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.resourcename;
 
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.assertEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.constants.ComposerConstants;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;

--- a/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameTokenizerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameTokenizerTest.java
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer;
+package com.google.api.generator.gapic.composer.resourcename;
 
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.assertEquals;
 
+import com.google.api.generator.gapic.composer.resourcename.ResourceNameTokenizer;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.showcase.v1beta1.EchoOuterClass;


### PR DESCRIPTION
After change on #616, sample code generate depend on default value composer, it causes bazel error of a cycle in bazel dependency graph.

In this PR,  I create `defaultvalue` bazel package, `resourcename` bazel package and `constants` bazel package. Also do the same for their matched tests.

dependency graph:
defaultvalue -> resourcename -> constants