### PR TITLE
fix(tests): Ensure deterministic field ordering in test classes [ggj]

### DIFF
--- a/rules_bazel/java/integration_test.bzl
+++ b/rules_bazel/java/integration_test.bzl
@@ -23,7 +23,7 @@ def _diff_integration_goldens_impl(ctx):
     rm -rf $(find ./ -type f -name 'PlaceholderFile.java')
     rm -r $(find ./ -type d -empty)
     cd ..
-    diff codegen_tmp test/integration/goldens/{api_name}/ > {diff_output}
+    diff -r codegen_tmp test/integration/goldens/{api_name} > {diff_output}
     # Bash `diff` command will return exit code 1 when there are differences between the two
     # folders. So we explicitly `exit 0` after the diff command to avoid build failure.
     exit 0

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -53,14 +53,13 @@ import com.google.api.generator.gapic.model.ResourceName;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.AbstractMessage;
 import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -115,7 +114,8 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     BiFunction<String, TypeNode, VariableExpr> varExprFn =
         (name, type) ->
             VariableExpr.withVariable(Variable.builder().setName(name).setType(type).build());
-    Map<String, TypeNode> fields = new LinkedHashMap<>();
+    // Keep keys sorted in alphabetical order to ensure that the test output is deterministic.
+    Map<String, TypeNode> fields = new TreeMap<>();
     fields.put(
         getMockServiceVarName(service), typeStore.get(ClassNames.getMockServiceClassName(service)));
     for (Service mixinService : context.mixinServices()) {
@@ -132,8 +132,10 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
             Collectors.toMap(
                 Map.Entry::getKey,
                 e -> varExprFn.apply(e.getKey(), e.getValue()),
-                (u, v) -> {throw new IllegalStateException();},
-                LinkedHashMap::new));
+                (u, v) -> {
+                  throw new IllegalStateException();
+                },
+                TreeMap::new));
   }
 
   @Override

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceClientTest.golden
@@ -26,8 +26,8 @@ import org.junit.Test;
 public class DeprecatedServiceClientTest {
   private static MockDeprecatedService mockDeprecatedService;
   private static MockServiceHelper mockServiceHelper;
-  private DeprecatedServiceClient client;
   private LocalChannelProvider channelProvider;
+  private DeprecatedServiceClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoClientTest.golden
@@ -42,8 +42,8 @@ import org.junit.Test;
 public class EchoClientTest {
   private static MockEcho mockEcho;
   private static MockServiceHelper mockServiceHelper;
-  private EchoClient client;
   private LocalChannelProvider channelProvider;
+  private EchoClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingClientTest.golden
@@ -45,8 +45,8 @@ import org.junit.Test;
 public class LoggingServiceV2ClientTest {
   private static MockLoggingServiceV2 mockLoggingServiceV2;
   private static MockServiceHelper mockServiceHelper;
-  private LoggingServiceV2Client client;
   private LocalChannelProvider channelProvider;
+  private LoggingServiceV2Client client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/SubscriberClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/SubscriberClientTest.golden
@@ -36,10 +36,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class SubscriberClientTest {
-  private static MockSubscriber mockSubscriber;
   private static MockServiceHelper mockServiceHelper;
-  private SubscriberClient client;
+  private static MockSubscriber mockSubscriber;
   private LocalChannelProvider channelProvider;
+  private SubscriberClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/TestingClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/TestingClientTest.golden
@@ -31,10 +31,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class TestingClientTest {
-  private static MockTesting mockTesting;
   private static MockServiceHelper mockServiceHelper;
-  private TestingClient client;
+  private static MockTesting mockTesting;
   private LocalChannelProvider channelProvider;
+  private TestingClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/asset/BUILD.bazel
+++ b/test/integration/goldens/asset/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/asset/com/google/cloud/asset/v1/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/com/google/cloud/asset/v1/AssetServiceClientTest.java
@@ -52,10 +52,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class AssetServiceClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private AssetServiceClient client;
-  private LocalChannelProvider channelProvider;
   private static MockAssetService mockAssetService;
+  private static MockServiceHelper mockServiceHelper;
+  private LocalChannelProvider channelProvider;
+  private AssetServiceClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/credentials/BUILD.bazel
+++ b/test/integration/goldens/credentials/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/credentials/com/google/cloud/iam/credentials/v1/IAMCredentialsClientTest.java
+++ b/test/integration/goldens/credentials/com/google/cloud/iam/credentials/v1/IAMCredentialsClientTest.java
@@ -43,10 +43,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class IAMCredentialsClientTest {
-  private static MockServiceHelper mockServiceHelper;
   private static MockIAMCredentials mockIAMCredentials;
-  private IamCredentialsClient client;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private IamCredentialsClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/iam/BUILD.bazel
+++ b/test/integration/goldens/iam/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/iam/com/google/iam/v1/IAMPolicyClientTest.java
+++ b/test/integration/goldens/iam/com/google/iam/v1/IAMPolicyClientTest.java
@@ -41,10 +41,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class IAMPolicyClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private IAMPolicyClient client;
   private static MockIAMPolicy mockIAMPolicy;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private IAMPolicyClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/kms/BUILD.bazel
+++ b/test/integration/goldens/kms/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/kms/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
+++ b/test/integration/goldens/kms/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
@@ -66,12 +66,12 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class KeyManagementServiceClientTest {
-  private static MockKeyManagementService mockKeyManagementService;
-  private static MockServiceHelper mockServiceHelper;
-  private KeyManagementServiceClient client;
   private static MockIAMPolicy mockIAMPolicy;
+  private static MockKeyManagementService mockKeyManagementService;
   private static MockLocations mockLocations;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private KeyManagementServiceClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/library/BUILD.bazel
+++ b/test/integration/goldens/library/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/library/com/google/cloud/example/library/v1/LibraryServiceClientTest.java
+++ b/test/integration/goldens/library/com/google/cloud/example/library/v1/LibraryServiceClientTest.java
@@ -61,10 +61,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class LibraryServiceClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private LibraryServiceClient client;
   private static MockLibraryService mockLibraryService;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private LibraryServiceClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/logging/BUILD.bazel
+++ b/test/integration/goldens/logging/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/logging/com/google/cloud/logging/v2/ConfigClientTest.java
+++ b/test/integration/goldens/logging/com/google/cloud/logging/v2/ConfigClientTest.java
@@ -95,10 +95,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class ConfigClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private ConfigClient client;
-  private LocalChannelProvider channelProvider;
   private static MockConfigServiceV2 mockConfigServiceV2;
+  private static MockServiceHelper mockServiceHelper;
+  private LocalChannelProvider channelProvider;
+  private ConfigClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/logging/com/google/cloud/logging/v2/LoggingClientTest.java
+++ b/test/integration/goldens/logging/com/google/cloud/logging/v2/LoggingClientTest.java
@@ -73,10 +73,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class LoggingClientTest {
-  private static MockServiceHelper mockServiceHelper;
   private static MockLoggingServiceV2 mockLoggingServiceV2;
-  private LoggingClient client;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private LoggingClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/logging/com/google/cloud/logging/v2/MetricsClientTest.java
+++ b/test/integration/goldens/logging/com/google/cloud/logging/v2/MetricsClientTest.java
@@ -56,10 +56,10 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class MetricsClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private MetricsClient client;
   private static MockMetricsServiceV2 mockMetricsServiceV2;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private MetricsClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/pubsub/BUILD.bazel
+++ b/test/integration/goldens/pubsub/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
@@ -65,11 +65,11 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class SchemaServiceClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private static MockSchemaService mockSchemaService;
-  private SchemaServiceClient client;
   private static MockIAMPolicy mockIAMPolicy;
+  private static MockSchemaService mockSchemaService;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private SchemaServiceClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -93,11 +93,11 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class SubscriptionAdminClientTest {
+  private static MockIAMPolicy mockIAMPolicy;
   private static MockServiceHelper mockServiceHelper;
   private static MockSubscriber mockSubscriber;
-  private SubscriptionAdminClient client;
-  private static MockIAMPolicy mockIAMPolicy;
   private LocalChannelProvider channelProvider;
+  private SubscriptionAdminClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
@@ -76,11 +76,11 @@ import org.junit.Test;
 
 @Generated("by gapic-generator-java")
 public class TopicAdminClientTest {
-  private static MockServiceHelper mockServiceHelper;
-  private static MockPublisher mockPublisher;
-  private TopicAdminClient client;
   private static MockIAMPolicy mockIAMPolicy;
+  private static MockPublisher mockPublisher;
+  private static MockServiceHelper mockServiceHelper;
   private LocalChannelProvider channelProvider;
+  private TopicAdminClient client;
 
   @BeforeClass
   public static void startStaticServer() {

--- a/test/integration/goldens/redis/BUILD.bazel
+++ b/test/integration/goldens/redis/BUILD.bazel
@@ -2,8 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "goldens_files",
-    srcs = glob([
-        "*.java",
-        "gapic_metadata.json",
-    ]),
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            ".*.sw*",
+        ],
+    ),
 )

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
@@ -52,8 +52,8 @@ import org.junit.Test;
 public class CloudRedisClientTest {
   private static MockCloudRedis mockCloudRedis;
   private static MockServiceHelper mockServiceHelper;
-  private CloudRedisClient client;
   private LocalChannelProvider channelProvider;
+  private CloudRedisClient client;
 
   @BeforeClass
   public static void startStaticServer() {


### PR DESCRIPTION
This is needed for the Bazel integration test fix in #744.