### PR TITLE
fix: add support for top-level protobuf enums

### DIFF
--- a/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
@@ -20,7 +20,6 @@ import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.Expr;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
-import com.google.api.generator.gapic.composer.defaultvalue.DefaultValueComposer;
 import com.google.api.generator.gapic.model.Field;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.ResourceName;
@@ -273,6 +272,7 @@ public class DefaultValueComposerTest {
         "EchoRequest.newBuilder().setName("
             + "FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())"
             + ".setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())"
+            + ".setSeverity(Severity.forNumber(0))"
             + ".setFoobar(Foobar.newBuilder().build()).build()",
         writerVisitor.write());
   }

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClient.golden
@@ -314,6 +314,7 @@ public class EchoClient implements BackgroundResource {
    *       EchoRequest.newBuilder()
    *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
    *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
    *           .setFoobar(Foobar.newBuilder().build())
    *           .build();
    *   EchoResponse response = echoClient.echo(request);
@@ -337,6 +338,7 @@ public class EchoClient implements BackgroundResource {
    *       EchoRequest.newBuilder()
    *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
    *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
    *           .setFoobar(Foobar.newBuilder().build())
    *           .build();
    *   ApiFuture<EchoResponse> future = echoClient.echoCallable().futureCall(request);
@@ -397,6 +399,7 @@ public class EchoClient implements BackgroundResource {
    *       EchoRequest.newBuilder()
    *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
    *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
    *           .setFoobar(Foobar.newBuilder().build())
    *           .build();
    *   requestObserver.onNext(request);
@@ -418,6 +421,7 @@ public class EchoClient implements BackgroundResource {
    *       EchoRequest.newBuilder()
    *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
    *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
    *           .setFoobar(Foobar.newBuilder().build())
    *           .build();
    *   bidiStream.send(request);
@@ -442,6 +446,7 @@ public class EchoClient implements BackgroundResource {
    *       EchoRequest.newBuilder()
    *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
    *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
    *           .setFoobar(Foobar.newBuilder().build())
    *           .build();
    *   bidiStream.send(request);

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/EchoClientTest.golden
@@ -79,7 +79,10 @@ public class EchoClientTest {
   @Test
   public void echoTest() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     EchoResponse actualResponse = client.echo();
@@ -105,6 +108,7 @@ public class EchoClientTest {
           EchoRequest.newBuilder()
               .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
               .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setSeverity(Severity.forNumber(0))
               .setFoobar(Foobar.newBuilder().build())
               .build();
       client.echo(request);
@@ -117,7 +121,10 @@ public class EchoClientTest {
   @Test
   public void echoTest2() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     ResourceName parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
@@ -153,7 +160,10 @@ public class EchoClientTest {
   @Test
   public void echoTest3() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     Status error = Status.newBuilder().build();
@@ -189,7 +199,10 @@ public class EchoClientTest {
   @Test
   public void echoTest4() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     FoobarName name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
@@ -225,7 +238,10 @@ public class EchoClientTest {
   @Test
   public void echoTest5() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     String content = "content951530617";
@@ -261,7 +277,10 @@ public class EchoClientTest {
   @Test
   public void echoTest6() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     String name = "name3373707";
@@ -297,7 +316,10 @@ public class EchoClientTest {
   @Test
   public void echoTest7() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     String parent = "parent-995424086";
@@ -333,7 +355,10 @@ public class EchoClientTest {
   @Test
   public void echoTest8() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
 
     String content = "content951530617";
@@ -372,7 +397,10 @@ public class EchoClientTest {
   @Test
   public void expandTest() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
     ExpandRequest request =
         ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
@@ -412,12 +440,16 @@ public class EchoClientTest {
   @Test
   public void collectTest() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
     EchoRequest request =
         EchoRequest.newBuilder()
             .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
             .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
             .setFoobar(Foobar.newBuilder().build())
             .build();
 
@@ -442,6 +474,7 @@ public class EchoClientTest {
         EchoRequest.newBuilder()
             .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
             .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
             .setFoobar(Foobar.newBuilder().build())
             .build();
 
@@ -465,12 +498,16 @@ public class EchoClientTest {
   @Test
   public void chatTest() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
     EchoRequest request =
         EchoRequest.newBuilder()
             .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
             .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
             .setFoobar(Foobar.newBuilder().build())
             .build();
 
@@ -495,6 +532,7 @@ public class EchoClientTest {
         EchoRequest.newBuilder()
             .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
             .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
             .setFoobar(Foobar.newBuilder().build())
             .build();
 
@@ -518,12 +556,16 @@ public class EchoClientTest {
   @Test
   public void chatAgainTest() throws Exception {
     EchoResponse expectedResponse =
-        EchoResponse.newBuilder().setContent("content951530617").build();
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
     mockEcho.addResponse(expectedResponse);
     EchoRequest request =
         EchoRequest.newBuilder()
             .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
             .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
             .setFoobar(Foobar.newBuilder().build())
             .build();
 
@@ -548,6 +590,7 @@ public class EchoClientTest {
         EchoRequest.newBuilder()
             .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
             .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
             .setFoobar(Foobar.newBuilder().build())
             .build();
 

--- a/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientSampleCodeComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientSampleCodeComposerTest.java
@@ -21,7 +21,6 @@ import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.Reference;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.VaporReference;
-import com.google.api.generator.gapic.composer.samplecode.ServiceClientSampleCodeComposer;
 import com.google.api.generator.gapic.model.Field;
 import com.google.api.generator.gapic.model.LongrunningOperation;
 import com.google.api.generator.gapic.model.Message;
@@ -68,7 +67,9 @@ public class ServiceClientSampleCodeComposerTest {
                 .setName("EchoClient")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
-    String results = ServiceClientSampleCodeComposer.composeClassHeaderMethodSampleCode(echoProtoService, clientType, resourceNames, messageTypes);
+    String results =
+        ServiceClientSampleCodeComposer.composeClassHeaderMethodSampleCode(
+            echoProtoService, clientType, resourceNames, messageTypes);
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
@@ -127,16 +128,17 @@ public class ServiceClientSampleCodeComposerTest {
             .setLro(lro)
             .setMethodSignatures(Arrays.asList(Arrays.asList(ttl)))
             .build();
-    Service service = Service.builder()
-        .setName("Echo")
-        .setDefaultHost("localhost:7469")
-        .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
-        .setPakkage(SHOWCASE_PACKAGE_NAME)
-        .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
-        .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
-        .setOverriddenName("Echo")
-        .setMethods(Arrays.asList(method))
-        .build();
+    Service service =
+        Service.builder()
+            .setName("Echo")
+            .setDefaultHost("localhost:7469")
+            .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
+            .setPakkage(SHOWCASE_PACKAGE_NAME)
+            .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
+            .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
+            .setOverriddenName("Echo")
+            .setMethods(Arrays.asList(method))
+            .build();
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -168,7 +170,10 @@ public class ServiceClientSampleCodeComposerTest {
                 .build());
     TypeNode outputType =
         TypeNode.withReference(
-            VaporReference.builder().setName("EchoResponse").setPakkage(SHOWCASE_PACKAGE_NAME).build());
+            VaporReference.builder()
+                .setName("EchoResponse")
+                .setPakkage(SHOWCASE_PACKAGE_NAME)
+                .build());
     Method method =
         Method.builder()
             .setName("Echo")
@@ -176,16 +181,17 @@ public class ServiceClientSampleCodeComposerTest {
             .setOutputType(outputType)
             .setMethodSignatures(Collections.emptyList())
             .build();
-    Service service = Service.builder()
-        .setName("Echo")
-        .setDefaultHost("localhost:7469")
-        .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
-        .setPakkage(SHOWCASE_PACKAGE_NAME)
-        .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
-        .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
-        .setOverriddenName("Echo")
-        .setMethods(Arrays.asList(method))
-        .build();
+    Service service =
+        Service.builder()
+            .setName("Echo")
+            .setDefaultHost("localhost:7469")
+            .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
+            .setPakkage(SHOWCASE_PACKAGE_NAME)
+            .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
+            .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
+            .setOverriddenName("Echo")
+            .setMethods(Arrays.asList(method))
+            .build();
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -200,8 +206,11 @@ public class ServiceClientSampleCodeComposerTest {
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  EchoRequest request =\n",
             "      EchoRequest.newBuilder()\n",
-            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
-            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setSeverity(Severity.forNumber(0))\n",
             "          .setFoobar(Foobar.newBuilder().build())\n",
             "          .build();\n",
             "  EchoResponse response = echoClient.echo(request);\n",
@@ -233,28 +242,32 @@ public class ServiceClientSampleCodeComposerTest {
             .setOutputType(outputType)
             .setStream(Stream.SERVER)
             .build();
-    Service service = Service.builder()
-        .setName("Echo")
-        .setDefaultHost("localhost:7469")
-        .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
-        .setPakkage(SHOWCASE_PACKAGE_NAME)
-        .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
-        .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
-        .setOverriddenName("Echo")
-        .setMethods(Arrays.asList(method))
-        .build();
+    Service service =
+        Service.builder()
+            .setName("Echo")
+            .setDefaultHost("localhost:7469")
+            .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
+            .setPakkage(SHOWCASE_PACKAGE_NAME)
+            .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
+            .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
+            .setOverriddenName("Echo")
+            .setMethods(Arrays.asList(method))
+            .build();
     TypeNode clientType =
         TypeNode.withReference(
             VaporReference.builder()
                 .setName("EchoClient")
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
-    String results = ServiceClientSampleCodeComposer.composeClassHeaderMethodSampleCode(service, clientType, resourceNames, messageTypes);
+    String results =
+        ServiceClientSampleCodeComposer.composeClassHeaderMethodSampleCode(
+            service, clientType, resourceNames, messageTypes);
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  ExpandRequest request =\n",
-            "      ExpandRequest.newBuilder().setContent(\"content951530617\").setInfo(\"info3237038\").build();\n",
+            "     "
+                + " ExpandRequest.newBuilder().setContent(\"content951530617\").setInfo(\"info3237038\").build();\n",
             "  ServerStream<EchoResponse> stream = echoClient.expandCallable().call(request);\n",
             "  for (EchoResponse response : stream) {\n",
             "    // Do something when a response is received.\n",
@@ -278,7 +291,8 @@ public class ServiceClientSampleCodeComposerTest {
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
     String results =
-        ServiceClientSampleCodeComposer.composeClassHeaderCredentialsSampleCode(clientType, settingsType);
+        ServiceClientSampleCodeComposer.composeClassHeaderCredentialsSampleCode(
+            clientType, settingsType);
     String expected =
         LineFormatter.lines(
             "EchoSettings echoSettings =\n",
@@ -304,10 +318,12 @@ public class ServiceClientSampleCodeComposerTest {
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
     String results =
-        ServiceClientSampleCodeComposer.composeClassHeaderEndpointSampleCode(clientType, settingsType);
+        ServiceClientSampleCodeComposer.composeClassHeaderEndpointSampleCode(
+            clientType, settingsType);
     String expected =
         LineFormatter.lines(
-            "EchoSettings echoSettings = EchoSettings.newBuilder().setEndpoint(myEndpoint).build();\n",
+            "EchoSettings echoSettings ="
+                + " EchoSettings.newBuilder().setEndpoint(myEndpoint).build();\n",
             "EchoClient echoClient = EchoClient.create(echoSettings);");
     assertEquals(expected, results);
   }
@@ -408,7 +424,8 @@ public class ServiceClientSampleCodeComposerTest {
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  ResourceName parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\");\n",
+            "  ResourceName parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\");\n",
             "  EchoResponse response = echoClient.echo(parent);\n",
             "}");
     assertEquals(expected, results);
@@ -529,7 +546,8 @@ public class ServiceClientSampleCodeComposerTest {
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String name = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
+            "  String name = FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString();\n",
             "  EchoResponse response = echoClient.echo(name);\n",
             "}");
     assertEquals(expected, results);
@@ -586,7 +604,8 @@ public class ServiceClientSampleCodeComposerTest {
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
+            "  String parent = FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString();\n",
             "  EchoResponse response = echoClient.echo(parent);\n",
             "}");
     assertEquals(expected, results);
@@ -719,7 +738,8 @@ public class ServiceClientSampleCodeComposerTest {
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  String displayName = FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString();\n",
+            "  String displayName = FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString();\n",
             "  String otherName = \"otherName-1946065477\";\n",
             "  EchoResponse response = echoClient.echo(displayName, otherName);\n",
             "}");
@@ -1018,7 +1038,8 @@ public class ServiceClientSampleCodeComposerTest {
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  List<String> resourceName = new ArrayList<>();\n",
             "  String filter = \"filter-1274492040\";\n",
-            "  for (Content element : echoClient.listContent(resourceName, filter).iterateAll()) {\n",
+            "  for (Content element : echoClient.listContent(resourceName, filter).iterateAll())"
+                + " {\n",
             "    // doThingsWith(element);\n",
             "  }\n",
             "}");
@@ -1611,8 +1632,11 @@ public class ServiceClientSampleCodeComposerTest {
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  EchoRequest request =\n",
             "      EchoRequest.newBuilder()\n",
-            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
-            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setSeverity(Severity.forNumber(0))\n",
             "          .setFoobar(Foobar.newBuilder().build())\n",
             "          .build();\n",
             "  echoClient.echo(request);\n",
@@ -1658,8 +1682,11 @@ public class ServiceClientSampleCodeComposerTest {
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  EchoRequest request =\n",
             "      EchoRequest.newBuilder()\n",
-            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
-            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setSeverity(Severity.forNumber(0))\n",
             "          .setFoobar(Foobar.newBuilder().build())\n",
             "          .build();\n",
             "  EchoResponse response = echoClient.echo(request);\n",
@@ -1818,7 +1845,8 @@ public class ServiceClientSampleCodeComposerTest {
             "          .setPageSize(883849137)\n",
             "          .setPageToken(\"pageToken873572522\")\n",
             "          .build();\n",
-            "  ApiFuture<EchoResponse> future = echoClient.pagedExpandPagedCallable().futureCall(request);\n",
+            "  ApiFuture<EchoResponse> future ="
+                + " echoClient.pagedExpandPagedCallable().futureCall(request);\n",
             "  // Do something.\n",
             "  for (EchoResponse element : future.get().iterateAll()) {\n",
             "    // doThingsWith(element);\n",
@@ -1989,7 +2017,8 @@ public class ServiceClientSampleCodeComposerTest {
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  ExpandRequest request =\n",
-            "      ExpandRequest.newBuilder().setContent(\"content951530617\").setInfo(\"info3237038\").build();\n",
+            "     "
+                + " ExpandRequest.newBuilder().setContent(\"content951530617\").setInfo(\"info3237038\").build();\n",
             "  ServerStream<EchoResponse> stream = echoClient.expandCallable().call(request);\n",
             "  for (EchoResponse response : stream) {\n",
             "    // Do something when a response is received.\n",
@@ -2071,11 +2100,15 @@ public class ServiceClientSampleCodeComposerTest {
     String expected =
         LineFormatter.lines(
             "try (EchoClient echoClient = EchoClient.create()) {\n",
-            "  BidiStream<EchoRequest, EchoResponse> bidiStream = echoClient.chatCallable().call();\n",
+            "  BidiStream<EchoRequest, EchoResponse> bidiStream ="
+                + " echoClient.chatCallable().call();\n",
             "  EchoRequest request =\n",
             "      EchoRequest.newBuilder()\n",
-            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
-            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setSeverity(Severity.forNumber(0))\n",
             "          .setFoobar(Foobar.newBuilder().build())\n",
             "          .build();\n",
             "  bidiStream.send(request);\n",
@@ -2180,8 +2213,11 @@ public class ServiceClientSampleCodeComposerTest {
             "      echoClient.collect().clientStreamingCall(responseObserver);\n",
             "  EchoRequest request =\n",
             "      EchoRequest.newBuilder()\n",
-            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
-            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setSeverity(Severity.forNumber(0))\n",
             "          .setFoobar(Foobar.newBuilder().build())\n",
             "          .build();\n",
             "  requestObserver.onNext(request);\n",
@@ -2251,11 +2287,7 @@ public class ServiceClientSampleCodeComposerTest {
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
     Method method =
-        Method.builder()
-            .setName("Echo")
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
+        Method.builder().setName("Echo").setInputType(inputType).setOutputType(outputType).build();
     String results =
         ServiceClientSampleCodeComposer.composeRegularCallableMethodHeaderSampleCode(
             method, clientType, resourceNames, messageTypes);
@@ -2264,8 +2296,11 @@ public class ServiceClientSampleCodeComposerTest {
             "try (EchoClient echoClient = EchoClient.create()) {\n",
             "  EchoRequest request =\n",
             "      EchoRequest.newBuilder()\n",
-            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
-            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\").toString())\n",
+            "          .setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setParent(FoobarName.ofProjectFoobarName(\"[PROJECT]\","
+                + " \"[FOOBAR]\").toString())\n",
+            "          .setSeverity(Severity.forNumber(0))\n",
             "          .setFoobar(Foobar.newBuilder().build())\n",
             "          .build();\n",
             "  ApiFuture<EchoResponse> future = echoClient.echoCallable().futureCall(request);\n",
@@ -2351,10 +2386,7 @@ public class ServiceClientSampleCodeComposerTest {
             VaporReference.builder().setName("Operation").setPakkage(LRO_PACKAGE_NAME).build());
     TypeNode responseType =
         TypeNode.withReference(
-            VaporReference.builder()
-                .setName("Empty")
-                .setPakkage(PROTO_PACKAGE_NAME)
-                .build());
+            VaporReference.builder().setName("Empty").setPakkage(PROTO_PACKAGE_NAME).build());
     TypeNode metadataType =
         TypeNode.withReference(
             VaporReference.builder()
@@ -2460,11 +2492,7 @@ public class ServiceClientSampleCodeComposerTest {
                 .setPakkage(SHOWCASE_PACKAGE_NAME)
                 .build());
     Method method =
-        Method.builder()
-            .setName("Echo")
-            .setInputType(inputType)
-            .setOutputType(outputType)
-            .build();
+        Method.builder().setName("Echo").setInputType(inputType).setOutputType(outputType).build();
     assertThrows(
         NullPointerException.class,
         () ->

--- a/test/integration/goldens/asset/AssetServiceClient.java
+++ b/test/integration/goldens/asset/AssetServiceClient.java
@@ -52,6 +52,7 @@ import javax.annotation.Generated;
  *       BatchGetAssetsHistoryRequest.newBuilder()
  *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
  *           .addAllAssetNames(new ArrayList<String>())
+ *           .setContentType(ContentType.forNumber(0))
  *           .setReadTimeWindow(TimeWindow.newBuilder().build())
  *           .build();
  *   BatchGetAssetsHistoryResponse response = assetServiceClient.batchGetAssetsHistory(request);
@@ -187,6 +188,7 @@ public class AssetServiceClient implements BackgroundResource {
    *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
+   *           .setContentType(ContentType.forNumber(0))
    *           .setOutputConfig(OutputConfig.newBuilder().build())
    *           .build();
    *   ExportAssetsResponse response = assetServiceClient.exportAssetsAsync(request).get();
@@ -221,6 +223,7 @@ public class AssetServiceClient implements BackgroundResource {
    *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
+   *           .setContentType(ContentType.forNumber(0))
    *           .setOutputConfig(OutputConfig.newBuilder().build())
    *           .build();
    *   OperationFuture<ExportAssetsResponse, ExportAssetsRequest> future =
@@ -255,6 +258,7 @@ public class AssetServiceClient implements BackgroundResource {
    *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
+   *           .setContentType(ContentType.forNumber(0))
    *           .setOutputConfig(OutputConfig.newBuilder().build())
    *           .build();
    *   ApiFuture<Operation> future = assetServiceClient.exportAssetsCallable().futureCall(request);
@@ -283,6 +287,7 @@ public class AssetServiceClient implements BackgroundResource {
    *       BatchGetAssetsHistoryRequest.newBuilder()
    *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
    *           .addAllAssetNames(new ArrayList<String>())
+   *           .setContentType(ContentType.forNumber(0))
    *           .setReadTimeWindow(TimeWindow.newBuilder().build())
    *           .build();
    *   BatchGetAssetsHistoryResponse response = assetServiceClient.batchGetAssetsHistory(request);
@@ -313,6 +318,7 @@ public class AssetServiceClient implements BackgroundResource {
    *       BatchGetAssetsHistoryRequest.newBuilder()
    *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
    *           .addAllAssetNames(new ArrayList<String>())
+   *           .setContentType(ContentType.forNumber(0))
    *           .setReadTimeWindow(TimeWindow.newBuilder().build())
    *           .build();
    *   ApiFuture<BatchGetAssetsHistoryResponse> future =

--- a/test/integration/goldens/asset/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/AssetServiceClientTest.java
@@ -108,6 +108,7 @@ public class AssetServiceClientTest {
             .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
             .setReadTime(Timestamp.newBuilder().build())
             .addAllAssetTypes(new ArrayList<String>())
+            .setContentType(ContentType.forNumber(0))
             .setOutputConfig(OutputConfig.newBuilder().build())
             .build();
 
@@ -140,6 +141,7 @@ public class AssetServiceClientTest {
               .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
+              .setContentType(ContentType.forNumber(0))
               .setOutputConfig(OutputConfig.newBuilder().build())
               .build();
       client.exportAssetsAsync(request).get();
@@ -163,6 +165,7 @@ public class AssetServiceClientTest {
         BatchGetAssetsHistoryRequest.newBuilder()
             .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
             .addAllAssetNames(new ArrayList<String>())
+            .setContentType(ContentType.forNumber(0))
             .setReadTimeWindow(TimeWindow.newBuilder().build())
             .build();
 
@@ -194,6 +197,7 @@ public class AssetServiceClientTest {
           BatchGetAssetsHistoryRequest.newBuilder()
               .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
               .addAllAssetNames(new ArrayList<String>())
+              .setContentType(ContentType.forNumber(0))
               .setReadTimeWindow(TimeWindow.newBuilder().build())
               .build();
       client.batchGetAssetsHistory(request);
@@ -210,6 +214,7 @@ public class AssetServiceClientTest {
             .setName(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
             .addAllAssetNames(new ArrayList<String>())
             .addAllAssetTypes(new ArrayList<String>())
+            .setContentType(ContentType.forNumber(0))
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .setCondition(Expr.newBuilder().build())
             .build();
@@ -252,6 +257,7 @@ public class AssetServiceClientTest {
             .setName(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
             .addAllAssetNames(new ArrayList<String>())
             .addAllAssetTypes(new ArrayList<String>())
+            .setContentType(ContentType.forNumber(0))
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .setCondition(Expr.newBuilder().build())
             .build();
@@ -294,6 +300,7 @@ public class AssetServiceClientTest {
             .setName(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
             .addAllAssetNames(new ArrayList<String>())
             .addAllAssetTypes(new ArrayList<String>())
+            .setContentType(ContentType.forNumber(0))
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .setCondition(Expr.newBuilder().build())
             .build();
@@ -372,6 +379,7 @@ public class AssetServiceClientTest {
             .setName(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
             .addAllAssetNames(new ArrayList<String>())
             .addAllAssetTypes(new ArrayList<String>())
+            .setContentType(ContentType.forNumber(0))
             .setFeedOutputConfig(FeedOutputConfig.newBuilder().build())
             .setCondition(Expr.newBuilder().build())
             .build();

--- a/test/integration/goldens/asset/package-info.java
+++ b/test/integration/goldens/asset/package-info.java
@@ -29,6 +29,7 @@
  *       BatchGetAssetsHistoryRequest.newBuilder()
  *           .setParent(ProjectName.of("[PROJECT]").toString())
  *           .addAllAssetNames(new ArrayList<String>())
+ *           .setContentType(ContentType.forNumber(0))
  *           .setReadTimeWindow(TimeWindow.newBuilder().build())
  *           .build();
  *   BatchGetAssetsHistoryResponse response = assetServiceClient.batchGetAssetsHistory(request);

--- a/test/integration/goldens/logging/ConfigClientTest.java
+++ b/test/integration/goldens/logging/ConfigClientTest.java
@@ -42,6 +42,7 @@ import com.google.logging.v2.GetBucketRequest;
 import com.google.logging.v2.GetCmekSettingsRequest;
 import com.google.logging.v2.GetExclusionRequest;
 import com.google.logging.v2.GetSinkRequest;
+import com.google.logging.v2.LifecycleState;
 import com.google.logging.v2.ListBucketsRequest;
 import com.google.logging.v2.ListBucketsResponse;
 import com.google.logging.v2.ListExclusionsRequest;
@@ -350,6 +351,7 @@ public class ConfigClientTest {
             .setCreateTime(Timestamp.newBuilder().build())
             .setUpdateTime(Timestamp.newBuilder().build())
             .setRetentionDays(1544391896)
+            .setLifecycleState(LifecycleState.forNumber(0))
             .build();
     mockConfigServiceV2.addResponse(expectedResponse);
 
@@ -404,6 +406,7 @@ public class ConfigClientTest {
             .setCreateTime(Timestamp.newBuilder().build())
             .setUpdateTime(Timestamp.newBuilder().build())
             .setRetentionDays(1544391896)
+            .setLifecycleState(LifecycleState.forNumber(0))
             .build();
     mockConfigServiceV2.addResponse(expectedResponse);
 


### PR DESCRIPTION
This is currently exercised when an RPC uses an enum type in `method_signature`.