### PR TITLE
fix(build): Update googleapis-discovery hash to fix compute integration test [ggj]

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -68,9 +68,9 @@ def gapic_generator_java_repositories():
     _maybe(
         http_archive,
         name = "com_google_googleapis_discovery",
-        strip_prefix = "googleapis-discovery-4f5d0604132e93e63330e65e2e6648c75012780c",
+        strip_prefix = "googleapis-discovery-6a189a8bada35e2657a67b903cad7fee649f2dbc",
         urls = [
-            "https://github.com/googleapis/googleapis-discovery/archive/4f5d0604132e93e63330e65e2e6648c75012780c.zip",
+            "https://github.com/googleapis/googleapis-discovery/archive/6a189a8bada35e2657a67b903cad7fee649f2dbc.zip",
         ],
     )
 


### PR DESCRIPTION
Otherwise, running `bazel test test/integration/compute` results in the following error:

```
ERROR: Traceback (most recent call last):
	File "/usr/local/google/home/miraleung/.cache/bazel/_bazel_miraleung/81d8a0d4367fd2fc950131569ad58216/external/com_google_googleapis_discovery/google/cloud/compute/v1/BUILD.bazel", line 102, column 6, in <toplevel>
		"java_gapic_assembly_gradle_pkg_legacy",
Error: file '@com_google_googleapis_imports//:imports.bzl' does not contain symbol 'java_gapic_assembly_gradle_pkg_legacy'
ERROR: /usr/local/google/home/miraleung/dev/ggj2/test/integration/BUILD.bazel:135:19: no such target '@com_google_googleapis_discovery//google/cloud/compute/v1:compute_small_java_proto': target 'compute_small_java_proto' not declared in package 'google/cloud/compute/v1' defined by /usr/local/google/home/miraleung/.cache/bazel/_bazel_miraleung/81d8a0d4367fd2fc950131569ad58216/external/com_google_googleapis_discovery/google/cloud/compute/v1/BUILD.bazel and referenced by '//test/integration:compute_small_java_gapic_test'
ERROR: Analysis of target '//test/integration:compute' failed; build aborted: Analysis failed
```