### PR TITLE
fix: (rest transport) Add `@BetaApi` to the generated `TransportServiceFactory` class and lro-specific method

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/AnnotationNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/AnnotationNode.java
@@ -41,11 +41,12 @@ public abstract class AnnotationNode implements AstNode {
     visitor.visit(this);
   }
 
+  public static AnnotationNode withTypeAndDescription(TypeNode type, String description) {
+    return AnnotationNode.builder().setType(type).setDescription(description).build();
+  }
+
   public static AnnotationNode withSuppressWarnings(String description) {
-    return AnnotationNode.builder()
-        .setType(annotationType(SuppressWarnings.class))
-        .setDescription(description)
-        .build();
+    return withTypeAndDescription(annotationType(SuppressWarnings.class), description);
   }
 
   public static AnnotationNode withType(TypeNode type) {

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
@@ -137,8 +137,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   protected MethodDefinition createPagedCallableMethod(TypeStore typeStore) {
@@ -160,8 +159,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   protected MethodDefinition createBatchingCallableMethod(TypeStore typeStore) {
@@ -181,11 +179,31 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   protected abstract MethodDefinition createOperationCallableMethod(TypeStore typeStore);
+
+  protected MethodDefinition createGenericCallableMethod(
+      TypeStore typeStore,
+      List<String> methodTemplateNames,
+      String returnCallableKindName,
+      List<String> returnCallableTemplateNames,
+      String methodVariantName,
+      List<Object> transportCallSettingsTemplateObjects,
+      String callSettingsVariantName,
+      List<Object> callSettingsTemplateObjects) {
+    return createGenericCallableMethod(
+        typeStore,
+        methodTemplateNames,
+        returnCallableKindName,
+        returnCallableTemplateNames,
+        methodVariantName,
+        transportCallSettingsTemplateObjects,
+        callSettingsVariantName,
+        callSettingsTemplateObjects,
+        Collections.emptyList());
+  }
 
   protected MethodDefinition createGenericCallableMethod(
       TypeStore typeStore,

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
@@ -44,6 +44,7 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
@@ -136,7 +137,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   protected MethodDefinition createPagedCallableMethod(TypeStore typeStore) {
@@ -158,7 +160,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   protected MethodDefinition createBatchingCallableMethod(TypeStore typeStore) {
@@ -178,7 +181,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   protected abstract MethodDefinition createOperationCallableMethod(TypeStore typeStore);
@@ -191,7 +195,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
       String methodVariantName,
       List<Object> transportCallSettingsTemplateObjects,
       String callSettingsVariantName,
-      List<Object> callSettingsTemplateObjects) {
+      List<Object> callSettingsTemplateObjects,
+      List<AnnotationNode> annotations) {
 
     String methodName = String.format("create%sCallable", methodVariantName);
     String callSettingsTypeName = String.format("%sCallSettings", callSettingsVariantName);
@@ -261,6 +266,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         .setName(methodName)
         .setArguments(arguments)
         .setReturnExpr(returnExpr)
+        .setAnnotations(annotations)
         .build();
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
@@ -22,6 +22,7 @@ import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.longrunning.Operation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -72,7 +73,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   protected MethodDefinition createPagedCallableMethod(TypeStore typeStore) {
@@ -94,7 +96,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   @Override
@@ -114,7 +117,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   private MethodDefinition createBidiStreamingCallableMethod(TypeStore typeStore) {
@@ -134,7 +138,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ "Streaming",
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   private MethodDefinition createServerStreamingCallableMethod(TypeStore typeStore) {
@@ -154,7 +159,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 
   private MethodDefinition createClientStreamingCallableMethod(TypeStore typeStore) {
@@ -174,6 +180,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ "Streaming",
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        Collections.emptyList());
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
@@ -22,7 +22,6 @@ import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.longrunning.Operation;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,8 +72,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   protected MethodDefinition createPagedCallableMethod(TypeStore typeStore) {
@@ -96,8 +94,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   @Override
@@ -117,8 +114,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   private MethodDefinition createBidiStreamingCallableMethod(TypeStore typeStore) {
@@ -138,8 +134,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ "Streaming",
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   private MethodDefinition createServerStreamingCallableMethod(TypeStore typeStore) {
@@ -159,8 +154,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ methodVariantName,
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 
   private MethodDefinition createClientStreamingCallableMethod(TypeStore typeStore) {
@@ -180,7 +174,6 @@ public class GrpcServiceCallableFactoryClassComposer
         /*callSettingsVariantName=*/ "Streaming",
         /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
-            .collect(Collectors.toList()),
-        Collections.emptyList());
+            .collect(Collectors.toList()));
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
@@ -52,6 +52,8 @@ public class HttpJsonServiceCallableFactoryClassComposer
     // Always add @BetaApi annotation to the generated CallableFactory for now. It is a public class
     // for technical reasons, end users are not expected to interact with it, but it may change
     // when we add LRO support, that is why making it @BetaApi for now.
+    //
+    // Remove the @BetaApi annotation once the LRO feature is fully implemented and stabilized.
     if (annotations.stream().noneMatch(a -> a.type().equals(typeStore.get("BetaApi")))) {
       annotations.add(AnnotationNode.withType(typeStore.get("BetaApi")));
     }
@@ -78,8 +80,10 @@ public class HttpJsonServiceCallableFactoryClassComposer
     List<String> methodTemplateNames =
         Arrays.asList(requestTemplateName, responseTemplateName, "MetadataT");
 
-    // Always add @BetaApi annotation to the generated createOperationCallable()method for now,
+    // Always add @BetaApi annotation to the generated createOperationCallable() method for now,
     // until LRO is fully implemented.
+    //
+    // Remove the @BetaApi annotation once the LRO feature is fully implemented and stabilized.
     AnnotationNode betaAnnotation =
         AnnotationNode.withTypeAndDescription(
             typeStore.get("BetaApi"),

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceCallableFactory.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceCallableFactory.golden
@@ -54,6 +54,8 @@ public class HttpJsonComplianceCallableFactory
         httpJsonCallSettings, callSettings, clientContext);
   }
 
+  @BetaApi(
+      "The surface for long-running operations is not stable yet and may change in the future.")
   @Override
   public <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesCallableFactory.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesCallableFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.compute.v1.stub;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
@@ -37,6 +38,7 @@ import javax.annotation.Generated;
  * <p>This class is for advanced usage.
  */
 @Generated("by gapic-generator-java")
+@BetaApi
 public class HttpJsonAddressesCallableFactory
     implements HttpJsonStubCallableFactory<ApiMessage, BackgroundResource> {
 
@@ -68,6 +70,8 @@ public class HttpJsonAddressesCallableFactory
         httpJsonCallSettings, callSettings, clientContext);
   }
 
+  @BetaApi(
+      "The surface for long-running operations is not stable yet and may change in the future.")
   @Override
   public <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonRegionOperationsCallableFactory.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonRegionOperationsCallableFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.compute.v1.stub;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
@@ -37,6 +38,7 @@ import javax.annotation.Generated;
  * <p>This class is for advanced usage.
  */
 @Generated("by gapic-generator-java")
+@BetaApi
 public class HttpJsonRegionOperationsCallableFactory
     implements HttpJsonStubCallableFactory<ApiMessage, BackgroundResource> {
 
@@ -68,6 +70,8 @@ public class HttpJsonRegionOperationsCallableFactory
         httpJsonCallSettings, callSettings, clientContext);
   }
 
+  @BetaApi(
+      "The surface for long-running operations is not stable yet and may change in the future.")
   @Override
   public <RequestT, ResponseT, MetadataT>
       OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(


### PR DESCRIPTION
This is to make implementing LRO post-GA safer. Note, `TransportServiceFactory` class is public for technical reasons, and is not supposed to be used by users directly.