### PR TITLE
feat: enable self signed jwt for gapic clients

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ jvm_maven_import_external(
 # gapic-generator-java dependencies to match the order in googleapis repository,
 # which in its turn, prioritizes actual generated clients runtime dependencies
 # over the generator dependencies.
-_gax_java_version = "1.65.1"
+_gax_java_version = "2.3.0"
 
 http_archive(
     name = "com_google_api_gax_java",

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -137,10 +137,6 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
   private static final String DOT = ".";
 
-  protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
-
-  protected static final VariableExpr DEFAULT_SERVICE_SCOPES_VAR_EXPR =
-      createDefaultServiceScopesVarExpr();
   private static final VariableExpr NESTED_UNARY_METHOD_SETTINGS_BUILDERS_VAR_EXPR =
       createNestedUnaryMethodSettingsBuildersVarExpr();
   private static final VariableExpr NESTED_RETRYABLE_CODE_DEFINITIONS_VAR_EXPR =
@@ -149,6 +145,11 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
       createNestedRetryParamDefinitionsVarExpr();
 
   private final TransportContext transportContext;
+
+  protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
+
+  protected static final VariableExpr DEFAULT_SERVICE_SCOPES_VAR_EXPR =
+      createDefaultServiceScopesVarExpr();
 
   protected AbstractServiceStubSettingsClassComposer(TransportContext transportContext) {
     this.transportContext = transportContext;

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -139,7 +139,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
   protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
 
-  private static final VariableExpr DEFAULT_SERVICE_SCOPES_VAR_EXPR =
+  protected static final VariableExpr DEFAULT_SERVICE_SCOPES_VAR_EXPR =
       createDefaultServiceScopesVarExpr();
   private static final VariableExpr NESTED_UNARY_METHOD_SETTINGS_BUILDERS_VAR_EXPR =
       createNestedUnaryMethodSettingsBuildersVarExpr();
@@ -195,6 +195,33 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
                 Arrays.asList(createNestedBuilderClass(service, serviceConfig, typeStore)))
             .build();
     return GapicClass.create(GapicClass.Kind.STUB, classDef);
+  }
+
+  protected MethodDefinition createDefaultCredentialsProviderBuilderMethod() {
+    TypeNode returnType =
+        TypeNode.withReference(
+            ConcreteReference.withClazz(GoogleCredentialsProvider.Builder.class));
+    MethodInvocationExpr credsProviderBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(FIXED_TYPESTORE.get("GoogleCredentialsProvider"))
+            .setMethodName("newBuilder")
+            .build();
+    credsProviderBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credsProviderBuilderExpr)
+            .setMethodName("setScopesToApply")
+            .setArguments(DEFAULT_SERVICE_SCOPES_VAR_EXPR)
+            .setReturnType(returnType)
+            .build();
+    return MethodDefinition.builder()
+        .setHeaderCommentStatements(
+            SettingsCommentComposer.DEFAULT_CREDENTIALS_PROVIDER_BUILDER_METHOD_COMMENT)
+        .setScope(ScopeNode.PUBLIC)
+        .setIsStatic(true)
+        .setReturnType(returnType)
+        .setName("defaultCredentialsProviderBuilder")
+        .setReturnExpr(credsProviderBuilderExpr)
+        .build();
   }
 
   protected abstract MethodDefinition createDefaultTransportTransportProviderBuilderMethod();
@@ -992,33 +1019,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnExpr(DEFAULT_SERVICE_SCOPES_VAR_EXPR)
             .build());
 
-    // Create the defaultCredentialsProviderBuilder method.
-    returnType =
-        TypeNode.withReference(
-            ConcreteReference.withClazz(GoogleCredentialsProvider.Builder.class));
-    MethodInvocationExpr credsProviderBuilderExpr =
-        MethodInvocationExpr.builder()
-            .setStaticReferenceType(FIXED_TYPESTORE.get("GoogleCredentialsProvider"))
-            .setMethodName("newBuilder")
-            .build();
-    credsProviderBuilderExpr =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(credsProviderBuilderExpr)
-            .setMethodName("setScopesToApply")
-            .setArguments(DEFAULT_SERVICE_SCOPES_VAR_EXPR)
-            .setReturnType(returnType)
-            .build();
-    javaMethods.add(
-        MethodDefinition.builder()
-            .setHeaderCommentStatements(
-                SettingsCommentComposer.DEFAULT_CREDENTIALS_PROVIDER_BUILDER_METHOD_COMMENT)
-            .setScope(ScopeNode.PUBLIC)
-            .setIsStatic(true)
-            .setReturnType(returnType)
-            .setName("defaultCredentialsProviderBuilder")
-            .setReturnExpr(credsProviderBuilderExpr)
-            .build());
-
+    javaMethods.add(createDefaultCredentialsProviderBuilderMethod());
     javaMethods.add(createDefaultTransportTransportProviderBuilderMethod());
     javaMethods.add(createDefaultTransportChannelProviderMethod());
     javaMethods.add(createDefaultApiClientHeaderProviderBuilderMethod(service, typeStore));

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -137,6 +137,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
   private static final String DOT = ".";
 
+  protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
+
   private static final VariableExpr NESTED_UNARY_METHOD_SETTINGS_BUILDERS_VAR_EXPR =
       createNestedUnaryMethodSettingsBuildersVarExpr();
   private static final VariableExpr NESTED_RETRYABLE_CODE_DEFINITIONS_VAR_EXPR =
@@ -145,8 +147,6 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
       createNestedRetryParamDefinitionsVarExpr();
 
   private final TransportContext transportContext;
-
-  protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
 
   protected static final VariableExpr DEFAULT_SERVICE_SCOPES_VAR_EXPR =
       createDefaultServiceScopesVarExpr();

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposer.java
@@ -14,6 +14,7 @@
 
 package com.google.api.generator.gapic.composer.grpc;
 
+import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
@@ -22,6 +23,7 @@ import com.google.api.generator.engine.ast.AnnotationNode;
 import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.MethodDefinition;
 import com.google.api.generator.engine.ast.MethodInvocationExpr;
+import com.google.api.generator.engine.ast.PrimitiveValue;
 import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.engine.ast.StringObjectValue;
 import com.google.api.generator.engine.ast.TypeNode;
@@ -91,6 +93,43 @@ public class ServiceStubSettingsClassComposer extends AbstractServiceStubSetting
         .setReturnType(returnType)
         .setName("defaultGrpcTransportProviderBuilder")
         .setReturnExpr(transportChannelProviderBuilderExpr)
+        .build();
+  }
+
+  @Override
+  protected MethodDefinition createDefaultCredentialsProviderBuilderMethod() {
+    TypeNode returnType =
+        TypeNode.withReference(
+            ConcreteReference.withClazz(GoogleCredentialsProvider.Builder.class));
+    MethodInvocationExpr credsProviderBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(FIXED_TYPESTORE.get("GoogleCredentialsProvider"))
+            .setMethodName("newBuilder")
+            .build();
+    credsProviderBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credsProviderBuilderExpr)
+            .setMethodName("setScopesToApply")
+            .setArguments(DEFAULT_SERVICE_SCOPES_VAR_EXPR)
+            .setReturnType(returnType)
+            .build();
+    credsProviderBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(credsProviderBuilderExpr)
+            .setMethodName("setUseJwtAccessWithScope")
+            .setArguments(
+                ValueExpr.withValue(
+                    PrimitiveValue.builder().setType(TypeNode.BOOLEAN).setValue("true").build()))
+            .setReturnType(returnType)
+            .build();
+    return MethodDefinition.builder()
+        .setHeaderCommentStatements(
+            SettingsCommentComposer.DEFAULT_CREDENTIALS_PROVIDER_BUILDER_METHOD_COMMENT)
+        .setScope(ScopeNode.PUBLIC)
+        .setIsStatic(true)
+        .setReturnType(returnType)
+        .setName("defaultCredentialsProviderBuilder")
+        .setReturnExpr(credsProviderBuilderExpr)
         .build();
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposer.java
@@ -113,6 +113,9 @@ public class ServiceStubSettingsClassComposer extends AbstractServiceStubSetting
             .setArguments(DEFAULT_SERVICE_SCOPES_VAR_EXPR)
             .setReturnType(returnType)
             .build();
+
+    // This section is specific to GAPIC clients. It sets UseJwtAccessWithScope value to true to
+    // enable self signed JWT feature.
     credsProviderBuilderExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(credsProviderBuilderExpr)
@@ -122,6 +125,7 @@ public class ServiceStubSettingsClassComposer extends AbstractServiceStubSetting
                     PrimitiveValue.builder().setType(TypeNode.BOOLEAN).setValue("true").build()))
             .setReturnType(returnType)
             .build();
+
     return MethodDefinition.builder()
         .setHeaderCommentStatements(
             SettingsCommentComposer.DEFAULT_CREDENTIALS_PROVIDER_BUILDER_METHOD_COMMENT)

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
@@ -120,7 +120,9 @@ public class DeprecatedServiceStubSettings extends StubSettings<DeprecatedServic
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -303,7 +303,9 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
@@ -440,7 +440,9 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
@@ -449,7 +449,9 @@ public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/asset/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
+++ b/test/integration/goldens/asset/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
@@ -452,7 +452,9 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/credentials/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
+++ b/test/integration/goldens/credentials/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
@@ -150,7 +150,9 @@ public class IamCredentialsStubSettings extends StubSettings<IamCredentialsStubS
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/iam/com/google/iam/v1/stub/IAMPolicyStubSettings.java
+++ b/test/integration/goldens/iam/com/google/iam/v1/stub/IAMPolicyStubSettings.java
@@ -137,7 +137,9 @@ public class IAMPolicyStubSettings extends StubSettings<IAMPolicyStubSettings> {
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/kms/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
+++ b/test/integration/goldens/kms/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
@@ -657,7 +657,9 @@ public class KeyManagementServiceStubSettings
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/library/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
+++ b/test/integration/goldens/library/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
@@ -316,7 +316,9 @@ public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubS
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/logging/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -526,7 +526,9 @@ public class ConfigServiceV2StubSettings extends StubSettings<ConfigServiceV2Stu
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/logging/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -456,7 +456,9 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/logging/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/test/integration/goldens/logging/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -224,7 +224,9 @@ public class MetricsServiceV2StubSettings extends StubSettings<MetricsServiceV2S
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
@@ -490,7 +490,9 @@ public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
@@ -254,7 +254,9 @@ public class SchemaServiceStubSettings extends StubSettings<SchemaServiceStubSet
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
@@ -395,7 +395,9 @@ public class SubscriberStubSettings extends StubSettings<SubscriberStubSettings>
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -306,7 +306,9 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */

--- a/test/integration/goldens/storage/com/google/storage/v2/stub/StorageStubSettings.java
+++ b/test/integration/goldens/storage/com/google/storage/v2/stub/StorageStubSettings.java
@@ -157,7 +157,9 @@ public class StorageStubSettings extends StubSettings<StorageStubSettings> {
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default ChannelProvider for this service. */


### PR DESCRIPTION
For GAPIC clients, this PR enables self signed jwt feature by changing the implementation of `defaultCredentialsProviderBuilder`  from 
```
public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES);
}
```
to
```
    return GoogleCredentialsProvider.newBuilder().setScopesToApply(DEFAULT_SERVICE_SCOPES)
        .setUseJwtAccessWithScope(true);
```

There is no changes for DIREGAPIC clients.

This PR relies on https://github.com/googleapis/gax-java/pull/1420.