### PR TITLE
chore(ci): Separate codecov to optimize presubmit check speed [ggj][engx][build]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,18 @@ jobs:
           path: ~/.cache/bazel/*/*/*/gapic_generator_java/bazel-out/*/testlogs/*
           retention-days: 5
 
+      - name: Java Linter
+        run: bazel --batch  build //:google_java_format_verification
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          java-version: 8
+      - run: java -version
+
       - name: Generate Code Coverage Report
         # Run only test targets, and not golden_update targets.
         run: bazel coverage  $(bazel query "src/test/..." | grep "Test$")  --combined_report=lcov
@@ -67,9 +79,6 @@ jobs:
         with:
           name: actions ${{ matrix.java }}
           files: ./bazel-out/_coverage/_coverage_report.dat
-
-      - name: Java Linter
-        run: bazel --batch  build //:google_java_format_verification
 
   license-header:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,8 @@ jobs:
           path: ~/artifacts
 
       - name: Generate Code Coverage Report
-        run: bazel coverage //src/test/... --combined_report=lcov
+        # Run only test targets, and not golden_update targets.
+        run: bazel coverage  $(bazel query "src/test/..." | grep "Test$")  --combined_report=lcov
 
       - name: Upload Code Coverage Report
         uses: codecov/codecov-action@v1

--- a/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -95,7 +95,7 @@ TEST_CLASS_DIR = "com.google.api.generator.gapic.composer."
     name = "{0}_update".format(test_name),
     srcs = [
         "{0}.java".format(test_name),
-    ],
+    ] + COMMON_SRCS,
     data = [
         "//src/test/java/com/google/api/generator/gapic/composer/goldens:goldens_files",
         "//src/test/java/com/google/api/generator/gapic/testdata:gapic_config_files",


### PR DESCRIPTION
This ensures it runs once, since the tests run twice (once for Java 8, another for 11).