### PR TITLE
fix(resnames): Use anon resname classes when only wildcards are present

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/AssignmentExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/AssignmentExpr.java
@@ -64,8 +64,10 @@ public abstract class AssignmentExpr implements Expr {
         if (rhsType != TypeNode.NULL && !lhsType.isSupertypeOrEquals(rhsType)) {
           throw new TypeMismatchException(
               String.format(
-                  "LHS type %s must be a supertype of the RHS type %s",
-                  lhsType.reference().name(), rhsType.reference().name()));
+                  "LHS type %s of variable %s must be a supertype of the RHS type %s",
+                  lhsType.reference().name(),
+                  assignmentExpr.variableExpr().variable().identifier(),
+                  rhsType.reference().name()));
         }
       }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/BUILD.bazel
@@ -17,6 +17,7 @@ java_library(
         "//src/main/java/com/google/api/generator/gapic/composer/resourcename",
         "//src/main/java/com/google/api/generator/gapic/model",
         "//src/main/java/com/google/api/generator/gapic/utils",
+        "@com_google_api_api_common",
         "@com_google_googleapis//google/longrunning:longrunning_java_proto",
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//java/core",

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
@@ -14,11 +14,16 @@
 
 package com.google.api.generator.gapic.composer.defaultvalue;
 
+import com.google.api.generator.engine.ast.AnonymousClassExpr;
+import com.google.api.generator.engine.ast.AssignmentExpr;
 import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.Expr;
+import com.google.api.generator.engine.ast.ExprStatement;
+import com.google.api.generator.engine.ast.MethodDefinition;
 import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.NewObjectExpr;
 import com.google.api.generator.engine.ast.PrimitiveValue;
+import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.engine.ast.StringObjectValue;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.ValueExpr;
@@ -31,6 +36,7 @@ import com.google.api.generator.gapic.model.MethodArgument;
 import com.google.api.generator.gapic.model.ResourceName;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.api.generator.gapic.utils.ResourceNameConstants;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
@@ -157,6 +163,16 @@ public class DefaultValueComposer {
 
   public static Expr createDefaultValue(
       ResourceName resourceName, List<ResourceName> resnames, String fieldOrMessageName) {
+    return createDefaultValueResourceHelper(resourceName, resnames, fieldOrMessageName, true);
+  }
+
+  @VisibleForTesting
+  static Expr createDefaultValueResourceHelper(
+      ResourceName resourceName,
+      List<ResourceName> resnames,
+      String fieldOrMessageName,
+      boolean allowAnonResourceNameClass) {
+
     boolean hasOnePattern = resourceName.patterns().size() == 1;
     if (resourceName.isOnlyWildcard()) {
       List<ResourceName> unexaminedResnames = new ArrayList<>(resnames);
@@ -170,9 +186,11 @@ public class DefaultValueComposer {
       }
 
       if (unexaminedResnames.isEmpty()) {
-        return ValueExpr.withValue(
-            StringObjectValue.withValue(
-                String.format("%s%s", fieldOrMessageName, fieldOrMessageName.hashCode())));
+        return allowAnonResourceNameClass
+            ? createAnonymousResourceNameClass(fieldOrMessageName)
+            : ValueExpr.withValue(
+                StringObjectValue.withValue(
+                    String.format("%s%s", fieldOrMessageName, fieldOrMessageName.hashCode())));
       }
     }
 
@@ -247,10 +265,11 @@ public class DefaultValueComposer {
       if (field.hasResourceReference()
           && resourceNames.get(field.resourceReference().resourceTypeString()) != null) {
         defaultExpr =
-            createDefaultValue(
+            createDefaultValueResourceHelper(
                 resourceNames.get(field.resourceReference().resourceTypeString()),
                 resourceNames.values().stream().collect(Collectors.toList()),
-                message.name());
+                message.name(),
+                /* allowAnonResourceNameClass = */ false);
         defaultExpr =
             MethodInvocationExpr.builder()
                 .setExprReferenceExpr(defaultExpr)
@@ -343,6 +362,94 @@ public class DefaultValueComposer {
         .setExprReferenceExpr(pagedResponseExpr)
         .setMethodName("build")
         .setReturnType(responseType)
+        .build();
+  }
+
+  @VisibleForTesting
+  static AnonymousClassExpr createAnonymousResourceNameClass(String fieldOrMessageName) {
+    TypeNode stringMapType =
+        TypeNode.withReference(
+            ConcreteReference.builder()
+                .setClazz(Map.class)
+                .setGenerics(
+                    Arrays.asList(
+                        ConcreteReference.withClazz(String.class),
+                        ConcreteReference.withClazz(String.class)))
+                .build());
+
+    // Method code:
+    // @Override
+    // public Map<String, String> getFieldValuesMap() {
+    //   Map<String, String> fieldValuesMap = new HashMap<>();
+    //   fieldValuesMap.put("resource", "resource-12345");
+    //   return fieldValuesMap;
+    // }
+    VariableExpr fieldValuesMapVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setType(stringMapType).setName("fieldValuesMap").build());
+    StringObjectValue fieldOrMessageStringValue =
+        StringObjectValue.withValue(
+            String.format("%s%s", fieldOrMessageName, fieldOrMessageName.hashCode()));
+
+    List<Expr> bodyExprs =
+        Arrays.asList(
+            AssignmentExpr.builder()
+                .setVariableExpr(fieldValuesMapVarExpr.toBuilder().setIsDecl(true).build())
+                .setValueExpr(
+                    NewObjectExpr.builder()
+                        .setType(TypeNode.withReference(ConcreteReference.withClazz(HashMap.class)))
+                        .setIsGeneric(true)
+                        .build())
+                .build(),
+            MethodInvocationExpr.builder()
+                .setExprReferenceExpr(fieldValuesMapVarExpr)
+                .setMethodName("put")
+                .setArguments(
+                    ValueExpr.withValue(StringObjectValue.withValue(fieldOrMessageName)),
+                    ValueExpr.withValue(fieldOrMessageStringValue))
+                .build());
+
+    MethodDefinition getFieldValuesMapMethod =
+        MethodDefinition.builder()
+            .setIsOverride(true)
+            .setScope(ScopeNode.PUBLIC)
+            .setReturnType(stringMapType)
+            .setName("getFieldValuesMap")
+            .setBody(
+                bodyExprs.stream().map(e -> ExprStatement.withExpr(e)).collect(Collectors.toList()))
+            .setReturnExpr(fieldValuesMapVarExpr)
+            .build();
+
+    // Method code:
+    // @Override
+    // public String getFieldValue(String fieldName) {
+    //   return getFieldValuesMap().get(fieldName);
+    // }
+    VariableExpr fieldNameVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setType(TypeNode.STRING).setName("fieldName").build());
+    MethodDefinition getFieldValueMethod =
+        MethodDefinition.builder()
+            .setIsOverride(true)
+            .setScope(ScopeNode.PUBLIC)
+            .setReturnType(TypeNode.STRING)
+            .setName("getFieldValue")
+            .setArguments(fieldNameVarExpr.toBuilder().setIsDecl(true).build())
+            .setReturnExpr(
+                MethodInvocationExpr.builder()
+                    .setExprReferenceExpr(
+                        MethodInvocationExpr.builder().setMethodName("getFieldValuesMap").build())
+                    .setMethodName("get")
+                    .setArguments(fieldNameVarExpr)
+                    .setReturnType(TypeNode.STRING)
+                    .build())
+            .build();
+
+    return AnonymousClassExpr.builder()
+        .setType(
+            TypeNode.withReference(
+                ConcreteReference.withClazz(com.google.api.resourcenames.ResourceName.class)))
+        .setMethods(Arrays.asList(getFieldValuesMapMethod, getFieldValueMethod))
         .build();
   }
 }


### PR DESCRIPTION
Use an anonymous ResourceName class as a default value when only wildcard resource name types are present. This primarily affects GCS and IAM. These anonymous classes will be used only for explicit field assignments, and not when the value is being set on a message. Specifically, note that the IAM integration goldens are unchanged.

The GCS use case is covered by the default value unit test. Integration tests may be added once the GCS protos are published.