### PR TITLE
[ggj] feat(gapic): propagate protobuf 'deprecated' to classes/methods

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/TypeNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/TypeNode.java
@@ -81,6 +81,9 @@ public abstract class TypeNode implements AstNode, Comparable<TypeNode> {
   public static final TypeNode STRING = withReference(ConcreteReference.withClazz(String.class));
   public static final TypeNode VOID_OBJECT = withReference(ConcreteReference.withClazz(Void.class));
 
+  public static final TypeNode DEPRECATED =
+      withReference(ConcreteReference.withClazz(Deprecated.class));
+
   public static final TypeNode STRING_ARRAY =
       builder()
           .setTypeKind(TypeKind.OBJECT)

--- a/src/main/java/com/google/api/generator/gapic/composer/GrpcServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/GrpcServiceCallableFactoryClassComposer.java
@@ -77,8 +77,8 @@ public class GrpcServiceCallableFactoryClassComposer implements ClassComposer {
             .setPackageString(pakkage)
             .setHeaderCommentStatements(
                 StubCommentComposer.createGrpcServiceCallableFactoryClassHeaderComments(
-                    service.name()))
-            .setAnnotations(createClassAnnotations(service.pakkage(), typeStore))
+                    service.name(), service.isDeprecated()))
+            .setAnnotations(createClassAnnotations(service, typeStore))
             .setImplementsTypes(createClassImplements(typeStore))
             .setName(className)
             .setMethods(createClassMethods(typeStore))
@@ -87,11 +87,16 @@ public class GrpcServiceCallableFactoryClassComposer implements ClassComposer {
     return GapicClass.create(kind, classDef);
   }
 
-  private static List<AnnotationNode> createClassAnnotations(String pakkage, TypeStore typeStore) {
+  private static List<AnnotationNode> createClassAnnotations(Service service, TypeStore typeStore) {
     List<AnnotationNode> annotations = new ArrayList<>();
-    if (!PackageChecker.isGaApi(pakkage)) {
+    if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(typeStore.get("BetaApi")));
     }
+
+    if (service.isDeprecated()) {
+      annotations.add(AnnotationNode.withType(TypeNode.DEPRECATED));
+    }
+
     annotations.add(
         AnnotationNode.builder()
             .setType(typeStore.get("Generated"))

--- a/src/main/java/com/google/api/generator/gapic/composer/GrpcServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/GrpcServiceStubClassComposer.java
@@ -162,8 +162,9 @@ public class GrpcServiceStubClassComposer implements ClassComposer {
         ClassDefinition.builder()
             .setPackageString(pakkage)
             .setHeaderCommentStatements(
-                StubCommentComposer.createGrpcServiceStubClassHeaderComments(service.name()))
-            .setAnnotations(createClassAnnotations(service.pakkage()))
+                StubCommentComposer.createGrpcServiceStubClassHeaderComments(
+                    service.name(), service.isDeprecated()))
+            .setAnnotations(createClassAnnotations(service))
             .setScope(ScopeNode.PUBLIC)
             .setName(className)
             .setExtendsType(typeStore.get(ClassNames.getServiceStubClassName(service)))
@@ -387,11 +388,16 @@ public class GrpcServiceStubClassComposer implements ClassComposer {
     return callableClassMembers;
   }
 
-  private static List<AnnotationNode> createClassAnnotations(String pakkage) {
+  private static List<AnnotationNode> createClassAnnotations(Service service) {
     List<AnnotationNode> annotations = new ArrayList<>();
-    if (!PackageChecker.isGaApi(pakkage)) {
+    if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("BetaApi")));
     }
+
+    if (service.isDeprecated()) {
+      annotations.add(AnnotationNode.withType(TypeNode.DEPRECATED));
+    }
+
     annotations.add(
         AnnotationNode.builder()
             .setType(FIXED_TYPESTORE.get("Generated"))

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceClientClassComposer.java
@@ -138,7 +138,7 @@ public class ServiceClientClassComposer implements ClassComposer {
             .setHeaderCommentStatements(
                 createClassHeaderComments(service, typeStore, resourceNames, messageTypes))
             .setPackageString(pakkage)
-            .setAnnotations(createClassAnnotations(pakkage, service.isDeprecated(), typeStore))
+            .setAnnotations(createClassAnnotations(service, typeStore))
             .setScope(ScopeNode.PUBLIC)
             .setName(className)
             .setImplementsTypes(createClassImplements(typeStore))
@@ -158,13 +158,12 @@ public class ServiceClientClassComposer implements ClassComposer {
     return GapicClass.create(kind, classDef);
   }
 
-  private static List<AnnotationNode> createClassAnnotations(
-      String pakkage, boolean isDeprecated, TypeStore typeStore) {
+  private static List<AnnotationNode> createClassAnnotations(Service service, TypeStore typeStore) {
     List<AnnotationNode> annotations = new ArrayList<>();
-    if (!PackageChecker.isGaApi(pakkage)) {
+    if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(typeStore.get("BetaApi")));
     }
-    if (isDeprecated) {
+    if (service.isDeprecated()) {
       annotations.add(AnnotationNode.withType(TypeNode.DEPRECATED));
     }
     annotations.add(

--- a/src/main/java/com/google/api/generator/gapic/composer/ServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ServiceStubSettingsClassComposer.java
@@ -106,11 +106,14 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -166,9 +169,15 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
     Map<String, Message> messageTypes = context.messages();
     String pakkage = String.format("%s.stub", service.pakkage());
     TypeStore typeStore = createDynamicTypes(service, pakkage);
+
+    Set<String> deprecatedSettingVarNames = new HashSet<>();
     Map<String, VariableExpr> methodSettingsMemberVarExprs =
         createMethodSettingsClassMemberVarExprs(
-            service, serviceConfig, typeStore, /* isNestedClass= */ false);
+            service,
+            serviceConfig,
+            typeStore,
+            /* isNestedClass= */ false,
+            deprecatedSettingVarNames);
     String className = ClassNames.getServiceStubSettingsClassName(service);
 
     ClassDefinition classDef =
@@ -176,25 +185,32 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
             .setPackageString(pakkage)
             .setHeaderCommentStatements(
                 createClassHeaderComments(service, typeStore.get(className)))
-            .setAnnotations(createClassAnnotations(service.pakkage()))
+            .setAnnotations(createClassAnnotations(service))
             .setScope(ScopeNode.PUBLIC)
             .setName(className)
             .setExtendsType(createExtendsType(service, typeStore))
             .setStatements(
                 createClassStatements(
                     service, serviceConfig, methodSettingsMemberVarExprs, messageTypes, typeStore))
-            .setMethods(createClassMethods(service, methodSettingsMemberVarExprs, typeStore))
+            .setMethods(
+                createClassMethods(
+                    service, methodSettingsMemberVarExprs, deprecatedSettingVarNames, typeStore))
             .setNestedClasses(
                 Arrays.asList(createNestedBuilderClass(service, serviceConfig, typeStore)))
             .build();
     return GapicClass.create(GapicClass.Kind.STUB, classDef);
   }
 
-  private static List<AnnotationNode> createClassAnnotations(String pakkage) {
+  private static List<AnnotationNode> createClassAnnotations(Service service) {
     List<AnnotationNode> annotations = new ArrayList<>();
-    if (!PackageChecker.isGaApi(pakkage)) {
+    if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("BetaApi")));
     }
+
+    if (service.isDeprecated()) {
+      annotations.add(AnnotationNode.withType(TypeNode.DEPRECATED));
+    }
+
     annotations.add(
         AnnotationNode.builder()
             .setType(FIXED_TYPESTORE.get("Generated"))
@@ -224,6 +240,7 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
     return SettingsCommentComposer.createClassHeaderComments(
         ClassNames.getServiceStubClassName(service),
         service.defaultHost(),
+        service.isDeprecated(),
         methodNameOpt,
         sampleCodeOpt,
         classType);
@@ -242,7 +259,8 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
       Service service,
       GapicServiceConfig serviceConfig,
       TypeStore typeStore,
-      boolean isNestedClass) {
+      boolean isNestedClass,
+      Set<String> deprecatedSettingVarNames) {
     // Maintain insertion order.
     Map<String, VariableExpr> varExprs = new LinkedHashMap<>();
 
@@ -254,6 +272,9 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
       TypeNode settingsType =
           getCallSettingsType(method, typeStore, hasBatchingSettings, isNestedClass);
       String varName = JavaStyle.toLowerCamelCase(String.format("%sSettings", method.name()));
+      if (method.isDeprecated()) {
+        deprecatedSettingVarNames.add(varName);
+      }
       varExprs.put(
           varName,
           VariableExpr.withVariable(
@@ -748,9 +769,11 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
   private static List<MethodDefinition> createClassMethods(
       Service service,
       Map<String, VariableExpr> methodSettingsMemberVarExprs,
+      Set<String> deprecatedSettingVarNames,
       TypeStore typeStore) {
     List<MethodDefinition> javaMethods = new ArrayList<>();
-    javaMethods.addAll(createMethodSettingsGetterMethods(methodSettingsMemberVarExprs));
+    javaMethods.addAll(
+        createMethodSettingsGetterMethods(methodSettingsMemberVarExprs, deprecatedSettingVarNames));
     javaMethods.add(createCreateStubMethod(service, typeStore));
     javaMethods.addAll(createDefaultHelperAndGetterMethods(service, typeStore));
     javaMethods.addAll(createBuilderHelperMethods(service, typeStore));
@@ -759,18 +782,25 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
   }
 
   private static List<MethodDefinition> createMethodSettingsGetterMethods(
-      Map<String, VariableExpr> methodSettingsMemberVarExprs) {
+      Map<String, VariableExpr> methodSettingsMemberVarExprs,
+      final Set<String> deprecatedSettingVarNames) {
     Function<Map.Entry<String, VariableExpr>, MethodDefinition> varToMethodFn =
-        e ->
-            MethodDefinition.builder()
-                .setHeaderCommentStatements(
-                    SettingsCommentComposer.createCallSettingsGetterComment(
-                        getMethodNameFromSettingsVarName(e.getKey())))
-                .setScope(ScopeNode.PUBLIC)
-                .setReturnType(e.getValue().type())
-                .setName(e.getKey())
-                .setReturnExpr(e.getValue())
-                .build();
+        e -> {
+          boolean isDeprecated = deprecatedSettingVarNames.contains(e.getKey());
+          return MethodDefinition.builder()
+              .setHeaderCommentStatements(
+                  SettingsCommentComposer.createCallSettingsGetterComment(
+                      getMethodNameFromSettingsVarName(e.getKey()), isDeprecated))
+              .setAnnotations(
+                  isDeprecated
+                      ? Arrays.asList(AnnotationNode.withType(TypeNode.DEPRECATED))
+                      : Collections.emptyList())
+              .setScope(ScopeNode.PUBLIC)
+              .setReturnType(e.getValue().type())
+              .setName(e.getKey())
+              .setReturnExpr(e.getValue())
+              .build();
+        };
     return methodSettingsMemberVarExprs.entrySet().stream()
         .map(e -> varToMethodFn.apply(e))
         .collect(Collectors.toList());
@@ -1173,9 +1203,14 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
                         .collect(Collectors.toList()))
                 .build());
 
+    Set<String> nestedDeprecatedSettingVarNames = new HashSet<>();
     Map<String, VariableExpr> nestedMethodSettingsMemberVarExprs =
         createMethodSettingsClassMemberVarExprs(
-            service, serviceConfig, typeStore, /* isNestedClass= */ true);
+            service,
+            serviceConfig,
+            typeStore,
+            /* isNestedClass= */ true,
+            nestedDeprecatedSettingVarNames);
 
     // TODO(miraleung): Fill this out.
     return ClassDefinition.builder()
@@ -1191,7 +1226,12 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
             createNestedClassStatements(service, serviceConfig, nestedMethodSettingsMemberVarExprs))
         .setMethods(
             createNestedClassMethods(
-                service, serviceConfig, extendsType, nestedMethodSettingsMemberVarExprs, typeStore))
+                service,
+                serviceConfig,
+                extendsType,
+                nestedMethodSettingsMemberVarExprs,
+                nestedDeprecatedSettingVarNames,
+                typeStore))
         .build();
   }
 
@@ -1250,6 +1290,7 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
       GapicServiceConfig serviceConfig,
       TypeNode superType,
       Map<String, VariableExpr> nestedMethodSettingsMemberVarExprs,
+      Set<String> nestedDeprecatedSettingVarNames,
       TypeStore typeStore) {
     List<MethodDefinition> nestedClassMethods = new ArrayList<>();
     nestedClassMethods.addAll(
@@ -1260,7 +1301,8 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
     nestedClassMethods.add(createNestedClassApplyToAllUnaryMethodsMethod(superType, typeStore));
     nestedClassMethods.add(createNestedClassUnaryMethodSettingsBuilderGetterMethod());
     nestedClassMethods.addAll(
-        createNestedClassSettingsBuilderGetterMethods(nestedMethodSettingsMemberVarExprs));
+        createNestedClassSettingsBuilderGetterMethods(
+            nestedMethodSettingsMemberVarExprs, nestedDeprecatedSettingVarNames));
     nestedClassMethods.add(createNestedClassBuildMethod(service, typeStore));
     return nestedClassMethods;
   }
@@ -1732,7 +1774,8 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
   }
 
   private static List<MethodDefinition> createNestedClassSettingsBuilderGetterMethods(
-      Map<String, VariableExpr> nestedMethodSettingsMemberVarExprs) {
+      Map<String, VariableExpr> nestedMethodSettingsMemberVarExprs,
+      Set<String> nestedDeprecatedSettingVarNames) {
     Reference operationCallSettingsBuilderRef =
         ConcreteReference.withClazz(OperationCallSettings.Builder.class);
     Function<TypeNode, Boolean> isOperationCallSettingsBuilderFn =
@@ -1740,14 +1783,14 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
             t.reference()
                 .copyAndSetGenerics(ImmutableList.of())
                 .equals(operationCallSettingsBuilderRef);
-    List<AnnotationNode> lroBetaAnnotations =
-        Arrays.asList(
-            AnnotationNode.builder()
-                .setType(FIXED_TYPESTORE.get("BetaApi"))
-                .setDescription(
-                    "The surface for use by generated code is not stable yet and may change in the"
-                        + " future.")
-                .build());
+    AnnotationNode lroBetaAnnotation =
+        AnnotationNode.builder()
+            .setType(FIXED_TYPESTORE.get("BetaApi"))
+            .setDescription(
+                "The surface for use by generated code is not stable yet and may change in the"
+                    + " future.")
+            .build();
+    AnnotationNode deprecatedAnnotation = AnnotationNode.withType(TypeNode.DEPRECATED);
 
     List<MethodDefinition> javaMethods = new ArrayList<>();
     for (Map.Entry<String, VariableExpr> settingsVarEntry :
@@ -1756,12 +1799,23 @@ public class ServiceStubSettingsClassComposer implements ClassComposer {
       VariableExpr settingsVarExpr = settingsVarEntry.getValue();
       boolean isOperationCallSettings =
           isOperationCallSettingsBuilderFn.apply(settingsVarExpr.type());
+
+      List<AnnotationNode> annotations = new ArrayList<>();
+      if (isOperationCallSettings) {
+        annotations.add(lroBetaAnnotation);
+      }
+
+      boolean isDeprecated = nestedDeprecatedSettingVarNames.contains(varName);
+      if (isDeprecated) {
+        annotations.add(deprecatedAnnotation);
+      }
+
       javaMethods.add(
           MethodDefinition.builder()
               .setHeaderCommentStatements(
                   SettingsCommentComposer.createCallSettingsBuilderGetterComment(
-                      getMethodNameFromSettingsVarName(varName)))
-              .setAnnotations(isOperationCallSettings ? lroBetaAnnotations : ImmutableList.of())
+                      getMethodNameFromSettingsVarName(varName), isDeprecated))
+              .setAnnotations(annotations)
               .setScope(ScopeNode.PUBLIC)
               .setReturnType(settingsVarExpr.type())
               .setName(settingsVarExpr.variable().identifier().name())

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/CommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/CommentComposer.java
@@ -37,6 +37,12 @@ public class CommentComposer {
   private static final String AUTO_GENERATED_METHOD_DISCLAIMER_STRING =
       "AUTO-GENERATED DOCUMENTATION AND METHOD.";
 
+  static final String DEPRECATED_CLASS_STRING =
+      "This class is deprecated and will be removed in the next major version update.";
+
+  static final String DEPRECATED_METHOD_STRING =
+      "This method is deprecated and will be removed in the next major version update.";
+
   public static final CommentStatement APACHE_LICENSE_COMMENT =
       CommentStatement.withComment(BlockComment.withComment(APACHE_LICENSE_STRING));
 

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -150,6 +150,10 @@ public class ServiceClientCommentComposer {
 
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_SAMPLE_REFERENCE_STRING);
 
+    if (service.isDeprecated()) {
+      classHeaderJavadocBuilder.setDeprecated(CommentComposer.DEPRECATED_CLASS_STRING);
+    }
+
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,
         CommentStatement.withComment(classHeaderJavadocBuilder.build()));
@@ -190,11 +194,16 @@ public class ServiceClientCommentComposer {
 
     methodJavadocBuilder.setThrows(API_EXCEPTION_TYPE_NAME, EXCEPTION_CONDITION);
 
+    if (method.isDeprecated()) {
+      methodJavadocBuilder.setDeprecated(CommentComposer.DEPRECATED_METHOD_STRING);
+    }
+
     List<CommentStatement> comments = new ArrayList<>();
     comments.add(CommentComposer.AUTO_GENERATED_METHOD_COMMENT);
     if (!methodJavadocBuilder.emptyComments()) {
       comments.add(CommentStatement.withComment(methodJavadocBuilder.build()));
     }
+
     return comments;
   }
 
@@ -227,6 +236,10 @@ public class ServiceClientCommentComposer {
     methodJavadocBuilder.addParagraph(METHOD_DESCRIPTION_SAMPLE_CODE_SUMMARY_STRING);
     if (sampleCodeOpt.isPresent()) {
       methodJavadocBuilder.addSampleCode(sampleCodeOpt.get());
+    }
+
+    if (method.isDeprecated()) {
+      methodJavadocBuilder.setDeprecated(CommentComposer.DEPRECATED_METHOD_STRING);
     }
 
     return Arrays.asList(

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/SettingsCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/SettingsCommentComposer.java
@@ -90,21 +90,30 @@ public class SettingsCommentComposer {
           .map(c -> CommentStatement.withComment(c))
           .collect(Collectors.toList());
 
-  public static CommentStatement createCallSettingsGetterComment(String javaMethodName) {
-    return toSimpleComment(String.format(CALL_SETTINGS_METHOD_DOC_PATTERN, javaMethodName));
+  public static CommentStatement createCallSettingsGetterComment(
+      String javaMethodName, boolean isMethodDeprecated) {
+    String methodComment = String.format(CALL_SETTINGS_METHOD_DOC_PATTERN, javaMethodName);
+    return isMethodDeprecated
+        ? toDeprecatedSimpleComment(methodComment)
+        : toSimpleComment(methodComment);
   }
 
   public static CommentStatement createBuilderClassComment(String outerClassName) {
     return toSimpleComment(String.format(BUILDER_CLASS_DOC_PATTERN, outerClassName));
   }
 
-  public static CommentStatement createCallSettingsBuilderGetterComment(String javaMethodName) {
-    return toSimpleComment(String.format(CALL_SETTINGS_BUILDER_METHOD_DOC_PATTERN, javaMethodName));
+  public static CommentStatement createCallSettingsBuilderGetterComment(
+      String javaMethodName, boolean isMethodDeprecated) {
+    String methodComment = String.format(CALL_SETTINGS_BUILDER_METHOD_DOC_PATTERN, javaMethodName);
+    return isMethodDeprecated
+        ? toDeprecatedSimpleComment(methodComment)
+        : toSimpleComment(methodComment);
   }
 
   public static List<CommentStatement> createClassHeaderComments(
       String configuredClassName,
       String defaultHost,
+      boolean isDeprecated,
       Optional<String> methodNameOpt,
       Optional<String> sampleCodeOpt,
       TypeNode classType) {
@@ -141,6 +150,10 @@ public class SettingsCommentComposer {
               .addSampleCode(sampleCodeOpt.get());
     }
 
+    if (isDeprecated) {
+      javaDocCommentBuilder.setDeprecated(CommentComposer.DEPRECATED_CLASS_STRING);
+    }
+
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,
         CommentStatement.withComment(javaDocCommentBuilder.build()));
@@ -148,5 +161,13 @@ public class SettingsCommentComposer {
 
   private static CommentStatement toSimpleComment(String comment) {
     return CommentStatement.withComment(JavaDocComment.withComment(comment));
+  }
+
+  private static CommentStatement toDeprecatedSimpleComment(String comment) {
+    return CommentStatement.withComment(
+        JavaDocComment.builder()
+            .addComment(comment)
+            .setDeprecated(CommentComposer.DEPRECATED_METHOD_STRING)
+            .build());
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/StubCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/StubCommentComposer.java
@@ -32,33 +32,49 @@ public class StubCommentComposer {
       "This class is for advanced usage and reflects the underlying API directly.";
 
   public static List<CommentStatement> createGrpcServiceStubClassHeaderComments(
-      String serviceName) {
+      String serviceName, boolean isDeprecated) {
+    JavaDocComment.Builder javaDocBuilder = JavaDocComment.builder();
+    if (isDeprecated) {
+      javaDocBuilder = javaDocBuilder.setDeprecated(CommentComposer.DEPRECATED_CLASS_STRING);
+    }
+
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,
         CommentStatement.withComment(
-            JavaDocComment.builder()
+            javaDocBuilder
                 .addComment(String.format(GRPC_STUB_CLASS_HEADER_SUMMARY_PATTERN, serviceName))
                 .addParagraph(ADVANCED_USAGE_API_REFLECTION_DESCRIPTION)
                 .build()));
   }
 
   public static List<CommentStatement> createGrpcServiceCallableFactoryClassHeaderComments(
-      String serviceName) {
+      String serviceName, boolean isDeprecated) {
+    JavaDocComment.Builder javaDocBuilder = JavaDocComment.builder();
+    if (isDeprecated) {
+      javaDocBuilder = javaDocBuilder.setDeprecated(CommentComposer.DEPRECATED_CLASS_STRING);
+    }
+
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,
         CommentStatement.withComment(
-            JavaDocComment.builder()
+            javaDocBuilder
                 .addComment(
                     String.format(GRPC_CALLABLE_FACTORY_CLASS_HEADER_SUMMARY_PATTERN, serviceName))
                 .addParagraph(ADVANCED_USAGE_DESCRIPTION)
                 .build()));
   }
 
-  public static List<CommentStatement> createServiceStubClassHeaderComments(String serviceName) {
+  public static List<CommentStatement> createServiceStubClassHeaderComments(
+      String serviceName, boolean isDeprecated) {
+    JavaDocComment.Builder javaDocBuilder = JavaDocComment.builder();
+    if (isDeprecated) {
+      javaDocBuilder = javaDocBuilder.setDeprecated(CommentComposer.DEPRECATED_CLASS_STRING);
+    }
+
     return Arrays.asList(
         CommentComposer.AUTO_GENERATED_CLASS_COMMENT,
         CommentStatement.withComment(
-            JavaDocComment.builder()
+            javaDocBuilder
                 .addComment(String.format(STUB_CLASS_HEADER_SUMMARY_PATTERN, serviceName))
                 .addParagraph(ADVANCED_USAGE_API_REFLECTION_DESCRIPTION)
                 .build()));

--- a/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -41,6 +41,8 @@ public abstract class Method {
 
   public abstract boolean isPaged();
 
+  public abstract boolean isDeprecated();
+
   @Nullable
   public abstract LongrunningOperation lro();
 
@@ -83,7 +85,8 @@ public abstract class Method {
         .setMethodSignatures(ImmutableList.of())
         .setHttpBindings(ImmutableList.of())
         .setIsBatching(false)
-        .setIsPaged(false);
+        .setIsPaged(false)
+        .setIsDeprecated(false);
   }
 
   public static Stream toStream(boolean isClientStreaming, boolean isServerStreaming) {
@@ -122,6 +125,8 @@ public abstract class Method {
     public abstract Builder setIsBatching(boolean isBatching);
 
     public abstract Builder setIsPaged(boolean isPaged);
+
+    public abstract Builder setIsDeprecated(boolean isDeprecated);
 
     public abstract Method build();
   }

--- a/src/main/java/com/google/api/generator/gapic/model/Service.java
+++ b/src/main/java/com/google/api/generator/gapic/model/Service.java
@@ -38,6 +38,8 @@ public abstract class Service {
   // New Java class name as defined in gapic.yaml's language settings.
   public abstract String overriddenName();
 
+  public abstract boolean isDeprecated();
+
   public abstract ImmutableList<Method> methods();
 
   @Nullable
@@ -50,7 +52,7 @@ public abstract class Service {
   public abstract Builder toBuilder();
 
   public static Builder builder() {
-    return new AutoValue_Service.Builder().setMethods(ImmutableList.of());
+    return new AutoValue_Service.Builder().setMethods(ImmutableList.of()).setIsDeprecated(false);
   }
 
   @AutoValue.Builder
@@ -68,6 +70,8 @@ public abstract class Service {
     public abstract Builder setProtoPakkage(String pakkage);
 
     public abstract Builder setOriginalJavaPackage(String originalJavaPackage);
+
+    public abstract Builder setIsDeprecated(boolean isDeprecated);
 
     public abstract Builder setMethods(List<Method> methods);
 

--- a/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -341,6 +341,11 @@ public class Parser {
                         serviceOptions.getExtension(ClientProto.oauthScopes).split(COMMA));
               }
 
+              boolean isDeprecated = false;
+              if (serviceOptions.hasDeprecated()) {
+                isDeprecated = serviceOptions.getDeprecated();
+              }
+
               Service.Builder serviceBuilder = Service.builder();
               if (fileDescriptor.toProto().hasSourceCodeInfo()) {
                 SourceCodeInfoLocation protoServiceLocation =
@@ -372,6 +377,7 @@ public class Parser {
                   .setPakkage(pakkage)
                   .setOriginalJavaPackage(originalJavaPackage)
                   .setProtoPakkage(fileDescriptor.getPackage())
+                  .setIsDeprecated(isDeprecated)
                   .setMethods(
                       parseMethods(
                           s,
@@ -542,6 +548,11 @@ public class Parser {
         }
       }
 
+      boolean isDeprecated = false;
+      if (protoMethod.getOptions().hasDeprecated()) {
+        isDeprecated = protoMethod.getOptions().getDeprecated();
+      }
+
       Message inputMessage = messageTypes.get(inputType.reference().simpleName());
       Preconditions.checkNotNull(
           inputMessage,
@@ -579,6 +590,7 @@ public class Parser {
               .setHttpBindings(httpBindings)
               .setIsBatching(isBatching)
               .setIsPaged(parseIsPaged(protoMethod, messageTypes))
+              .setIsDeprecated(isDeprecated)
               .build());
 
       // Any input type that has a resource reference will need a resource name helper class.

--- a/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/composer/BUILD.bazel
@@ -38,6 +38,7 @@ TEST_DEPS = [
     "//src/main/java/com/google/api/generator/gapic/model",
     "//src/main/java/com/google/api/generator/gapic/protoparser",
     "//src/main/java/com/google/api/generator/gapic/composer/defaultvalue",
+    "//src/test/java/com/google/api/generator/gapic/testdata:deprecated_service_java_proto",
     "//src/test/java/com/google/api/generator/gapic/testdata:showcase_java_proto",
     "//src/test/java/com/google/api/generator/gapic/testdata:testgapic_java_proto",
     "//src/test/java/com/google/api/generator/gapic/composer/constants",

--- a/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceCallableFactoryClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceCallableFactoryClassComposerTest.java
@@ -40,4 +40,21 @@ public class GrpcServiceCallableFactoryClassComposerTest {
         Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "GrpcEchoCallableFactory.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
+
+  @Test
+  public void generateServiceClasses_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz =
+        GrpcServiceCallableFactoryClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(
+        this.getClass(), "GrpcDeprecatedServiceCallableFactory.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(
+            ComposerConstants.GOLDENFILES_DIRECTORY, "GrpcDeprecatedServiceCallableFactory.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/GrpcServiceStubClassComposerTest.java
@@ -40,6 +40,20 @@ public class GrpcServiceStubClassComposerTest {
   }
 
   @Test
+  public void generateGrpcServiceStubClass_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "GrpcDeprecatedServiceStub.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "GrpcDeprecatedServiceStub.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
+
+  @Test
   public void generateGrpcServiceStubClass_httpBindings() {
     GapicContext context = TestProtoLoaderUtil.parseShowcaseTesting();
     Service testingProtoService = context.services().get(0);

--- a/src/test/java/com/google/api/generator/gapic/composer/MockServiceClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/MockServiceClassComposerTest.java
@@ -38,4 +38,18 @@ public class MockServiceClassComposerTest {
     Path goldenFilePath = Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "MockEcho.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
+
+  @Test
+  public void generateServiceClasses_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "MockDeprecatedService.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "MockDeprecatedService.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/MockServiceImplClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/MockServiceImplClassComposerTest.java
@@ -38,4 +38,18 @@ public class MockServiceImplClassComposerTest {
     Path goldenFilePath = Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "MockEchoImpl.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
+
+  @Test
+  public void generateServiceClasses_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "MockDeprecatedServiceImpl.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "MockDeprecatedServiceImpl.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceClientClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceClientClassComposerTest.java
@@ -41,6 +41,20 @@ public class ServiceClientClassComposerTest {
   }
 
   @Test
+  public void generateServiceClasses_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "DeprecatedServiceClient.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "DeprecatedServiceClient.golden");
+    assertCodeEquals(goldenFilePath, visitor.write());
+  }
+
+  @Test
   public void generateServiceClasses_methodSignatureHasNestedFields() {
     GapicContext context = TestProtoLoaderUtil.parseShowcaseIdentity();
     Service protoService = context.services().get(0);

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceClientTestClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceClientTestClassComposerTest.java
@@ -44,6 +44,20 @@ public class ServiceClientTestClassComposerTest {
   }
 
   @Test
+  public void generateClientTest_deprecatedServiceClient() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "DeprecatedServiceClientTest.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "DeprecatedServiceClientTest.golden");
+    assertCodeEquals(goldenFilePath, visitor.write());
+  }
+
+  @Test
   public void generateClientTest_testingClientResnameWithOnePatternWithNonSlashSepNames() {
     GapicContext context = TestProtoLoaderUtil.parseShowcaseTesting();
     Service testingProtoService = context.services().get(0);

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceSettingsClassComposerTest.java
@@ -38,4 +38,18 @@ public class ServiceSettingsClassComposerTest {
     Path goldenFilePath = Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "EchoSettings.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
+
+  @Test
+  public void generateServiceClasses_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "DeprecatedServiceSettings.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "DeprecatedServiceSettings.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceStubClassComposerTest.java
@@ -38,4 +38,18 @@ public class ServiceStubClassComposerTest {
     Path goldenFilePath = Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "EchoStub.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
+
+  @Test
+  public void generateServiceClasses_deprecated() {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(this.getClass(), "DeprecatedServiceStub.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "DeprecatedServiceStub.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/ServiceStubSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ServiceStubSettingsClassComposerTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Paths;
 import org.junit.Test;
 
 public class ServiceStubSettingsClassComposerTest {
-
   @Test
   public void generateServiceStubSettingsClasses_batchingWithEmptyResponses() throws IOException {
     GapicContext context = TestProtoLoaderUtil.parseLogging();
@@ -73,6 +72,21 @@ public class ServiceStubSettingsClassComposerTest {
     Utils.saveCodegenToFile(this.getClass(), "EchoStubSettings.golden", visitor.write());
     Path goldenFilePath =
         Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "EchoStubSettings.golden");
+    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+  }
+
+  @Test
+  public void generateServiceStubSettingsClasses_deprecated() throws IOException {
+    GapicContext context = TestProtoLoaderUtil.parseDeprecatedService();
+    Service protoService = context.services().get(0);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, protoService);
+
+    JavaWriterVisitor visitor = new JavaWriterVisitor();
+    clazz.classDefinition().accept(visitor);
+    Utils.saveCodegenToFile(
+        this.getClass(), "DeprecatedServiceStubSettings.golden", visitor.write());
+    Path goldenFilePath =
+        Paths.get(ComposerConstants.GOLDENFILES_DIRECTORY, "DeprecatedServiceStubSettings.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/TestProtoLoaderUtil.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/TestProtoLoaderUtil.java
@@ -37,6 +37,7 @@ import com.google.pubsub.v1.PubsubProto;
 import com.google.showcase.v1beta1.EchoOuterClass;
 import com.google.showcase.v1beta1.IdentityOuterClass;
 import com.google.showcase.v1beta1.TestingOuterClass;
+import com.google.testdata.v1.DeprecatedServiceOuterClass;
 import google.cloud.CommonResources;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,6 +50,33 @@ import java.util.Optional;
 import java.util.Set;
 
 public class TestProtoLoaderUtil {
+  public static GapicContext parseDeprecatedService() {
+    FileDescriptor fileDescriptor = DeprecatedServiceOuterClass.getDescriptor();
+    ServiceDescriptor serviceDescriptor = fileDescriptor.getServices().get(0);
+    assertEquals(serviceDescriptor.getName(), "DeprecatedService");
+
+    Map<String, Message> messageTypes = Parser.parseMessages(fileDescriptor);
+    Map<String, ResourceName> resourceNames = new HashMap<>();
+    Set<ResourceName> outputResourceNames = new HashSet<>();
+    List<Service> services =
+        Parser.parseService(
+            fileDescriptor, messageTypes, resourceNames, Optional.empty(), outputResourceNames);
+
+    String jsonFilename = "deprecated_service_grpc_service_config.json";
+    Path jsonPath = Paths.get(ComposerConstants.TESTFILES_DIRECTORY, jsonFilename);
+    Optional<GapicServiceConfig> configOpt = ServiceConfigParser.parse(jsonPath.toString());
+    assertTrue(configOpt.isPresent());
+    GapicServiceConfig config = configOpt.get();
+
+    return GapicContext.builder()
+        .setMessages(messageTypes)
+        .setResourceNames(resourceNames)
+        .setServices(services)
+        .setServiceConfig(config)
+        .setHelperResourceNames(outputResourceNames)
+        .build();
+  }
+
   public static GapicContext parseShowcaseEcho() {
     FileDescriptor echoFileDescriptor = EchoOuterClass.getDescriptor();
     ServiceDescriptor echoServiceDescriptor = echoFileDescriptor.getServices().get(0);

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceClient.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceClientTest.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceSettings.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceStub.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceStubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/DeprecatedServiceStubSettings.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/GrpcDeprecatedServiceCallableFactory.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/GrpcDeprecatedServiceCallableFactory.golden
@@ -1,0 +1,100 @@
+package com.google.testdata.v1.stub;
+
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcCallableFactory;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.OperationsStub;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * gRPC callable factory implementation for the DeprecatedService service API.
+ *
+ * <p>This class is for advanced usage.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class GrpcDeprecatedServiceCallableFactory implements GrpcStubCallableFactory {
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      UnaryCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createUnaryCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, PagedListResponseT>
+      UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          PagedCallSettings<RequestT, ResponseT, PagedListResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createPagedCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      BatchingCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createBatchingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          GrpcCallSettings<RequestT, Operation> grpcCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
+          ClientContext clientContext,
+          OperationsStub operationsStub) {
+    return GrpcCallableFactory.createOperationCallable(
+        grpcCallSettings, callSettings, clientContext, operationsStub);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createBidiStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createServerStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createClientStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/GrpcDeprecatedServiceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/GrpcDeprecatedServiceStub.golden
@@ -1,0 +1,155 @@
+package com.google.testdata.v1.stub;
+
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.stub.GrpcOperationsStub;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.FibonacciRequest;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * gRPC stub implementation for the DeprecatedService service API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class GrpcDeprecatedServiceStub extends DeprecatedServiceStub {
+  private static final MethodDescriptor<FibonacciRequest, Empty> fastFibonacciMethodDescriptor =
+      MethodDescriptor.<FibonacciRequest, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.testdata.v1.DeprecatedService/FastFibonacci")
+          .setRequestMarshaller(ProtoUtils.marshaller(FibonacciRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
+
+  private static final MethodDescriptor<FibonacciRequest, Empty> slowFibonacciMethodDescriptor =
+      MethodDescriptor.<FibonacciRequest, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.testdata.v1.DeprecatedService/SlowFibonacci")
+          .setRequestMarshaller(ProtoUtils.marshaller(FibonacciRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Empty.getDefaultInstance()))
+          .build();
+
+  private final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable;
+  private final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable;
+
+  private final BackgroundResource backgroundResources;
+  private final GrpcOperationsStub operationsStub;
+  private final GrpcStubCallableFactory callableFactory;
+
+  public static final GrpcDeprecatedServiceStub create(DeprecatedServiceStubSettings settings)
+      throws IOException {
+    return new GrpcDeprecatedServiceStub(settings, ClientContext.create(settings));
+  }
+
+  public static final GrpcDeprecatedServiceStub create(ClientContext clientContext)
+      throws IOException {
+    return new GrpcDeprecatedServiceStub(
+        DeprecatedServiceStubSettings.newBuilder().build(), clientContext);
+  }
+
+  public static final GrpcDeprecatedServiceStub create(
+      ClientContext clientContext, GrpcStubCallableFactory callableFactory) throws IOException {
+    return new GrpcDeprecatedServiceStub(
+        DeprecatedServiceStubSettings.newBuilder().build(), clientContext, callableFactory);
+  }
+
+  /**
+   * Constructs an instance of GrpcDeprecatedServiceStub, using the given settings. This is
+   * protected so that it is easy to make a subclass, but otherwise, the static factory methods
+   * should be preferred.
+   */
+  protected GrpcDeprecatedServiceStub(
+      DeprecatedServiceStubSettings settings, ClientContext clientContext) throws IOException {
+    this(settings, clientContext, new GrpcDeprecatedServiceCallableFactory());
+  }
+
+  /**
+   * Constructs an instance of GrpcDeprecatedServiceStub, using the given settings. This is
+   * protected so that it is easy to make a subclass, but otherwise, the static factory methods
+   * should be preferred.
+   */
+  protected GrpcDeprecatedServiceStub(
+      DeprecatedServiceStubSettings settings,
+      ClientContext clientContext,
+      GrpcStubCallableFactory callableFactory)
+      throws IOException {
+    this.callableFactory = callableFactory;
+    this.operationsStub = GrpcOperationsStub.create(clientContext, callableFactory);
+
+    GrpcCallSettings<FibonacciRequest, Empty> fastFibonacciTransportSettings =
+        GrpcCallSettings.<FibonacciRequest, Empty>newBuilder()
+            .setMethodDescriptor(fastFibonacciMethodDescriptor)
+            .build();
+    GrpcCallSettings<FibonacciRequest, Empty> slowFibonacciTransportSettings =
+        GrpcCallSettings.<FibonacciRequest, Empty>newBuilder()
+            .setMethodDescriptor(slowFibonacciMethodDescriptor)
+            .build();
+
+    this.fastFibonacciCallable =
+        callableFactory.createUnaryCallable(
+            fastFibonacciTransportSettings, settings.fastFibonacciSettings(), clientContext);
+    this.slowFibonacciCallable =
+        callableFactory.createUnaryCallable(
+            slowFibonacciTransportSettings, settings.slowFibonacciSettings(), clientContext);
+
+    this.backgroundResources =
+        new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+  }
+
+  public GrpcOperationsStub getOperationsStub() {
+    return operationsStub;
+  }
+
+  @Override
+  public UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return fastFibonacciCallable;
+  }
+
+  @Override
+  public UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return slowFibonacciCallable;
+  }
+
+  @Override
+  public final void close() {
+    shutdown();
+  }
+
+  @Override
+  public void shutdown() {
+    backgroundResources.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return backgroundResources.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return backgroundResources.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    backgroundResources.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return backgroundResources.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/MockDeprecatedService.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/MockDeprecatedService.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/goldens/MockDeprecatedServiceImpl.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/goldens/MockDeprecatedServiceImpl.golden
@@ -1,0 +1,234 @@
+package com.google.testdata.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.protobuf.Empty;
+import com.google.testdata.v1.stub.DeprecatedServiceStub;
+import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+ *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+ *   deprecatedServiceClient.fastFibonacci(request);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the DeprecatedServiceClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DeprecatedServiceSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * DeprecatedServiceSettings deprecatedServiceSettings =
+ *     DeprecatedServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DeprecatedServiceClient deprecatedServiceClient =
+ *     DeprecatedServiceClient.create(deprecatedServiceSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ *
+ * @deprecated This class is deprecated and will be removed in the next major version update.
+ */
+@Deprecated
+@Generated("by gapic-generator-java")
+public class DeprecatedServiceClient implements BackgroundResource {
+  private final DeprecatedServiceSettings settings;
+  private final DeprecatedServiceStub stub;
+
+  /** Constructs an instance of DeprecatedServiceClient with default settings. */
+  public static final DeprecatedServiceClient create() throws IOException {
+    return create(DeprecatedServiceSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final DeprecatedServiceClient create(DeprecatedServiceSettings settings)
+      throws IOException {
+    return new DeprecatedServiceClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(DeprecatedServiceSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DeprecatedServiceClient create(DeprecatedServiceStub stub) {
+    return new DeprecatedServiceClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DeprecatedServiceClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected DeprecatedServiceClient(DeprecatedServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DeprecatedServiceStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DeprecatedServiceClient(DeprecatedServiceStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DeprecatedServiceSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DeprecatedServiceStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.fastFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final void fastFibonacci(FibonacciRequest request) {
+    fastFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.fastFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<FibonacciRequest, Empty> fastFibonacciCallable() {
+    return stub.fastFibonacciCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   deprecatedServiceClient.slowFibonacci(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final void slowFibonacci(FibonacciRequest request) {
+    slowFibonacciCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * try (DeprecatedServiceClient deprecatedServiceClient = DeprecatedServiceClient.create()) {
+   *   FibonacciRequest request = FibonacciRequest.newBuilder().setValue(111972721).build();
+   *   ApiFuture<Empty> future = deprecatedServiceClient.slowFibonacciCallable().futureCall(request);
+   *   // Do something.
+   *   future.get();
+   * }
+   * }</pre>
+   *
+   * @deprecated This method is deprecated and will be removed in the next major version update.
+   */
+  @Deprecated
+  public final UnaryCallable<FibonacciRequest, Empty> slowFibonacciCallable() {
+    return stub.slowFibonacciCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/testdata/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/testdata/BUILD.bazel
@@ -56,6 +56,24 @@ proto_library(
 )
 
 proto_library(
+    name = "deprecated_service_proto",
+    srcs = [
+        "deprecated_service.proto",
+    ],
+    deps = [
+        "@com_google_googleapis//google/api:annotations_proto",
+        "@com_google_googleapis//google/api:client_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/longrunning:operations_proto",
+        "@com_google_googleapis//google/rpc:error_details_proto",
+        "@com_google_googleapis//google/rpc:status_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+proto_library(
     name = "testgapic_proto",
     srcs = [
         "bad_message_resname_def.proto",
@@ -75,6 +93,11 @@ proto_library(
         "@com_google_protobuf//:field_mask_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
+)
+
+java_proto_library(
+    name = "deprecated_service_java_proto",
+    deps = [":deprecated_service_proto"],
 )
 
 java_proto_library(

--- a/src/test/java/com/google/api/generator/gapic/testdata/deprecated_service.proto
+++ b/src/test/java/com/google/api/generator/gapic/testdata/deprecated_service.proto
@@ -1,0 +1,49 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/protobuf/empty.proto";
+
+package google.testdata.v1;
+
+option java_package = "com.google.testdata.v1";
+option java_multiple_files = true;
+
+// This is a service description.
+// It takes up multiple lines, like so.
+service DeprecatedService {
+  option (google.api.default_host) = "localhost:7469";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  option deprecated = true;
+
+  // Calculates Fibonacci on the provided value, quickly.
+  rpc FastFibonacci(FibonacciRequest) returns (google.protobuf.Empty);
+
+  // Calculates Fibonacci on the provided value, slowly.
+  rpc SlowFibonacci(FibonacciRequest) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  };
+}
+
+// This is a message descxription.
+// Lorum ipsum dolor sit amet consectetur adipiscing elit.
+message FibonacciRequest {
+  // The nth term to retrieve in the Fibonacci sequence.
+  int32 value = 1;
+}

--- a/src/test/java/com/google/api/generator/gapic/testdata/deprecated_service_grpc_service_config.json
+++ b/src/test/java/com/google/api/generator/gapic/testdata/deprecated_service_grpc_service_config.json
@@ -1,0 +1,8 @@
+{
+  "methodConfig": [
+    {
+      "name": [{"service": "google.testdata.v1.DeprecatedService"}],
+      "timeout": "60s"
+    }
+  ]
+}

--- a/test/integration/goldens/kms/GrpcKeyManagementServiceStub.java
+++ b/test/integration/goldens/kms/GrpcKeyManagementServiceStub.java
@@ -326,25 +326,6 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
           .setResponseMarshaller(ProtoUtils.marshaller(Policy.getDefaultInstance()))
           .build();
 
-  private static final MethodDescriptor<SetIamPolicyRequest, Policy> setIamPolicyMethodDescriptor =
-      MethodDescriptor.<SetIamPolicyRequest, Policy>newBuilder()
-          .setType(MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName("google.iam.v1.IAMPolicy/SetIamPolicy")
-          .setRequestMarshaller(ProtoUtils.marshaller(SetIamPolicyRequest.getDefaultInstance()))
-          .setResponseMarshaller(ProtoUtils.marshaller(Policy.getDefaultInstance()))
-          .build();
-
-  private static final MethodDescriptor<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsMethodDescriptor =
-          MethodDescriptor.<TestIamPermissionsRequest, TestIamPermissionsResponse>newBuilder()
-              .setType(MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName("google.iam.v1.IAMPolicy/TestIamPermissions")
-              .setRequestMarshaller(
-                  ProtoUtils.marshaller(TestIamPermissionsRequest.getDefaultInstance()))
-              .setResponseMarshaller(
-                  ProtoUtils.marshaller(TestIamPermissionsResponse.getDefaultInstance()))
-              .build();
-
   private static final MethodDescriptor<ListLocationsRequest, ListLocationsResponse>
       listLocationsMethodDescriptor =
           MethodDescriptor.<ListLocationsRequest, ListLocationsResponse>newBuilder()
@@ -363,6 +344,25 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
           .setRequestMarshaller(ProtoUtils.marshaller(GetLocationRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Location.getDefaultInstance()))
           .build();
+
+  private static final MethodDescriptor<SetIamPolicyRequest, Policy> setIamPolicyMethodDescriptor =
+      MethodDescriptor.<SetIamPolicyRequest, Policy>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.iam.v1.IAMPolicy/SetIamPolicy")
+          .setRequestMarshaller(ProtoUtils.marshaller(SetIamPolicyRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Policy.getDefaultInstance()))
+          .build();
+
+  private static final MethodDescriptor<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsMethodDescriptor =
+          MethodDescriptor.<TestIamPermissionsRequest, TestIamPermissionsResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.iam.v1.IAMPolicy/TestIamPermissions")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(TestIamPermissionsRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(TestIamPermissionsResponse.getDefaultInstance()))
+              .build();
 
   private final UnaryCallable<ListKeyRingsRequest, ListKeyRingsResponse> listKeyRingsCallable;
   private final UnaryCallable<ListKeyRingsRequest, ListKeyRingsPagedResponse>
@@ -405,13 +405,13 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
   private final UnaryCallable<RestoreCryptoKeyVersionRequest, CryptoKeyVersion>
       restoreCryptoKeyVersionCallable;
   private final UnaryCallable<GetIamPolicyRequest, Policy> getIamPolicyCallable;
-  private final UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable;
-  private final UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsCallable;
   private final UnaryCallable<ListLocationsRequest, ListLocationsResponse> listLocationsCallable;
   private final UnaryCallable<ListLocationsRequest, ListLocationsPagedResponse>
       listLocationsPagedCallable;
   private final UnaryCallable<GetLocationRequest, Location> getLocationCallable;
+  private final UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable;
+  private final UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable;
 
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
@@ -785,6 +785,32 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
                   }
                 })
             .build();
+    GrpcCallSettings<ListLocationsRequest, ListLocationsResponse> listLocationsTransportSettings =
+        GrpcCallSettings.<ListLocationsRequest, ListLocationsResponse>newBuilder()
+            .setMethodDescriptor(listLocationsMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<ListLocationsRequest>() {
+                  @Override
+                  public Map<String, String> extract(ListLocationsRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
+            .build();
+    GrpcCallSettings<GetLocationRequest, Location> getLocationTransportSettings =
+        GrpcCallSettings.<GetLocationRequest, Location>newBuilder()
+            .setMethodDescriptor(getLocationMethodDescriptor)
+            .setParamsExtractor(
+                new RequestParamsExtractor<GetLocationRequest>() {
+                  @Override
+                  public Map<String, String> extract(GetLocationRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    return params.build();
+                  }
+                })
+            .build();
     GrpcCallSettings<SetIamPolicyRequest, Policy> setIamPolicyTransportSettings =
         GrpcCallSettings.<SetIamPolicyRequest, Policy>newBuilder()
             .setMethodDescriptor(setIamPolicyMethodDescriptor)
@@ -812,32 +838,6 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
                       }
                     })
                 .build();
-    GrpcCallSettings<ListLocationsRequest, ListLocationsResponse> listLocationsTransportSettings =
-        GrpcCallSettings.<ListLocationsRequest, ListLocationsResponse>newBuilder()
-            .setMethodDescriptor(listLocationsMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<ListLocationsRequest>() {
-                  @Override
-                  public Map<String, String> extract(ListLocationsRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
-            .build();
-    GrpcCallSettings<GetLocationRequest, Location> getLocationTransportSettings =
-        GrpcCallSettings.<GetLocationRequest, Location>newBuilder()
-            .setMethodDescriptor(getLocationMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<GetLocationRequest>() {
-                  @Override
-                  public Map<String, String> extract(GetLocationRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    return params.build();
-                  }
-                })
-            .build();
 
     this.listKeyRingsCallable =
         callableFactory.createUnaryCallable(
@@ -943,14 +943,6 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
     this.getIamPolicyCallable =
         callableFactory.createUnaryCallable(
             getIamPolicyTransportSettings, settings.getIamPolicySettings(), clientContext);
-    this.setIamPolicyCallable =
-        callableFactory.createUnaryCallable(
-            setIamPolicyTransportSettings, settings.setIamPolicySettings(), clientContext);
-    this.testIamPermissionsCallable =
-        callableFactory.createUnaryCallable(
-            testIamPermissionsTransportSettings,
-            settings.testIamPermissionsSettings(),
-            clientContext);
     this.listLocationsCallable =
         callableFactory.createUnaryCallable(
             listLocationsTransportSettings, settings.listLocationsSettings(), clientContext);
@@ -960,6 +952,14 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
     this.getLocationCallable =
         callableFactory.createUnaryCallable(
             getLocationTransportSettings, settings.getLocationSettings(), clientContext);
+    this.setIamPolicyCallable =
+        callableFactory.createUnaryCallable(
+            setIamPolicyTransportSettings, settings.setIamPolicySettings(), clientContext);
+    this.testIamPermissionsCallable =
+        callableFactory.createUnaryCallable(
+            testIamPermissionsTransportSettings,
+            settings.testIamPermissionsSettings(),
+            clientContext);
 
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -1121,17 +1121,6 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
   }
 
   @Override
-  public UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
-    return setIamPolicyCallable;
-  }
-
-  @Override
-  public UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsCallable() {
-    return testIamPermissionsCallable;
-  }
-
-  @Override
   public UnaryCallable<ListLocationsRequest, ListLocationsResponse> listLocationsCallable() {
     return listLocationsCallable;
   }
@@ -1145,6 +1134,17 @@ public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
   @Override
   public UnaryCallable<GetLocationRequest, Location> getLocationCallable() {
     return getLocationCallable;
+  }
+
+  @Override
+  public UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
+    return setIamPolicyCallable;
+  }
+
+  @Override
+  public UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable() {
+    return testIamPermissionsCallable;
   }
 
   @Override

--- a/test/integration/goldens/kms/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/KeyManagementServiceClient.java
@@ -3197,117 +3197,6 @@ public class KeyManagementServiceClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Sets the access control policy on the specified resource. Replaces any existing policy.
-   *
-   * <p>Sample code:
-   *
-   * <pre>{@code
-   * try (KeyManagementServiceClient keyManagementServiceClient =
-   *     KeyManagementServiceClient.create()) {
-   *   SetIamPolicyRequest request =
-   *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-   *           .setPolicy(Policy.newBuilder().build())
-   *           .build();
-   *   Policy response = keyManagementServiceClient.setIamPolicy(request);
-   * }
-   * }</pre>
-   *
-   * @param request The request object containing all of the parameters for the API call.
-   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
-   */
-  public final Policy setIamPolicy(SetIamPolicyRequest request) {
-    return setIamPolicyCallable().call(request);
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD.
-  /**
-   * Sets the access control policy on the specified resource. Replaces any existing policy.
-   *
-   * <p>Sample code:
-   *
-   * <pre>{@code
-   * try (KeyManagementServiceClient keyManagementServiceClient =
-   *     KeyManagementServiceClient.create()) {
-   *   SetIamPolicyRequest request =
-   *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-   *           .setPolicy(Policy.newBuilder().build())
-   *           .build();
-   *   ApiFuture<Policy> future =
-   *       keyManagementServiceClient.setIamPolicyCallable().futureCall(request);
-   *   // Do something.
-   *   Policy response = future.get();
-   * }
-   * }</pre>
-   */
-  public final UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
-    return stub.setIamPolicyCallable();
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD.
-  /**
-   * Returns permissions that a caller has on the specified resource. If the resource does not
-   * exist, this will return an empty set of permissions, not a NOT_FOUND error.
-   *
-   * <p>Note: This operation is designed to be used for building permission-aware UIs and
-   * command-line tools, not for authorization checking. This operation may "fail open" without
-   * warning.
-   *
-   * <p>Sample code:
-   *
-   * <pre>{@code
-   * try (KeyManagementServiceClient keyManagementServiceClient =
-   *     KeyManagementServiceClient.create()) {
-   *   TestIamPermissionsRequest request =
-   *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-   *           .addAllPermissions(new ArrayList<String>())
-   *           .build();
-   *   TestIamPermissionsResponse response = keyManagementServiceClient.testIamPermissions(request);
-   * }
-   * }</pre>
-   *
-   * @param request The request object containing all of the parameters for the API call.
-   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
-   */
-  public final TestIamPermissionsResponse testIamPermissions(TestIamPermissionsRequest request) {
-    return testIamPermissionsCallable().call(request);
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD.
-  /**
-   * Returns permissions that a caller has on the specified resource. If the resource does not
-   * exist, this will return an empty set of permissions, not a NOT_FOUND error.
-   *
-   * <p>Note: This operation is designed to be used for building permission-aware UIs and
-   * command-line tools, not for authorization checking. This operation may "fail open" without
-   * warning.
-   *
-   * <p>Sample code:
-   *
-   * <pre>{@code
-   * try (KeyManagementServiceClient keyManagementServiceClient =
-   *     KeyManagementServiceClient.create()) {
-   *   TestIamPermissionsRequest request =
-   *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-   *           .addAllPermissions(new ArrayList<String>())
-   *           .build();
-   *   ApiFuture<TestIamPermissionsResponse> future =
-   *       keyManagementServiceClient.testIamPermissionsCallable().futureCall(request);
-   *   // Do something.
-   *   TestIamPermissionsResponse response = future.get();
-   * }
-   * }</pre>
-   */
-  public final UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsCallable() {
-    return stub.testIamPermissionsCallable();
-  }
-
-  // AUTO-GENERATED DOCUMENTATION AND METHOD.
-  /**
    * Lists information about the supported locations for this service.
    *
    * <p>Sample code:
@@ -3441,6 +3330,117 @@ public class KeyManagementServiceClient implements BackgroundResource {
    */
   public final UnaryCallable<GetLocationRequest, Location> getLocationCallable() {
     return stub.getLocationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sets the access control policy on the specified resource. Replaces any existing policy.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (KeyManagementServiceClient keyManagementServiceClient =
+   *     KeyManagementServiceClient.create()) {
+   *   SetIamPolicyRequest request =
+   *       SetIamPolicyRequest.newBuilder()
+   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+   *           .setPolicy(Policy.newBuilder().build())
+   *           .build();
+   *   Policy response = keyManagementServiceClient.setIamPolicy(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Policy setIamPolicy(SetIamPolicyRequest request) {
+    return setIamPolicyCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sets the access control policy on the specified resource. Replaces any existing policy.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (KeyManagementServiceClient keyManagementServiceClient =
+   *     KeyManagementServiceClient.create()) {
+   *   SetIamPolicyRequest request =
+   *       SetIamPolicyRequest.newBuilder()
+   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+   *           .setPolicy(Policy.newBuilder().build())
+   *           .build();
+   *   ApiFuture<Policy> future =
+   *       keyManagementServiceClient.setIamPolicyCallable().futureCall(request);
+   *   // Do something.
+   *   Policy response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
+    return stub.setIamPolicyCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Returns permissions that a caller has on the specified resource. If the resource does not
+   * exist, this will return an empty set of permissions, not a NOT_FOUND error.
+   *
+   * <p>Note: This operation is designed to be used for building permission-aware UIs and
+   * command-line tools, not for authorization checking. This operation may "fail open" without
+   * warning.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (KeyManagementServiceClient keyManagementServiceClient =
+   *     KeyManagementServiceClient.create()) {
+   *   TestIamPermissionsRequest request =
+   *       TestIamPermissionsRequest.newBuilder()
+   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+   *           .addAllPermissions(new ArrayList<String>())
+   *           .build();
+   *   TestIamPermissionsResponse response = keyManagementServiceClient.testIamPermissions(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final TestIamPermissionsResponse testIamPermissions(TestIamPermissionsRequest request) {
+    return testIamPermissionsCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Returns permissions that a caller has on the specified resource. If the resource does not
+   * exist, this will return an empty set of permissions, not a NOT_FOUND error.
+   *
+   * <p>Note: This operation is designed to be used for building permission-aware UIs and
+   * command-line tools, not for authorization checking. This operation may "fail open" without
+   * warning.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (KeyManagementServiceClient keyManagementServiceClient =
+   *     KeyManagementServiceClient.create()) {
+   *   TestIamPermissionsRequest request =
+   *       TestIamPermissionsRequest.newBuilder()
+   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+   *           .addAllPermissions(new ArrayList<String>())
+   *           .build();
+   *   ApiFuture<TestIamPermissionsResponse> future =
+   *       keyManagementServiceClient.testIamPermissionsCallable().futureCall(request);
+   *   // Do something.
+   *   TestIamPermissionsResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable() {
+    return stub.testIamPermissionsCallable();
   }
 
   @Override

--- a/test/integration/goldens/kms/KeyManagementServiceClientTest.java
+++ b/test/integration/goldens/kms/KeyManagementServiceClientTest.java
@@ -77,12 +77,12 @@ public class KeyManagementServiceClientTest {
   @BeforeClass
   public static void startStaticServer() {
     mockKeyManagementService = new MockKeyManagementService();
-    mockIAMPolicy = new MockIAMPolicy();
     mockLocations = new MockLocations();
+    mockIAMPolicy = new MockIAMPolicy();
     mockServiceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
-            Arrays.<MockGrpcService>asList(mockKeyManagementService, mockIAMPolicy, mockLocations));
+            Arrays.<MockGrpcService>asList(mockKeyManagementService, mockLocations, mockIAMPolicy));
     mockServiceHelper.start();
   }
 
@@ -2274,100 +2274,6 @@ public class KeyManagementServiceClientTest {
   }
 
   @Test
-  public void setIamPolicyTest() throws Exception {
-    Policy expectedResponse =
-        Policy.newBuilder()
-            .setVersion(351608024)
-            .addAllBindings(new ArrayList<Binding>())
-            .setEtag(ByteString.EMPTY)
-            .build();
-    mockIAMPolicy.addResponse(expectedResponse);
-
-    SetIamPolicyRequest request =
-        SetIamPolicyRequest.newBuilder()
-            .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-            .setPolicy(Policy.newBuilder().build())
-            .build();
-
-    Policy actualResponse = client.setIamPolicy(request);
-    Assert.assertEquals(expectedResponse, actualResponse);
-
-    List<AbstractMessage> actualRequests = mockIAMPolicy.getRequests();
-    Assert.assertEquals(1, actualRequests.size());
-    SetIamPolicyRequest actualRequest = ((SetIamPolicyRequest) actualRequests.get(0));
-
-    Assert.assertEquals(request.getResource(), actualRequest.getResource());
-    Assert.assertEquals(request.getPolicy(), actualRequest.getPolicy());
-    Assert.assertTrue(
-        channelProvider.isHeaderSent(
-            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
-  }
-
-  @Test
-  public void setIamPolicyExceptionTest() throws Exception {
-    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
-    mockIAMPolicy.addException(exception);
-
-    try {
-      SetIamPolicyRequest request =
-          SetIamPolicyRequest.newBuilder()
-              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-              .setPolicy(Policy.newBuilder().build())
-              .build();
-      client.setIamPolicy(request);
-      Assert.fail("No exception raised");
-    } catch (InvalidArgumentException e) {
-      // Expected exception.
-    }
-  }
-
-  @Test
-  public void testIamPermissionsTest() throws Exception {
-    TestIamPermissionsResponse expectedResponse =
-        TestIamPermissionsResponse.newBuilder().addAllPermissions(new ArrayList<String>()).build();
-    mockIAMPolicy.addResponse(expectedResponse);
-
-    TestIamPermissionsRequest request =
-        TestIamPermissionsRequest.newBuilder()
-            .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-            .addAllPermissions(new ArrayList<String>())
-            .build();
-
-    TestIamPermissionsResponse actualResponse = client.testIamPermissions(request);
-    Assert.assertEquals(expectedResponse, actualResponse);
-
-    List<AbstractMessage> actualRequests = mockIAMPolicy.getRequests();
-    Assert.assertEquals(1, actualRequests.size());
-    TestIamPermissionsRequest actualRequest = ((TestIamPermissionsRequest) actualRequests.get(0));
-
-    Assert.assertEquals(request.getResource(), actualRequest.getResource());
-    Assert.assertEquals(request.getPermissionsList(), actualRequest.getPermissionsList());
-    Assert.assertTrue(
-        channelProvider.isHeaderSent(
-            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
-  }
-
-  @Test
-  public void testIamPermissionsExceptionTest() throws Exception {
-    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
-    mockIAMPolicy.addException(exception);
-
-    try {
-      TestIamPermissionsRequest request =
-          TestIamPermissionsRequest.newBuilder()
-              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
-              .addAllPermissions(new ArrayList<String>())
-              .build();
-      client.testIamPermissions(request);
-      Assert.fail("No exception raised");
-    } catch (InvalidArgumentException e) {
-      // Expected exception.
-    }
-  }
-
-  @Test
   public void listLocationsTest() throws Exception {
     Location responsesElement = Location.newBuilder().build();
     ListLocationsResponse expectedResponse =
@@ -2462,6 +2368,100 @@ public class KeyManagementServiceClientTest {
     try {
       GetLocationRequest request = GetLocationRequest.newBuilder().setName("name3373707").build();
       client.getLocation(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void setIamPolicyTest() throws Exception {
+    Policy expectedResponse =
+        Policy.newBuilder()
+            .setVersion(351608024)
+            .addAllBindings(new ArrayList<Binding>())
+            .setEtag(ByteString.EMPTY)
+            .build();
+    mockIAMPolicy.addResponse(expectedResponse);
+
+    SetIamPolicyRequest request =
+        SetIamPolicyRequest.newBuilder()
+            .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+            .setPolicy(Policy.newBuilder().build())
+            .build();
+
+    Policy actualResponse = client.setIamPolicy(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockIAMPolicy.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    SetIamPolicyRequest actualRequest = ((SetIamPolicyRequest) actualRequests.get(0));
+
+    Assert.assertEquals(request.getResource(), actualRequest.getResource());
+    Assert.assertEquals(request.getPolicy(), actualRequest.getPolicy());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void setIamPolicyExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockIAMPolicy.addException(exception);
+
+    try {
+      SetIamPolicyRequest request =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+              .setPolicy(Policy.newBuilder().build())
+              .build();
+      client.setIamPolicy(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void testIamPermissionsTest() throws Exception {
+    TestIamPermissionsResponse expectedResponse =
+        TestIamPermissionsResponse.newBuilder().addAllPermissions(new ArrayList<String>()).build();
+    mockIAMPolicy.addResponse(expectedResponse);
+
+    TestIamPermissionsRequest request =
+        TestIamPermissionsRequest.newBuilder()
+            .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+            .addAllPermissions(new ArrayList<String>())
+            .build();
+
+    TestIamPermissionsResponse actualResponse = client.testIamPermissions(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockIAMPolicy.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    TestIamPermissionsRequest actualRequest = ((TestIamPermissionsRequest) actualRequests.get(0));
+
+    Assert.assertEquals(request.getResource(), actualRequest.getResource());
+    Assert.assertEquals(request.getPermissionsList(), actualRequest.getPermissionsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void testIamPermissionsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockIAMPolicy.addException(exception);
+
+    try {
+      TestIamPermissionsRequest request =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+              .addAllPermissions(new ArrayList<String>())
+              .build();
+      client.testIamPermissions(request);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.

--- a/test/integration/goldens/kms/KeyManagementServiceSettings.java
+++ b/test/integration/goldens/kms/KeyManagementServiceSettings.java
@@ -222,17 +222,6 @@ public class KeyManagementServiceSettings extends ClientSettings<KeyManagementSe
     return ((KeyManagementServiceStubSettings) getStubSettings()).getIamPolicySettings();
   }
 
-  /** Returns the object with the settings used for calls to setIamPolicy. */
-  public UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings() {
-    return ((KeyManagementServiceStubSettings) getStubSettings()).setIamPolicySettings();
-  }
-
-  /** Returns the object with the settings used for calls to testIamPermissions. */
-  public UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsSettings() {
-    return ((KeyManagementServiceStubSettings) getStubSettings()).testIamPermissionsSettings();
-  }
-
   /** Returns the object with the settings used for calls to listLocations. */
   public PagedCallSettings<ListLocationsRequest, ListLocationsResponse, ListLocationsPagedResponse>
       listLocationsSettings() {
@@ -242,6 +231,17 @@ public class KeyManagementServiceSettings extends ClientSettings<KeyManagementSe
   /** Returns the object with the settings used for calls to getLocation. */
   public UnaryCallSettings<GetLocationRequest, Location> getLocationSettings() {
     return ((KeyManagementServiceStubSettings) getStubSettings()).getLocationSettings();
+  }
+
+  /** Returns the object with the settings used for calls to setIamPolicy. */
+  public UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings() {
+    return ((KeyManagementServiceStubSettings) getStubSettings()).setIamPolicySettings();
+  }
+
+  /** Returns the object with the settings used for calls to testIamPermissions. */
+  public UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsSettings() {
+    return ((KeyManagementServiceStubSettings) getStubSettings()).testIamPermissionsSettings();
   }
 
   public static final KeyManagementServiceSettings create(KeyManagementServiceStubSettings stub)
@@ -482,17 +482,6 @@ public class KeyManagementServiceSettings extends ClientSettings<KeyManagementSe
       return getStubSettingsBuilder().getIamPolicySettings();
     }
 
-    /** Returns the builder for the settings used for calls to setIamPolicy. */
-    public UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings() {
-      return getStubSettingsBuilder().setIamPolicySettings();
-    }
-
-    /** Returns the builder for the settings used for calls to testIamPermissions. */
-    public UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
-        testIamPermissionsSettings() {
-      return getStubSettingsBuilder().testIamPermissionsSettings();
-    }
-
     /** Returns the builder for the settings used for calls to listLocations. */
     public PagedCallSettings.Builder<
             ListLocationsRequest, ListLocationsResponse, ListLocationsPagedResponse>
@@ -503,6 +492,17 @@ public class KeyManagementServiceSettings extends ClientSettings<KeyManagementSe
     /** Returns the builder for the settings used for calls to getLocation. */
     public UnaryCallSettings.Builder<GetLocationRequest, Location> getLocationSettings() {
       return getStubSettingsBuilder().getLocationSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to setIamPolicy. */
+    public UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings() {
+      return getStubSettingsBuilder().setIamPolicySettings();
+    }
+
+    /** Returns the builder for the settings used for calls to testIamPermissions. */
+    public UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
+        testIamPermissionsSettings() {
+      return getStubSettingsBuilder().testIamPermissionsSettings();
     }
 
     @Override

--- a/test/integration/goldens/kms/KeyManagementServiceStub.java
+++ b/test/integration/goldens/kms/KeyManagementServiceStub.java
@@ -205,15 +205,6 @@ public abstract class KeyManagementServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: getIamPolicyCallable()");
   }
 
-  public UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
-    throw new UnsupportedOperationException("Not implemented: setIamPolicyCallable()");
-  }
-
-  public UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsCallable() {
-    throw new UnsupportedOperationException("Not implemented: testIamPermissionsCallable()");
-  }
-
   public UnaryCallable<ListLocationsRequest, ListLocationsPagedResponse>
       listLocationsPagedCallable() {
     throw new UnsupportedOperationException("Not implemented: listLocationsPagedCallable()");
@@ -225,6 +216,15 @@ public abstract class KeyManagementServiceStub implements BackgroundResource {
 
   public UnaryCallable<GetLocationRequest, Location> getLocationCallable() {
     throw new UnsupportedOperationException("Not implemented: getLocationCallable()");
+  }
+
+  public UnaryCallable<SetIamPolicyRequest, Policy> setIamPolicyCallable() {
+    throw new UnsupportedOperationException("Not implemented: setIamPolicyCallable()");
+  }
+
+  public UnaryCallable<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsCallable() {
+    throw new UnsupportedOperationException("Not implemented: testIamPermissionsCallable()");
   }
 
   @Override

--- a/test/integration/goldens/kms/KeyManagementServiceStubSettings.java
+++ b/test/integration/goldens/kms/KeyManagementServiceStubSettings.java
@@ -184,13 +184,13 @@ public class KeyManagementServiceStubSettings
   private final UnaryCallSettings<RestoreCryptoKeyVersionRequest, CryptoKeyVersion>
       restoreCryptoKeyVersionSettings;
   private final UnaryCallSettings<GetIamPolicyRequest, Policy> getIamPolicySettings;
-  private final UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings;
-  private final UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsSettings;
   private final PagedCallSettings<
           ListLocationsRequest, ListLocationsResponse, ListLocationsPagedResponse>
       listLocationsSettings;
   private final UnaryCallSettings<GetLocationRequest, Location> getLocationSettings;
+  private final UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings;
+  private final UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsSettings;
 
   private static final PagedListDescriptor<ListKeyRingsRequest, ListKeyRingsResponse, KeyRing>
       LIST_KEY_RINGS_PAGE_STR_DESC =
@@ -608,17 +608,6 @@ public class KeyManagementServiceStubSettings
     return getIamPolicySettings;
   }
 
-  /** Returns the object with the settings used for calls to setIamPolicy. */
-  public UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings() {
-    return setIamPolicySettings;
-  }
-
-  /** Returns the object with the settings used for calls to testIamPermissions. */
-  public UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
-      testIamPermissionsSettings() {
-    return testIamPermissionsSettings;
-  }
-
   /** Returns the object with the settings used for calls to listLocations. */
   public PagedCallSettings<ListLocationsRequest, ListLocationsResponse, ListLocationsPagedResponse>
       listLocationsSettings() {
@@ -628,6 +617,17 @@ public class KeyManagementServiceStubSettings
   /** Returns the object with the settings used for calls to getLocation. */
   public UnaryCallSettings<GetLocationRequest, Location> getLocationSettings() {
     return getLocationSettings;
+  }
+
+  /** Returns the object with the settings used for calls to setIamPolicy. */
+  public UnaryCallSettings<SetIamPolicyRequest, Policy> setIamPolicySettings() {
+    return setIamPolicySettings;
+  }
+
+  /** Returns the object with the settings used for calls to testIamPermissions. */
+  public UnaryCallSettings<TestIamPermissionsRequest, TestIamPermissionsResponse>
+      testIamPermissionsSettings() {
+    return testIamPermissionsSettings;
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
@@ -724,10 +724,10 @@ public class KeyManagementServiceStubSettings
     destroyCryptoKeyVersionSettings = settingsBuilder.destroyCryptoKeyVersionSettings().build();
     restoreCryptoKeyVersionSettings = settingsBuilder.restoreCryptoKeyVersionSettings().build();
     getIamPolicySettings = settingsBuilder.getIamPolicySettings().build();
-    setIamPolicySettings = settingsBuilder.setIamPolicySettings().build();
-    testIamPermissionsSettings = settingsBuilder.testIamPermissionsSettings().build();
     listLocationsSettings = settingsBuilder.listLocationsSettings().build();
     getLocationSettings = settingsBuilder.getLocationSettings().build();
+    setIamPolicySettings = settingsBuilder.setIamPolicySettings().build();
+    testIamPermissionsSettings = settingsBuilder.testIamPermissionsSettings().build();
   }
 
   /** Builder for KeyManagementServiceStubSettings. */
@@ -780,13 +780,13 @@ public class KeyManagementServiceStubSettings
     private final UnaryCallSettings.Builder<RestoreCryptoKeyVersionRequest, CryptoKeyVersion>
         restoreCryptoKeyVersionSettings;
     private final UnaryCallSettings.Builder<GetIamPolicyRequest, Policy> getIamPolicySettings;
-    private final UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings;
-    private final UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
-        testIamPermissionsSettings;
     private final PagedCallSettings.Builder<
             ListLocationsRequest, ListLocationsResponse, ListLocationsPagedResponse>
         listLocationsSettings;
     private final UnaryCallSettings.Builder<GetLocationRequest, Location> getLocationSettings;
+    private final UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings;
+    private final UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
+        testIamPermissionsSettings;
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
         RETRYABLE_CODE_DEFINITIONS;
 
@@ -865,10 +865,10 @@ public class KeyManagementServiceStubSettings
       destroyCryptoKeyVersionSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       restoreCryptoKeyVersionSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       getIamPolicySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-      setIamPolicySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
-      testIamPermissionsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       listLocationsSettings = PagedCallSettings.newBuilder(LIST_LOCATIONS_PAGE_STR_FACT);
       getLocationSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      setIamPolicySettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      testIamPermissionsSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -896,10 +896,10 @@ public class KeyManagementServiceStubSettings
               destroyCryptoKeyVersionSettings,
               restoreCryptoKeyVersionSettings,
               getIamPolicySettings,
-              setIamPolicySettings,
-              testIamPermissionsSettings,
               listLocationsSettings,
-              getLocationSettings);
+              getLocationSettings,
+              setIamPolicySettings,
+              testIamPermissionsSettings);
       initDefaults(this);
     }
 
@@ -931,10 +931,10 @@ public class KeyManagementServiceStubSettings
       destroyCryptoKeyVersionSettings = settings.destroyCryptoKeyVersionSettings.toBuilder();
       restoreCryptoKeyVersionSettings = settings.restoreCryptoKeyVersionSettings.toBuilder();
       getIamPolicySettings = settings.getIamPolicySettings.toBuilder();
-      setIamPolicySettings = settings.setIamPolicySettings.toBuilder();
-      testIamPermissionsSettings = settings.testIamPermissionsSettings.toBuilder();
       listLocationsSettings = settings.listLocationsSettings.toBuilder();
       getLocationSettings = settings.getLocationSettings.toBuilder();
+      setIamPolicySettings = settings.setIamPolicySettings.toBuilder();
+      testIamPermissionsSettings = settings.testIamPermissionsSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -962,10 +962,10 @@ public class KeyManagementServiceStubSettings
               destroyCryptoKeyVersionSettings,
               restoreCryptoKeyVersionSettings,
               getIamPolicySettings,
-              setIamPolicySettings,
-              testIamPermissionsSettings,
               listLocationsSettings,
-              getLocationSettings);
+              getLocationSettings,
+              setIamPolicySettings,
+              testIamPermissionsSettings);
     }
 
     private static Builder createDefault() {
@@ -1101,16 +1101,6 @@ public class KeyManagementServiceStubSettings
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
 
       builder
-          .setIamPolicySettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
-          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
-
-      builder
-          .testIamPermissionsSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
-          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
-
-      builder
           .listLocationsSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
@@ -1119,6 +1109,16 @@ public class KeyManagementServiceStubSettings
           .getLocationSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .setIamPolicySettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder
+          .testIamPermissionsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
 
       return builder;
     }
@@ -1278,17 +1278,6 @@ public class KeyManagementServiceStubSettings
       return getIamPolicySettings;
     }
 
-    /** Returns the builder for the settings used for calls to setIamPolicy. */
-    public UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings() {
-      return setIamPolicySettings;
-    }
-
-    /** Returns the builder for the settings used for calls to testIamPermissions. */
-    public UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
-        testIamPermissionsSettings() {
-      return testIamPermissionsSettings;
-    }
-
     /** Returns the builder for the settings used for calls to listLocations. */
     public PagedCallSettings.Builder<
             ListLocationsRequest, ListLocationsResponse, ListLocationsPagedResponse>
@@ -1299,6 +1288,17 @@ public class KeyManagementServiceStubSettings
     /** Returns the builder for the settings used for calls to getLocation. */
     public UnaryCallSettings.Builder<GetLocationRequest, Location> getLocationSettings() {
       return getLocationSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to setIamPolicy. */
+    public UnaryCallSettings.Builder<SetIamPolicyRequest, Policy> setIamPolicySettings() {
+      return setIamPolicySettings;
+    }
+
+    /** Returns the builder for the settings used for calls to testIamPermissions. */
+    public UnaryCallSettings.Builder<TestIamPermissionsRequest, TestIamPermissionsResponse>
+        testIamPermissionsSettings() {
+      return testIamPermissionsSettings;
     }
 
     @Override


### PR DESCRIPTION
Closes #703. Note that the per-RPC methods in ServiceStub are not marked with `@deprecated` or `@Deprecated` since they are overrides, and the superclass's method has already been marked as such.