### PR TITLE
DIREGAPIC LRO implementation without annotations

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ jvm_maven_import_external(
 # gapic-generator-java dependencies to match the order in googleapis repository,
 # which in its turn, prioritizes actual generated clients runtime dependencies
 # over the generator dependencies.
-_gax_java_version = "1.65.1"
+_gax_java_version = "2.2.0"
 
 http_archive(
     name = "com_google_api_gax_java",

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
@@ -52,6 +52,7 @@ import com.google.api.generator.gapic.composer.utils.PackageChecker;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicClass.Kind;
 import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
@@ -159,12 +160,14 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
                 .setType(getTransportContext().stubCallableFactoryType())
                 .build()));
 
+    Map<String, Message> messageTypes = context.messages();
     List<Statement> classStatements =
         createClassStatements(
             service,
             protoMethodNameToDescriptorVarExprs,
             callableClassMemberVarExprs,
-            classMemberVarExprs);
+            classMemberVarExprs,
+            messageTypes);
 
     StubCommentComposer commentComposer =
         new StubCommentComposer(getTransportContext().transportName());
@@ -193,7 +196,7 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
   }
 
   protected abstract Statement createMethodDescriptorVariableDecl(
-      Service service, Method protoMethod, VariableExpr methodDescriptorVarExpr);
+      Service service, Method protoMethod, VariableExpr methodDescriptorVarExpr, Map<String, Message> messageTypes);
 
   protected abstract List<MethodDefinition> createOperationsStubGetterMethod(
       VariableExpr operationsStubVarExpr);
@@ -212,10 +215,11 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
       Service service,
       Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs,
       Map<String, VariableExpr> callableClassMemberVarExprs,
-      Map<String, VariableExpr> classMemberVarExprs) {
+      Map<String, VariableExpr> classMemberVarExprs,
+      Map<String, Message> messageTypes) {
     List<Statement> classStatements = new ArrayList<>();
     for (Statement statement :
-        createMethodDescriptorVariableDecls(service, protoMethodNameToDescriptorVarExprs)) {
+        createMethodDescriptorVariableDecls(service, protoMethodNameToDescriptorVarExprs, messageTypes)) {
       classStatements.add(statement);
       classStatements.add(EMPTY_LINE_STATEMENT);
     }
@@ -228,12 +232,12 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
   }
 
   protected List<Statement> createMethodDescriptorVariableDecls(
-      Service service, Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs) {
+      Service service, Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs, Map<String, Message> messageTypes) {
     return service.methods().stream()
         .map(
             m ->
                 createMethodDescriptorVariableDecl(
-                    service, m, protoMethodNameToDescriptorVarExprs.get(m.name())))
+                    service, m, protoMethodNameToDescriptorVarExprs.get(m.name()), messageTypes))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -86,7 +86,10 @@ public class GrpcServiceStubClassComposer extends AbstractServiceStubClassCompos
 
   @Override
   protected Statement createMethodDescriptorVariableDecl(
-      Service service, Method protoMethod, VariableExpr methodDescriptorVarExpr, Map<String, Message> messageTypes) {
+      Service service,
+      Method protoMethod,
+      VariableExpr methodDescriptorVarExpr,
+      Map<String, Message> messageTypes) {
     MethodInvocationExpr methodDescriptorMaker =
         MethodInvocationExpr.builder()
             .setMethodName("newBuilder")

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -34,6 +34,7 @@ import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.gapic.composer.common.AbstractServiceStubClassComposer;
 import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
+import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
@@ -85,7 +86,7 @@ public class GrpcServiceStubClassComposer extends AbstractServiceStubClassCompos
 
   @Override
   protected Statement createMethodDescriptorVariableDecl(
-      Service service, Method protoMethod, VariableExpr methodDescriptorVarExpr) {
+      Service service, Method protoMethod, VariableExpr methodDescriptorVarExpr, Map<String, Message> messageTypes) {
     MethodInvocationExpr methodDescriptorMaker =
         MethodInvocationExpr.builder()
             .setMethodName("newBuilder")

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
@@ -29,7 +29,6 @@ import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.NewObjectExpr;
 import com.google.api.generator.engine.ast.Statement;
 import com.google.api.generator.engine.ast.TypeNode;
-import com.google.api.generator.engine.ast.ValueExpr;
 import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
@@ -125,92 +124,108 @@ public class HttpJsonServiceCallableFactoryClassComposer
     List<VariableExpr> arguments = method.arguments();
 
     // Generate innerCallable
-    VariableExpr innerCallableVarExpr = VariableExpr.builder()
-        .setVariable(
-            Variable.builder()
-                .setName("innerCallable")
-                .setType(TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
-                .build())
-        .setTemplateObjects(Arrays.asList(requestTemplateName, methodVariantName))
-        .build();
-    MethodInvocationExpr getInitialCallSettingsExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(1).variable()))
-        .setMethodName("getInitialCallSettings")
-        .build();
-    MethodInvocationExpr createBaseUnaryCallableExpr = MethodInvocationExpr.builder()
-        .setStaticReferenceType(TypeNode.withReference(ConcreteReference.withClazz(
-            HttpJsonCallableFactory.class)))
-        .setMethodName("createBaseUnaryCallable")
-        .setArguments(
-            VariableExpr.withVariable(arguments.get(0).variable()),
-            getInitialCallSettingsExpr,
-            VariableExpr.withVariable(arguments.get(2).variable()))
-        .setReturnType(TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
-        .build();
-    AssignmentExpr innerCallableAssignExpr = AssignmentExpr.builder()
-        .setVariableExpr(innerCallableVarExpr.toBuilder().setIsDecl(true).build())
-        .setValueExpr(createBaseUnaryCallableExpr)
-        .build();
+    VariableExpr innerCallableVarExpr =
+        VariableExpr.builder()
+            .setVariable(
+                Variable.builder()
+                    .setName("innerCallable")
+                    .setType(
+                        TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
+                    .build())
+            .setTemplateObjects(Arrays.asList(requestTemplateName, methodVariantName))
+            .build();
+    MethodInvocationExpr getInitialCallSettingsExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(1).variable()))
+            .setMethodName("getInitialCallSettings")
+            .build();
+    MethodInvocationExpr createBaseUnaryCallableExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(
+                TypeNode.withReference(ConcreteReference.withClazz(HttpJsonCallableFactory.class)))
+            .setMethodName("createBaseUnaryCallable")
+            .setArguments(
+                VariableExpr.withVariable(arguments.get(0).variable()),
+                getInitialCallSettingsExpr,
+                VariableExpr.withVariable(arguments.get(2).variable()))
+            .setReturnType(TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
+            .build();
+    AssignmentExpr innerCallableAssignExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(innerCallableVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(createBaseUnaryCallableExpr)
+            .build();
     createOperationCallableBody.add(ExprStatement.withExpr(innerCallableAssignExpr));
 
     // Generate initialCallable
-    VariableExpr initialCallableVarExpr = VariableExpr.builder()
-        .setVariable(
-            Variable.builder()
-                .setName("initialCallable")
-                .setType(TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
-                .build())
-        .setTemplateObjects(Arrays.asList(requestTemplateName, methodVariantName))
-        .build();
-    MethodInvocationExpr getMethodDescriptorExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(0).variable()))
-        .setMethodName("getMethodDescriptor")
-        .build();
-    MethodInvocationExpr getOperationSnapshotFactoryExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(getMethodDescriptorExpr)
-        .setMethodName("getOperationSnapshotFactory")
-        .build();
+    VariableExpr initialCallableVarExpr =
+        VariableExpr.builder()
+            .setVariable(
+                Variable.builder()
+                    .setName("initialCallable")
+                    .setType(
+                        TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
+                    .build())
+            .setTemplateObjects(Arrays.asList(requestTemplateName, methodVariantName))
+            .build();
+    MethodInvocationExpr getMethodDescriptorExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(0).variable()))
+            .setMethodName("getMethodDescriptor")
+            .build();
+    MethodInvocationExpr getOperationSnapshotFactoryExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(getMethodDescriptorExpr)
+            .setMethodName("getOperationSnapshotFactory")
+            .build();
     // This is a temporary solution
-    VaporReference requestT = VaporReference.builder()
-        .setName("RequestT")
-        .setPakkage("com.google.cloud.compute.v1.stub")
-        .build();
-    TypeNode operationSnapshotCallableType = TypeNode.withReference(
-        ConcreteReference.builder()
-            .setClazz(HttpJsonOperationSnapshotCallable.class)
-            .setGenerics(requestT, ConcreteReference.withClazz(Operation.class))
-            .build());
-    NewObjectExpr initialCallableObject = NewObjectExpr.builder()
-        .setType(operationSnapshotCallableType)
-        .setIsGeneric(true)
-        .setArguments(innerCallableVarExpr, getOperationSnapshotFactoryExpr)
-        .build();
-    AssignmentExpr initialCallableAssignExpr = AssignmentExpr.builder()
-        .setVariableExpr(initialCallableVarExpr.toBuilder().setIsDecl(true).build())
-        .setValueExpr(initialCallableObject)
-        .build();
+    VaporReference requestT =
+        VaporReference.builder()
+            .setName("RequestT")
+            .setPakkage("com.google.cloud.compute.v1.stub")
+            .build();
+    TypeNode operationSnapshotCallableType =
+        TypeNode.withReference(
+            ConcreteReference.builder()
+                .setClazz(HttpJsonOperationSnapshotCallable.class)
+                .setGenerics(requestT, ConcreteReference.withClazz(Operation.class))
+                .build());
+    NewObjectExpr initialCallableObject =
+        NewObjectExpr.builder()
+            .setType(operationSnapshotCallableType)
+            .setIsGeneric(true)
+            .setArguments(innerCallableVarExpr, getOperationSnapshotFactoryExpr)
+            .build();
+    AssignmentExpr initialCallableAssignExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(initialCallableVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(initialCallableObject)
+            .build();
     createOperationCallableBody.add(ExprStatement.withExpr(initialCallableAssignExpr));
 
     // Generate return statement
-    MethodInvocationExpr longRunningClient = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(3).variable()))
-        .setMethodName("longRunningClient")
-        .build();
-    MethodInvocationExpr createOperationCallable = MethodInvocationExpr.builder()
-        .setStaticReferenceType(
-            TypeNode.withReference(ConcreteReference.withClazz(HttpJsonCallableFactory.class)))
-        .setMethodName("createOperationCallable")
-        .setArguments(
-            VariableExpr.withVariable(arguments.get(1).variable()),
-            VariableExpr.withVariable(arguments.get(2).variable()),
-            longRunningClient,
-            initialCallableVarExpr
-        )
-        .setReturnType(TypeNode.withReference(ConcreteReference.withClazz(OperationCallable.class)))
-        .build();
+    MethodInvocationExpr longRunningClient =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(3).variable()))
+            .setMethodName("longRunningClient")
+            .build();
+    MethodInvocationExpr createOperationCallable =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(
+                TypeNode.withReference(ConcreteReference.withClazz(HttpJsonCallableFactory.class)))
+            .setMethodName("createOperationCallable")
+            .setArguments(
+                VariableExpr.withVariable(arguments.get(1).variable()),
+                VariableExpr.withVariable(arguments.get(2).variable()),
+                longRunningClient,
+                initialCallableVarExpr)
+            .setReturnType(
+                TypeNode.withReference(ConcreteReference.withClazz(OperationCallable.class)))
+            .build();
 
     // Add body and return statement to method
-    return method.toBuilder()
+    return method
+        .toBuilder()
         .setBody(createOperationCallableBody)
         .setReturnExpr(createOperationCallable)
         .build();

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
@@ -122,7 +122,10 @@ public class HttpJsonServiceCallableFactoryClassComposer
     List<Statement> createOperationCallableBody = new ArrayList<Statement>(2);
 
     List<VariableExpr> arguments = method.arguments();
-
+    Variable httpJsonCallSettingsVar = arguments.get(0).variable();
+    Variable callSettingsVar = arguments.get(1).variable();
+    Variable clientContextVar  = arguments.get(2).variable();
+    Variable operationsStub = arguments.get(3).variable();
     // Generate innerCallable
     VariableExpr innerCallableVarExpr =
         VariableExpr.builder()
@@ -136,7 +139,7 @@ public class HttpJsonServiceCallableFactoryClassComposer
             .build();
     MethodInvocationExpr getInitialCallSettingsExpr =
         MethodInvocationExpr.builder()
-            .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(1).variable()))
+            .setExprReferenceExpr(VariableExpr.withVariable(callSettingsVar))
             .setMethodName("getInitialCallSettings")
             .build();
     MethodInvocationExpr createBaseUnaryCallableExpr =
@@ -145,9 +148,9 @@ public class HttpJsonServiceCallableFactoryClassComposer
                 TypeNode.withReference(ConcreteReference.withClazz(HttpJsonCallableFactory.class)))
             .setMethodName("createBaseUnaryCallable")
             .setArguments(
-                VariableExpr.withVariable(arguments.get(0).variable()),
+                VariableExpr.withVariable(httpJsonCallSettingsVar),
                 getInitialCallSettingsExpr,
-                VariableExpr.withVariable(arguments.get(2).variable()))
+                VariableExpr.withVariable(clientContextVar))
             .setReturnType(TypeNode.withReference(ConcreteReference.withClazz(UnaryCallable.class)))
             .build();
     AssignmentExpr innerCallableAssignExpr =
@@ -170,7 +173,7 @@ public class HttpJsonServiceCallableFactoryClassComposer
             .build();
     MethodInvocationExpr getMethodDescriptorExpr =
         MethodInvocationExpr.builder()
-            .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(0).variable()))
+            .setExprReferenceExpr(VariableExpr.withVariable(httpJsonCallSettingsVar))
             .setMethodName("getMethodDescriptor")
             .build();
     MethodInvocationExpr getOperationSnapshotFactoryExpr =
@@ -206,7 +209,7 @@ public class HttpJsonServiceCallableFactoryClassComposer
     // Generate return statement
     MethodInvocationExpr longRunningClient =
         MethodInvocationExpr.builder()
-            .setExprReferenceExpr(VariableExpr.withVariable(arguments.get(3).variable()))
+            .setExprReferenceExpr(VariableExpr.withVariable(operationsStub))
             .setMethodName("longRunningClient")
             .build();
     MethodInvocationExpr createOperationCallable =
@@ -215,8 +218,8 @@ public class HttpJsonServiceCallableFactoryClassComposer
                 TypeNode.withReference(ConcreteReference.withClazz(HttpJsonCallableFactory.class)))
             .setMethodName("createOperationCallable")
             .setArguments(
-                VariableExpr.withVariable(arguments.get(1).variable()),
-                VariableExpr.withVariable(arguments.get(2).variable()),
+                VariableExpr.withVariable(callSettingsVar),
+                VariableExpr.withVariable(clientContextVar),
                 longRunningClient,
                 initialCallableVarExpr)
             .setReturnType(

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
@@ -124,7 +124,7 @@ public class HttpJsonServiceCallableFactoryClassComposer
     List<VariableExpr> arguments = method.arguments();
     Variable httpJsonCallSettingsVar = arguments.get(0).variable();
     Variable callSettingsVar = arguments.get(1).variable();
-    Variable clientContextVar  = arguments.get(2).variable();
+    Variable clientContextVar = arguments.get(2).variable();
     Variable operationsStub = arguments.get(3).variable();
     // Generate innerCallable
     VariableExpr innerCallableVarExpr =

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -31,8 +31,8 @@ import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.EnumRefExpr;
 import com.google.api.generator.engine.ast.Expr;
 import com.google.api.generator.engine.ast.ExprStatement;
-import com.google.api.generator.engine.ast.LambdaExpr;
 import com.google.api.generator.engine.ast.IfStatement;
+import com.google.api.generator.engine.ast.LambdaExpr;
 import com.google.api.generator.engine.ast.MethodDefinition;
 import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.NewObjectExpr;
@@ -120,8 +120,14 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
         methodMaker.apply("setRequestFormatter", getRequestFormatterExpr(protoMethod)).apply(expr);
     expr = methodMaker.apply("setResponseParser", setResponseParserExpr(protoMethod)).apply(expr);
 
-    expr = methodMaker.apply("setOperationSnapshotFactory", setOperationSnapshotFactoryExpr(protoMethod)).apply(expr);
-    expr = methodMaker.apply("setPollingRequestFactory", setPollingRequestFactoryExpr(protoMethod)).apply(expr);
+    expr =
+        methodMaker
+            .apply("setOperationSnapshotFactory", setOperationSnapshotFactoryExpr(protoMethod))
+            .apply(expr);
+    expr =
+        methodMaker
+            .apply("setPollingRequestFactory", setPollingRequestFactoryExpr(protoMethod))
+            .apply(expr);
 
     expr =
         MethodInvocationExpr.builder()
@@ -369,10 +375,12 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
         methodMaker = getMethodMaker();
 
     // Generate input varibles for create()
-    VariableExpr requestVarExpr = VariableExpr.withVariable(
-        Variable.builder().setType(protoMethod.inputType()).setName("request").build());
-    VariableExpr responseVarExpr = VariableExpr.withVariable(
-        Variable.builder().setType(protoMethod.outputType()).setName("response").build());
+    VariableExpr requestVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setType(protoMethod.inputType()).setName("request").build());
+    VariableExpr responseVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setType(protoMethod.outputType()).setName("response").build());
 
     List<Statement> createBody = new ArrayList<Statement>(4);
 
@@ -385,11 +393,10 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     MethodInvocationExpr getId =
         MethodInvocationExpr.builder()
             .setMethodName("getId")
-            .setExprReferenceExpr(responseVarExpr).build();
-    Expr opNameObjectExpr = NewObjectExpr.builder()
-        .setType(stringBuilderType)
-        .setArguments(getId)
-        .build();
+            .setExprReferenceExpr(responseVarExpr)
+            .build();
+    Expr opNameObjectExpr =
+        NewObjectExpr.builder().setType(stringBuilderType).setArguments(getId).build();
     AssignmentExpr opNameAssignExpr =
         AssignmentExpr.builder()
             .setVariableExpr(opNameVarExpr.toBuilder().setIsDecl(true).build())
@@ -398,101 +405,123 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     createBody.add(ExprStatement.withExpr(opNameAssignExpr));
 
     // Generate changes opName
-    MethodInvocationExpr requestGetProjectExpr = MethodInvocationExpr.builder()
-        .setMethodName("getProject")
-        .setExprReferenceExpr(requestVarExpr)
-        .build();
+    MethodInvocationExpr requestGetProjectExpr =
+        MethodInvocationExpr.builder()
+            .setMethodName("getProject")
+            .setExprReferenceExpr(requestVarExpr)
+            .build();
     ValueExpr colonValueExpr =
         ValueExpr.builder().setValue(StringObjectValue.builder().setValue(":").build()).build();
-    MethodInvocationExpr opNameAppendColonProjectExpr = MethodInvocationExpr.builder()
-        .setMethodName("append")
-        .setArguments(colonValueExpr)
-        .setExprReferenceExpr(opNameVarExpr)
-        .build();
-    opNameAppendColonProjectExpr = methodMaker.apply(
-        "append", Collections.singletonList(requestGetProjectExpr))
-        .apply(opNameAppendColonProjectExpr);
+    MethodInvocationExpr opNameAppendColonProjectExpr =
+        MethodInvocationExpr.builder()
+            .setMethodName("append")
+            .setArguments(colonValueExpr)
+            .setExprReferenceExpr(opNameVarExpr)
+            .build();
+    opNameAppendColonProjectExpr =
+        methodMaker
+            .apply("append", Collections.singletonList(requestGetProjectExpr))
+            .apply(opNameAppendColonProjectExpr);
     createBody.add(ExprStatement.withExpr(opNameAppendColonProjectExpr));
 
     // Generate changes to opName
-    MethodInvocationExpr requestGetRegionExpr = MethodInvocationExpr.builder()
-        .setMethodName("getRegion")
-        .setExprReferenceExpr(requestVarExpr)
-        .build();
-    MethodInvocationExpr opNameAppendColonRegionExpr = MethodInvocationExpr.builder()
-        .setMethodName("append")
-        .setArguments(colonValueExpr)
-        .setExprReferenceExpr(opNameVarExpr)
-        .build();
-    opNameAppendColonRegionExpr = methodMaker.apply(
-        "append", Collections.singletonList(requestGetRegionExpr))
-        .apply(opNameAppendColonRegionExpr);
+    MethodInvocationExpr requestGetRegionExpr =
+        MethodInvocationExpr.builder()
+            .setMethodName("getRegion")
+            .setExprReferenceExpr(requestVarExpr)
+            .build();
+    MethodInvocationExpr opNameAppendColonRegionExpr =
+        MethodInvocationExpr.builder()
+            .setMethodName("append")
+            .setArguments(colonValueExpr)
+            .setExprReferenceExpr(opNameVarExpr)
+            .build();
+    opNameAppendColonRegionExpr =
+        methodMaker
+            .apply("append", Collections.singletonList(requestGetRegionExpr))
+            .apply(opNameAppendColonRegionExpr);
     createBody.add(ExprStatement.withExpr(opNameAppendColonRegionExpr));
 
     // Generate check status expression
-    MethodInvocationExpr getStatusExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(responseVarExpr)
-        .setMethodName("getStatus")
-        .build();
-    TypeNode statusType = TypeNode.withReference(
-        VaporReference.builder()
-            .setName("Status")
-            .setPakkage("com.google.cloud.compute.v1")
-            .setIsStaticImport(false)
-            .build());
-    VariableExpr statusDoneExpr = VariableExpr.builder()
-        .setVariable(Variable.builder().setName("DONE").setType(TypeNode.INT).build())
-        .setStaticReferenceType(statusType)
-        .build();
-    MethodInvocationExpr statusEqualsExpr = methodMaker.apply(
-        "equals", Collections.singletonList(statusDoneExpr)).apply(getStatusExpr);
+    MethodInvocationExpr getStatusExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(responseVarExpr)
+            .setMethodName("getStatus")
+            .build();
+    TypeNode statusType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("Status")
+                .setPakkage("com.google.cloud.compute.v1")
+                .setIsStaticImport(false)
+                .build());
+    VariableExpr statusDoneExpr =
+        VariableExpr.builder()
+            .setVariable(Variable.builder().setName("DONE").setType(TypeNode.INT).build())
+            .setStaticReferenceType(statusType)
+            .build();
+    MethodInvocationExpr statusEqualsExpr =
+        methodMaker.apply("equals", Collections.singletonList(statusDoneExpr)).apply(getStatusExpr);
 
     // Generate return statement
     TypeNode httpJsonOperationSnapshotType =
         TypeNode.withReference(ConcreteReference.withClazz(HttpJsonOperationSnapshot.class));
-    MethodInvocationExpr newBuilderExpr = MethodInvocationExpr.builder()
-        .setStaticReferenceType(httpJsonOperationSnapshotType)
-        .setMethodName("newBuilder")
-        .build();
-    MethodInvocationExpr opNameToStringExpr = MethodInvocationExpr.builder()
-        .setMethodName("toString")
-        .setExprReferenceExpr(opNameVarExpr)
-        .build();
-    MethodInvocationExpr getHttpErrorStatusCodeExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(responseVarExpr)
-        .setMethodName("getHttpErrorStatusCode")
-        .build();
-    MethodInvocationExpr getHttpErrorMessageExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(responseVarExpr)
-        .setMethodName("getHttpErrorMessage")
-        .build();
-    newBuilderExpr = methodMaker.apply(
-        "setName", Collections.singletonList(opNameToStringExpr)).apply(newBuilderExpr);
-    newBuilderExpr = methodMaker.apply(
-        "setMetadata", Collections.singletonList(responseVarExpr)).apply(newBuilderExpr);
-    newBuilderExpr = methodMaker.apply(
-        "setDone", Collections.singletonList(statusEqualsExpr)).apply(newBuilderExpr);
-    newBuilderExpr = methodMaker.apply(
-        "setResponse", Collections.singletonList(responseVarExpr)).apply(newBuilderExpr);
-    newBuilderExpr = methodMaker.apply(
-        "setError", Arrays.asList(
-            getHttpErrorStatusCodeExpr, getHttpErrorMessageExpr))
-        .apply(newBuilderExpr);
-    TypeNode operationSnapshotType = TypeNode.withReference(
-        ConcreteReference.builder().setClazz(OperationSnapshot.class).build());
-    MethodInvocationExpr buildExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(newBuilderExpr)
-        .setMethodName("build")
-        .setReturnType(operationSnapshotType)
-        .build();
+    MethodInvocationExpr newBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(httpJsonOperationSnapshotType)
+            .setMethodName("newBuilder")
+            .build();
+    MethodInvocationExpr opNameToStringExpr =
+        MethodInvocationExpr.builder()
+            .setMethodName("toString")
+            .setExprReferenceExpr(opNameVarExpr)
+            .build();
+    MethodInvocationExpr getHttpErrorStatusCodeExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(responseVarExpr)
+            .setMethodName("getHttpErrorStatusCode")
+            .build();
+    MethodInvocationExpr getHttpErrorMessageExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(responseVarExpr)
+            .setMethodName("getHttpErrorMessage")
+            .build();
+    newBuilderExpr =
+        methodMaker
+            .apply("setName", Collections.singletonList(opNameToStringExpr))
+            .apply(newBuilderExpr);
+    newBuilderExpr =
+        methodMaker
+            .apply("setMetadata", Collections.singletonList(responseVarExpr))
+            .apply(newBuilderExpr);
+    newBuilderExpr =
+        methodMaker
+            .apply("setDone", Collections.singletonList(statusEqualsExpr))
+            .apply(newBuilderExpr);
+    newBuilderExpr =
+        methodMaker
+            .apply("setResponse", Collections.singletonList(responseVarExpr))
+            .apply(newBuilderExpr);
+    newBuilderExpr =
+        methodMaker
+            .apply("setError", Arrays.asList(getHttpErrorStatusCodeExpr, getHttpErrorMessageExpr))
+            .apply(newBuilderExpr);
+    TypeNode operationSnapshotType =
+        TypeNode.withReference(
+            ConcreteReference.builder().setClazz(OperationSnapshot.class).build());
+    MethodInvocationExpr buildExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(newBuilderExpr)
+            .setMethodName("build")
+            .setReturnType(operationSnapshotType)
+            .build();
 
     // Generate lambda anonymous class
     return Collections.singletonList(
         LambdaExpr.builder()
             .setArguments(
                 requestVarExpr.toBuilder().setIsDecl(true).build(),
-                responseVarExpr.toBuilder().setIsDecl(true).build()
-            )
+                responseVarExpr.toBuilder().setIsDecl(true).build())
             .setBody(createBody)
             .setReturnExpr(buildExpr)
             .build());
@@ -506,68 +535,81 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     List<Statement> createBody = new ArrayList<Statement>(1);
 
     // Generate input variables for create
-    VariableExpr compoundOperationIdVarExpr = VariableExpr.builder()
-        .setVariable(
-            Variable.builder().setType(TypeNode.STRING).setName("compoundOperationId").build())
-        .build();
+    VariableExpr compoundOperationIdVarExpr =
+        VariableExpr.builder()
+            .setVariable(
+                Variable.builder().setType(TypeNode.STRING).setName("compoundOperationId").build())
+            .build();
 
     // Generate idComponenets
-    TypeNode listStringType = TypeNode.withReference(
-        ConcreteReference.builder()
-            .setClazz(List.class)
-            .setGenerics(ConcreteReference.withClazz(String.class))
-            .build());
-    TypeNode arrayListStringType = TypeNode.withReference(
-        ConcreteReference.builder()
-            .setClazz(ArrayList.class)
-            .setGenerics(ConcreteReference.withClazz(String.class))
-            .build());
+    TypeNode listStringType =
+        TypeNode.withReference(
+            ConcreteReference.builder()
+                .setClazz(List.class)
+                .setGenerics(ConcreteReference.withClazz(String.class))
+                .build());
+    TypeNode arrayListStringType =
+        TypeNode.withReference(
+            ConcreteReference.builder()
+                .setClazz(ArrayList.class)
+                .setGenerics(ConcreteReference.withClazz(String.class))
+                .build());
     TypeNode arraysType = TypeNode.withReference(ConcreteReference.withClazz(Arrays.class));
-    VariableExpr idComponentsVarExpr = VariableExpr.withVariable(
-        Variable.builder().setName("idComponents").setType(listStringType).build());
-    MethodInvocationExpr compoundOperationIdSplitExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(compoundOperationIdVarExpr)
-        .setMethodName("split")
-        .setArguments(ValueExpr.withValue(StringObjectValue.withValue(":")))
-        .setReturnType(arrayListStringType)
-        .build();
-    MethodInvocationExpr asListExpr = MethodInvocationExpr.builder()
-        .setStaticReferenceType(arraysType)
-        .setMethodName("asList")
-        .setArguments(compoundOperationIdSplitExpr)
-        .setReturnType(arrayListStringType)
-        .build();
-    AssignmentExpr idComponentsAssignExpr = AssignmentExpr.builder()
-        .setVariableExpr(idComponentsVarExpr.toBuilder().setIsDecl(true).build())
-        .setValueExpr(asListExpr)
-        .build();
+    VariableExpr idComponentsVarExpr =
+        VariableExpr.withVariable(
+            Variable.builder().setName("idComponents").setType(listStringType).build());
+    MethodInvocationExpr compoundOperationIdSplitExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(compoundOperationIdVarExpr)
+            .setMethodName("split")
+            .setArguments(ValueExpr.withValue(StringObjectValue.withValue(":")))
+            .setReturnType(arrayListStringType)
+            .build();
+    MethodInvocationExpr asListExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(arraysType)
+            .setMethodName("asList")
+            .setArguments(compoundOperationIdSplitExpr)
+            .setReturnType(arrayListStringType)
+            .build();
+    AssignmentExpr idComponentsAssignExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(idComponentsVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(asListExpr)
+            .build();
     createBody.add(ExprStatement.withExpr(idComponentsAssignExpr));
 
     // Generate return statement
-    TypeNode getRegionOperationRequestType = TypeNode.withReference(
-        VaporReference.builder()
-            .setName("GetRegionOperationRequest")
-            .setPakkage("com.google.cloud.compute.v1")
-            .setIsStaticImport(false)
-            .build());
-    MethodInvocationExpr newBuilderExpr = MethodInvocationExpr.builder()
-        .setStaticReferenceType(getRegionOperationRequestType)
-        .setMethodName("newBuilder")
-        .build();
-    newBuilderExpr = methodMaker.apply(
-        "setOperation", Collections.singletonList(getExpr(idComponentsVarExpr, "0")))
-        .apply(newBuilderExpr);
-    newBuilderExpr = methodMaker.apply(
-        "setProject", Collections.singletonList(getExpr(idComponentsVarExpr, "1")))
-        .apply(newBuilderExpr);
-    newBuilderExpr = methodMaker.apply(
-        "setRegion", Collections.singletonList(getExpr(idComponentsVarExpr, "2")))
-        .apply(newBuilderExpr);
-    MethodInvocationExpr buildExpr = MethodInvocationExpr.builder()
-        .setExprReferenceExpr(newBuilderExpr)
-        .setMethodName("build")
-        .setReturnType(getRegionOperationRequestType)
-        .build();
+    TypeNode getRegionOperationRequestType =
+        TypeNode.withReference(
+            VaporReference.builder()
+                .setName("GetRegionOperationRequest")
+                .setPakkage("com.google.cloud.compute.v1")
+                .setIsStaticImport(false)
+                .build());
+    MethodInvocationExpr newBuilderExpr =
+        MethodInvocationExpr.builder()
+            .setStaticReferenceType(getRegionOperationRequestType)
+            .setMethodName("newBuilder")
+            .build();
+    newBuilderExpr =
+        methodMaker
+            .apply("setOperation", Collections.singletonList(getExpr(idComponentsVarExpr, "0")))
+            .apply(newBuilderExpr);
+    newBuilderExpr =
+        methodMaker
+            .apply("setProject", Collections.singletonList(getExpr(idComponentsVarExpr, "1")))
+            .apply(newBuilderExpr);
+    newBuilderExpr =
+        methodMaker
+            .apply("setRegion", Collections.singletonList(getExpr(idComponentsVarExpr, "2")))
+            .apply(newBuilderExpr);
+    MethodInvocationExpr buildExpr =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(newBuilderExpr)
+            .setMethodName("build")
+            .setReturnType(getRegionOperationRequestType)
+            .build();
 
     // Return lambda anonymous class
     return Collections.singletonList(
@@ -575,20 +617,19 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
             .setArguments(compoundOperationIdVarExpr.toBuilder().setIsDecl(true).build())
             .setBody(createBody)
             .setReturnExpr(buildExpr)
-            .build()
-    );
+            .build());
   }
 
   // returns var.get(num);
   private MethodInvocationExpr getExpr(VariableExpr var, String num) {
-    return
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(var)
-            .setMethodName("get")
-            .setArguments(ValueExpr.builder().
-                setValue(
-                    PrimitiveValue.builder().setValue(num).setType(TypeNode.INT).build()).build())
-            .build();
+    return MethodInvocationExpr.builder()
+        .setExprReferenceExpr(var)
+        .setMethodName("get")
+        .setArguments(
+            ValueExpr.builder()
+                .setValue(PrimitiveValue.builder().setValue(num).setType(TypeNode.INT).build())
+                .build())
+        .build();
   }
 
   private Expr createFieldsExtractorClassInstance(

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -385,6 +385,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     List<Statement> createBody = new ArrayList<Statement>(4);
 
     // Generate opName
+    // This will be replaced and edited based on annotations
     TypeNode stringBuilderType =
         TypeNode.withReference(ConcreteReference.withClazz(StringBuilder.class));
     VariableExpr opNameVarExpr =
@@ -405,6 +406,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     createBody.add(ExprStatement.withExpr(opNameAssignExpr));
 
     // Generate changes opName
+    // This will be replaced and edited based on annotations
     MethodInvocationExpr requestGetProjectExpr =
         MethodInvocationExpr.builder()
             .setMethodName("getProject")
@@ -443,6 +445,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     createBody.add(ExprStatement.withExpr(opNameAppendColonRegionExpr));
 
     // Generate check status expression
+    // This will be replaced and edited based on annotations
     MethodInvocationExpr getStatusExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(responseVarExpr)
@@ -476,11 +479,13 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
             .setMethodName("toString")
             .setExprReferenceExpr(opNameVarExpr)
             .build();
+    // This will be replaced and edited based on annotations
     MethodInvocationExpr getHttpErrorStatusCodeExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(responseVarExpr)
             .setMethodName("getHttpErrorStatusCode")
             .build();
+    // This will be replaced and edited based on annotations
     MethodInvocationExpr getHttpErrorMessageExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(responseVarExpr)
@@ -580,6 +585,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     createBody.add(ExprStatement.withExpr(idComponentsAssignExpr));
 
     // Generate return statement
+    // This will be replaced and edited based on annotations
     TypeNode getRegionOperationRequestType =
         TypeNode.withReference(
             VaporReference.builder()

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -53,7 +53,6 @@ import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.collect.ImmutableList;
-import com.google.longrunning.Operation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -97,7 +96,10 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
 
   @Override
   protected Statement createMethodDescriptorVariableDecl(
-      Service service, Method protoMethod, VariableExpr methodDescriptorVarExpr, Map<String, Message> messageTypes) {
+      Service service,
+      Method protoMethod,
+      VariableExpr methodDescriptorVarExpr,
+      Map<String, Message> messageTypes) {
     MethodInvocationExpr expr =
         MethodInvocationExpr.builder()
             .setMethodName("newBuilder")
@@ -122,16 +124,18 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
         methodMaker.apply("setRequestFormatter", getRequestFormatterExpr(protoMethod)).apply(expr);
     expr = methodMaker.apply("setResponseParser", setResponseParserExpr(protoMethod)).apply(expr);
 
-    //System.out.println(protoMethod.outputType().reference().simpleName());
-    if(protoMethod.outputType().reference().simpleName().equals("Operation")) {
+    // System.out.println(protoMethod.outputType().reference().simpleName());
+    if (protoMethod.outputType().reference().simpleName().equals("Operation")) {
       expr =
           methodMaker
-              .apply("setOperationSnapshotFactory",
+              .apply(
+                  "setOperationSnapshotFactory",
                   setOperationSnapshotFactoryExpr(protoMethod, messageTypes))
               .apply(expr);
       expr =
           methodMaker
-              .apply("setPollingRequestFactory",
+              .apply(
+                  "setPollingRequestFactory",
                   setPollingRequestFactoryExpr(protoMethod, messageTypes))
               .apply(expr);
     }
@@ -376,7 +380,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
     return Collections.singletonList(expr);
   }
 
-  private List<Expr> setOperationSnapshotFactoryExpr(Method protoMethod, Map<String, Message> messageTypes) {
+  private List<Expr> setOperationSnapshotFactoryExpr(
+      Method protoMethod, Map<String, Message> messageTypes) {
 
     BiFunction<String, List<Expr>, Function<MethodInvocationExpr, MethodInvocationExpr>>
         methodMaker = getMethodMaker();
@@ -539,7 +544,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractServiceStubClassCo
             .build());
   }
 
-  private List<Expr> setPollingRequestFactoryExpr(Method protoMethod, Map<String, Message> messageTypes) {
+  private List<Expr> setPollingRequestFactoryExpr(
+      Method protoMethod, Map<String, Message> messageTypes) {
 
     BiFunction<String, List<Expr>, Function<MethodInvocationExpr, MethodInvocationExpr>>
         methodMaker = getMethodMaker();

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceCallableFactory.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceCallableFactory.golden
@@ -5,6 +5,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshotCallable;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
@@ -13,6 +14,8 @@ import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.compute.v1.stub.RequestT;
+import com.google.longrunning.Operation;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -63,6 +66,14 @@ public class HttpJsonComplianceCallableFactory
           OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
           ClientContext clientContext,
           BackgroundResource operationsStub) {
-    return null;
+    UnaryCallable<RequestT, Operation> innerCallable =
+        HttpJsonCallableFactory.createBaseUnaryCallable(
+            httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);
+    UnaryCallable<RequestT, Operation> initialCallable =
+        new HttpJsonOperationSnapshotCallable<RequestT, Operation>(
+            innerCallable,
+            httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
+    return HttpJsonCallableFactory.createOperationCallable(
+        callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
@@ -1,15 +1,11 @@
 package com.google.showcase.v1beta1.stub;
 
-import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
-import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
-
 import com.google.api.client.http.HttpMethods;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
-import com.google.api.gax.httpjson.FieldsExtractor;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
@@ -19,54 +15,17 @@ import com.google.api.gax.httpjson.ProtoRestSerializer;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.api.generator.engine.ast.AnnotationNode;
-import com.google.api.generator.engine.ast.AssignmentExpr;
-import com.google.api.generator.engine.ast.ConcreteReference;
-import com.google.api.generator.engine.ast.EnumRefExpr;
-import com.google.api.generator.engine.ast.Expr;
-import com.google.api.generator.engine.ast.ExprStatement;
-import com.google.api.generator.engine.ast.LambdaExpr;
-import com.google.api.generator.engine.ast.IfStatement;
-import com.google.api.generator.engine.ast.MethodDefinition;
-import com.google.api.generator.engine.ast.MethodInvocationExpr;
-import com.google.api.generator.engine.ast.NewObjectExpr;
-import com.google.api.generator.engine.ast.PrimitiveValue;
-import com.google.api.generator.engine.ast.ScopeNode;
-import com.google.api.generator.engine.ast.Statement;
-import com.google.api.generator.engine.ast.StringObjectValue;
-import com.google.api.generator.engine.ast.TypeNode;
-import com.google.api.generator.engine.ast.ValueExpr;
-import com.google.api.generator.engine.ast.VaporReference;
-import com.google.api.generator.engine.ast.Variable;
-import com.google.api.generator.engine.ast.VariableExpr;
-import com.google.api.generator.gapic.composer.common.AbstractServiceStubClassComposer;
-import com.google.api.generator.gapic.composer.store.TypeStore;
-import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
-import com.google.api.generator.gapic.model.Method;
-import com.google.api.generator.gapic.model.Service;
-import com.google.api.generator.gapic.utils.JavaStyle;
-import com.google.cloud.compute.v1.AddressAggregatedList;
-import com.google.cloud.compute.v1.AddressList;
-import com.google.cloud.compute.v1.AggregatedListAddressesRequest;
-import com.google.cloud.compute.v1.DeleteAddressRequest;
 import com.google.cloud.compute.v1.GetRegionOperationRequest;
-import com.google.cloud.compute.v1.InsertAddressRequest;
-import com.google.cloud.compute.v1.ListAddressesRequest;
-import com.google.cloud.compute.v1.Operation;
 import com.google.cloud.compute.v1.Status;
-import com.google.common.collect.ImmutableList;
+import com.google.showcase.v1beta1.RepeatRequest;
+import com.google.showcase.v1beta1.RepeatResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -222,6 +181,28 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (RepeatRequest request, RepeatResponse response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
@@ -1,26 +1,72 @@
 package com.google.showcase.v1beta1.stub;
 
+import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
+import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
+
 import com.google.api.client.http.HttpMethods;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.FieldsExtractor;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
 import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
+import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.showcase.v1beta1.RepeatRequest;
-import com.google.showcase.v1beta1.RepeatResponse;
+import com.google.api.generator.engine.ast.AnnotationNode;
+import com.google.api.generator.engine.ast.AssignmentExpr;
+import com.google.api.generator.engine.ast.ConcreteReference;
+import com.google.api.generator.engine.ast.EnumRefExpr;
+import com.google.api.generator.engine.ast.Expr;
+import com.google.api.generator.engine.ast.ExprStatement;
+import com.google.api.generator.engine.ast.LambdaExpr;
+import com.google.api.generator.engine.ast.IfStatement;
+import com.google.api.generator.engine.ast.MethodDefinition;
+import com.google.api.generator.engine.ast.MethodInvocationExpr;
+import com.google.api.generator.engine.ast.NewObjectExpr;
+import com.google.api.generator.engine.ast.PrimitiveValue;
+import com.google.api.generator.engine.ast.ScopeNode;
+import com.google.api.generator.engine.ast.Statement;
+import com.google.api.generator.engine.ast.StringObjectValue;
+import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.engine.ast.ValueExpr;
+import com.google.api.generator.engine.ast.VaporReference;
+import com.google.api.generator.engine.ast.Variable;
+import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.gapic.composer.common.AbstractServiceStubClassComposer;
+import com.google.api.generator.gapic.composer.store.TypeStore;
+import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
+import com.google.api.generator.gapic.model.Method;
+import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.utils.JavaStyle;
+import com.google.cloud.compute.v1.AddressAggregatedList;
+import com.google.cloud.compute.v1.AddressList;
+import com.google.cloud.compute.v1.AggregatedListAddressesRequest;
+import com.google.cloud.compute.v1.DeleteAddressRequest;
+import com.google.cloud.compute.v1.GetRegionOperationRequest;
+import com.google.cloud.compute.v1.InsertAddressRequest;
+import com.google.cloud.compute.v1.ListAddressesRequest;
+import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1.Status;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -64,6 +110,28 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (RepeatRequest request, RepeatResponse response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -98,6 +166,28 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (RepeatRequest request, RepeatResponse response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -178,6 +268,28 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (RepeatRequest request, RepeatResponse response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -222,6 +334,28 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (RepeatRequest request, RepeatResponse response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -263,6 +397,28 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (RepeatRequest request, RepeatResponse response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private final UnaryCallable<RepeatRequest, RepeatResponse> repeatDataBodyCallable;

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
@@ -7,21 +7,16 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
-import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
 import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
-import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.GetRegionOperationRequest;
-import com.google.cloud.compute.v1.Status;
 import com.google.showcase.v1beta1.RepeatRequest;
 import com.google.showcase.v1beta1.RepeatResponse;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,28 +64,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (RepeatRequest request, RepeatResponse response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -125,28 +98,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (RepeatRequest request, RepeatResponse response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -181,28 +132,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (RepeatRequest request, RepeatResponse response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -249,28 +178,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (RepeatRequest request, RepeatResponse response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -315,28 +222,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (RepeatRequest request, RepeatResponse response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private static final ApiMethodDescriptor<RepeatRequest, RepeatResponse>
@@ -378,28 +263,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
                       .setDefaultInstance(RepeatResponse.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (RepeatRequest request, RepeatResponse response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private final UnaryCallable<RepeatRequest, RepeatResponse> repeatDataBodyCallable;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesCallableFactory.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesCallableFactory.java
@@ -21,6 +21,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshotCallable;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
@@ -29,6 +30,7 @@ import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -79,6 +81,14 @@ public class HttpJsonAddressesCallableFactory
           OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
           ClientContext clientContext,
           BackgroundResource operationsStub) {
-    return null;
+    UnaryCallable<RequestT, Operation> innerCallable =
+        HttpJsonCallableFactory.createBaseUnaryCallable(
+            httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);
+    UnaryCallable<RequestT, Operation> initialCallable =
+        new HttpJsonOperationSnapshotCallable<RequestT, Operation>(
+            innerCallable,
+            httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
+    return HttpJsonCallableFactory.createOperationCallable(
+        callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
   }
 }

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesStub.java
@@ -26,21 +26,26 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
 import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
+import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.compute.v1.AddressAggregatedList;
 import com.google.cloud.compute.v1.AddressList;
 import com.google.cloud.compute.v1.AggregatedListAddressesRequest;
 import com.google.cloud.compute.v1.DeleteAddressRequest;
+import com.google.cloud.compute.v1.GetRegionOperationRequest;
 import com.google.cloud.compute.v1.InsertAddressRequest;
 import com.google.cloud.compute.v1.ListAddressesRequest;
 import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1.Status;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +107,28 @@ public class HttpJsonAddressesStub extends AddressesStub {
                   ProtoMessageResponseParser.<AddressAggregatedList>newBuilder()
                       .setDefaultInstance(AddressAggregatedList.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (AggregatedListAddressesRequest request, AddressAggregatedList response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private static final ApiMethodDescriptor<DeleteAddressRequest, Operation> deleteMethodDescriptor =
@@ -137,6 +164,28 @@ public class HttpJsonAddressesStub extends AddressesStub {
               ProtoMessageResponseParser.<Operation>newBuilder()
                   .setDefaultInstance(Operation.getDefaultInstance())
                   .build())
+          .setOperationSnapshotFactory(
+              (DeleteAddressRequest request, Operation response) -> {
+                StringBuilder opName = new StringBuilder(response.getId());
+                opName.append(":").append(request.getProject());
+                opName.append(":").append(request.getRegion());
+                return HttpJsonOperationSnapshot.newBuilder()
+                    .setName(opName.toString())
+                    .setMetadata(response)
+                    .setDone(response.getStatus().equals(Status.DONE))
+                    .setResponse(response)
+                    .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                    .build();
+              })
+          .setPollingRequestFactory(
+              compoundOperationId -> {
+                List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                return GetRegionOperationRequest.newBuilder()
+                    .setOperation(idComponents.get(0))
+                    .setProject(idComponents.get(1))
+                    .setRegion(idComponents.get(2))
+                    .build();
+              })
           .build();
 
   private static final ApiMethodDescriptor<InsertAddressRequest, Operation> insertMethodDescriptor =
@@ -174,6 +223,28 @@ public class HttpJsonAddressesStub extends AddressesStub {
               ProtoMessageResponseParser.<Operation>newBuilder()
                   .setDefaultInstance(Operation.getDefaultInstance())
                   .build())
+          .setOperationSnapshotFactory(
+              (InsertAddressRequest request, Operation response) -> {
+                StringBuilder opName = new StringBuilder(response.getId());
+                opName.append(":").append(request.getProject());
+                opName.append(":").append(request.getRegion());
+                return HttpJsonOperationSnapshot.newBuilder()
+                    .setName(opName.toString())
+                    .setMetadata(response)
+                    .setDone(response.getStatus().equals(Status.DONE))
+                    .setResponse(response)
+                    .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                    .build();
+              })
+          .setPollingRequestFactory(
+              compoundOperationId -> {
+                List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                return GetRegionOperationRequest.newBuilder()
+                    .setOperation(idComponents.get(0))
+                    .setProject(idComponents.get(1))
+                    .setRegion(idComponents.get(2))
+                    .build();
+              })
           .build();
 
   private static final ApiMethodDescriptor<ListAddressesRequest, AddressList> listMethodDescriptor =
@@ -215,6 +286,28 @@ public class HttpJsonAddressesStub extends AddressesStub {
               ProtoMessageResponseParser.<AddressList>newBuilder()
                   .setDefaultInstance(AddressList.getDefaultInstance())
                   .build())
+          .setOperationSnapshotFactory(
+              (ListAddressesRequest request, AddressList response) -> {
+                StringBuilder opName = new StringBuilder(response.getId());
+                opName.append(":").append(request.getProject());
+                opName.append(":").append(request.getRegion());
+                return HttpJsonOperationSnapshot.newBuilder()
+                    .setName(opName.toString())
+                    .setMetadata(response)
+                    .setDone(response.getStatus().equals(Status.DONE))
+                    .setResponse(response)
+                    .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                    .build();
+              })
+          .setPollingRequestFactory(
+              compoundOperationId -> {
+                List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                return GetRegionOperationRequest.newBuilder()
+                    .setOperation(idComponents.get(0))
+                    .setProject(idComponents.get(1))
+                    .setRegion(idComponents.get(2))
+                    .build();
+              })
           .build();
 
   private final UnaryCallable<AggregatedListAddressesRequest, AddressAggregatedList>

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonAddressesStub.java
@@ -107,28 +107,6 @@ public class HttpJsonAddressesStub extends AddressesStub {
                   ProtoMessageResponseParser.<AddressAggregatedList>newBuilder()
                       .setDefaultInstance(AddressAggregatedList.getDefaultInstance())
                       .build())
-              .setOperationSnapshotFactory(
-                  (AggregatedListAddressesRequest request, AddressAggregatedList response) -> {
-                    StringBuilder opName = new StringBuilder(response.getId());
-                    opName.append(":").append(request.getProject());
-                    opName.append(":").append(request.getRegion());
-                    return HttpJsonOperationSnapshot.newBuilder()
-                        .setName(opName.toString())
-                        .setMetadata(response)
-                        .setDone(response.getStatus().equals(Status.DONE))
-                        .setResponse(response)
-                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                        .build();
-                  })
-              .setPollingRequestFactory(
-                  compoundOperationId -> {
-                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                    return GetRegionOperationRequest.newBuilder()
-                        .setOperation(idComponents.get(0))
-                        .setProject(idComponents.get(1))
-                        .setRegion(idComponents.get(2))
-                        .build();
-                  })
               .build();
 
   private static final ApiMethodDescriptor<DeleteAddressRequest, Operation> deleteMethodDescriptor =
@@ -286,28 +264,6 @@ public class HttpJsonAddressesStub extends AddressesStub {
               ProtoMessageResponseParser.<AddressList>newBuilder()
                   .setDefaultInstance(AddressList.getDefaultInstance())
                   .build())
-          .setOperationSnapshotFactory(
-              (ListAddressesRequest request, AddressList response) -> {
-                StringBuilder opName = new StringBuilder(response.getId());
-                opName.append(":").append(request.getProject());
-                opName.append(":").append(request.getRegion());
-                return HttpJsonOperationSnapshot.newBuilder()
-                    .setName(opName.toString())
-                    .setMetadata(response)
-                    .setDone(response.getStatus().equals(Status.DONE))
-                    .setResponse(response)
-                    .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
-                    .build();
-              })
-          .setPollingRequestFactory(
-              compoundOperationId -> {
-                List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
-                return GetRegionOperationRequest.newBuilder()
-                    .setOperation(idComponents.get(0))
-                    .setProject(idComponents.get(1))
-                    .setRegion(idComponents.get(2))
-                    .build();
-              })
           .build();
 
   private final UnaryCallable<AggregatedListAddressesRequest, AddressAggregatedList>

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonRegionOperationsCallableFactory.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonRegionOperationsCallableFactory.java
@@ -21,6 +21,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.httpjson.ApiMessage;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshotCallable;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
@@ -29,6 +30,7 @@ import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -79,6 +81,14 @@ public class HttpJsonRegionOperationsCallableFactory
           OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
           ClientContext clientContext,
           BackgroundResource operationsStub) {
-    return null;
+    UnaryCallable<RequestT, Operation> innerCallable =
+        HttpJsonCallableFactory.createBaseUnaryCallable(
+            httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);
+    UnaryCallable<RequestT, Operation> initialCallable =
+        new HttpJsonOperationSnapshotCallable<RequestT, Operation>(
+            innerCallable,
+            httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
+    return HttpJsonCallableFactory.createOperationCallable(
+        callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
   }
 }

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonRegionOperationsStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1/stub/HttpJsonRegionOperationsStub.java
@@ -23,16 +23,20 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
 import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
 import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
+import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.compute.v1.GetRegionOperationRequest;
 import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1.Status;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +83,28 @@ public class HttpJsonRegionOperationsStub extends RegionOperationsStub {
                   ProtoMessageResponseParser.<Operation>newBuilder()
                       .setDefaultInstance(Operation.getDefaultInstance())
                       .build())
+              .setOperationSnapshotFactory(
+                  (GetRegionOperationRequest request, Operation response) -> {
+                    StringBuilder opName = new StringBuilder(response.getId());
+                    opName.append(":").append(request.getProject());
+                    opName.append(":").append(request.getRegion());
+                    return HttpJsonOperationSnapshot.newBuilder()
+                        .setName(opName.toString())
+                        .setMetadata(response)
+                        .setDone(response.getStatus().equals(Status.DONE))
+                        .setResponse(response)
+                        .setError(response.getHttpErrorStatusCode(), response.getHttpErrorMessage())
+                        .build();
+                  })
+              .setPollingRequestFactory(
+                  compoundOperationId -> {
+                    List<String> idComponents = Arrays.asList(compoundOperationId.split(":"));
+                    return GetRegionOperationRequest.newBuilder()
+                        .setOperation(idComponents.get(0))
+                        .setProject(idComponents.get(1))
+                        .setRegion(idComponents.get(2))
+                        .build();
+                  })
               .build();
 
   private final UnaryCallable<GetRegionOperationRequest, Operation> getCallable;


### PR DESCRIPTION
Added methods to HttpJsonServiceCallableFactoryClassComposer and HttpJsonServiceStubClassComposer to generate LRO machinery without annotations. Used the established AST format.

Methods generated:
- getOperationSnapshotFactory
- setPollingRequestFactory
- createOperationCallable

TODO:
Add annotations
Find alternative way of representing generic types. Currently using a vapor reference with the same package as the class being generated.