### PR TITLE
feat: REGAPIC Multitransport implementation (grpc+rest)

### DIFF
--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -351,10 +351,12 @@ def java_gapic_assembly_gradle_pkg(
         grpc_target_dep = ["%s" % grpc_target]
 
     if client_deps:
-        if transport == "rest":
-            template_label = Label("//rules_java_gapic:resources/gradle/client_rest.gradle.tmpl")
-        else:
+        if not transport or transport == "rest":
             template_label = Label("//rules_java_gapic:resources/gradle/client_grpc.gradle.tmpl")
+        elif transport == "rest":
+            template_label = Label("//rules_java_gapic:resources/gradle/client_rest.gradle.tmpl")
+        elif transport == "grpc+rest":
+            template_label = Label("//rules_java_gapic:resources/gradle/client_grpcrest.gradle.tmpl")
 
         _java_gapic_gradle_pkg(
             name = client_target,

--- a/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
@@ -1,0 +1,63 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+}
+
+apply plugin: 'java'
+
+description = 'GAPIC library for {{name}}'
+group = 'com.google.cloud'
+version = (findProperty('version') == 'unspecified') ? '0.0.0-SNAPSHOT' : version
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+  mavenLocal()
+}
+
+compileJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
+
+dependencies {
+  compile 'com.google.api:gax:{{version.gax}}'
+  testCompile 'com.google.api:gax:{{version.gax}}:testlib'
+  compile 'com.google.api:gax-grpc:{{version.gax_grpc}}'
+  testCompile 'com.google.api:gax-grpc:{{version.gax_grpc}}:testlib'
+  compile 'com.google.api:gax-httpjson:{{version.gax_httpjson}}'
+  testCompile 'com.google.api:gax-httpjson:{{version.gax_httpjson}}:testlib'
+  testCompile 'io.grpc:grpc-netty-shaded:{{version.io_grpc}}'
+  testCompile '{{maven.junit_junit}}'
+  {{extra_deps}}
+}
+
+task smokeTest(type: Test) {
+  filter {
+    includeTestsMatching "*SmokeTest"
+    setFailOnNoMatchingTests false
+  }
+}
+
+test {
+  exclude "**/*SmokeTest*"
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir 'src/main/java'
+    }
+  }
+}
+
+clean {
+  delete 'all-jars'
+}
+
+task allJars(type: Copy) {
+  dependsOn test, jar
+  into 'all-jars'
+  // Replace with `from configurations.testRuntime, jar` to include test dependencies
+  from configurations.runtime, jar
+}

--- a/src/main/java/com/google/api/generator/gapic/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/BUILD.bazel
@@ -9,6 +9,7 @@ filegroup(
         "//src/main/java/com/google/api/generator/gapic/composer/comment:comment_files",
         "//src/main/java/com/google/api/generator/gapic/composer/defaultvalue:defaultvalue_files",
         "//src/main/java/com/google/api/generator/gapic/composer/grpc:grpc_files",
+        "//src/main/java/com/google/api/generator/gapic/composer/grpcrest:grpcrest_files",
         "//src/main/java/com/google/api/generator/gapic/composer/resourcename:resourcename_files",
         "//src/main/java/com/google/api/generator/gapic/composer/rest:rest_files",
         "//src/main/java/com/google/api/generator/gapic/composer/samplecode:samplecode_files",

--- a/src/main/java/com/google/api/generator/gapic/composer/Composer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/Composer.java
@@ -15,7 +15,6 @@
 package com.google.api.generator.gapic.composer;
 
 import com.google.api.generator.engine.ast.ClassDefinition;
-import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.gapic.composer.comment.CommentComposer;
 import com.google.api.generator.gapic.composer.grpc.GrpcServiceCallableFactoryClassComposer;
 import com.google.api.generator.gapic.composer.grpc.GrpcServiceStubClassComposer;
@@ -26,11 +25,11 @@ import com.google.api.generator.gapic.composer.grpc.ServiceClientTestClassCompos
 import com.google.api.generator.gapic.composer.grpc.ServiceSettingsClassComposer;
 import com.google.api.generator.gapic.composer.grpc.ServiceStubClassComposer;
 import com.google.api.generator.gapic.composer.grpc.ServiceStubSettingsClassComposer;
+import com.google.api.generator.gapic.composer.grpcrest.HttpJsonServiceClientTestClassComposer;
 import com.google.api.generator.gapic.composer.resourcename.ResourceNameHelperClassComposer;
 import com.google.api.generator.gapic.composer.rest.HttpJsonServiceCallableFactoryClassComposer;
 import com.google.api.generator.gapic.composer.rest.HttpJsonServiceStubClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
-import com.google.api.generator.gapic.model.GapicClass.Kind;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.GapicPackageInfo;
 import com.google.api.generator.gapic.model.Service;
@@ -87,12 +86,30 @@ public class Composer {
                 clazzes.add(
                     HttpJsonServiceCallableFactoryClassComposer.instance().generate(context, s));
                 clazzes.add(HttpJsonServiceStubClassComposer.instance().generate(context, s));
-              } else {
+              } else if (context.transport() == Transport.GRPC) {
                 clazzes.add(ServiceStubClassComposer.instance().generate(context, s));
                 clazzes.add(ServiceStubSettingsClassComposer.instance().generate(context, s));
                 clazzes.add(
                     GrpcServiceCallableFactoryClassComposer.instance().generate(context, s));
                 clazzes.add(GrpcServiceStubClassComposer.instance().generate(context, s));
+              } else if (context.transport() == Transport.GRPC_REST) {
+                clazzes.add(
+                    com.google.api.generator.gapic.composer.grpcrest.ServiceStubClassComposer
+                        .instance()
+                        .generate(context, s));
+                clazzes.add(
+                    com.google.api.generator.gapic.composer.grpcrest
+                        .ServiceStubSettingsClassComposer.instance()
+                        .generate(context, s));
+                clazzes.add(
+                    GrpcServiceCallableFactoryClassComposer.instance().generate(context, s));
+                clazzes.add(GrpcServiceStubClassComposer.instance().generate(context, s));
+                clazzes.add(
+                    HttpJsonServiceCallableFactoryClassComposer.instance().generate(context, s));
+                clazzes.add(
+                    com.google.api.generator.gapic.composer.grpcrest
+                        .HttpJsonServiceStubClassComposer.instance()
+                        .generate(context, s));
               }
             });
     return clazzes;
@@ -113,9 +130,18 @@ public class Composer {
                     com.google.api.generator.gapic.composer.rest.ServiceSettingsClassComposer
                         .instance()
                         .generate(context, s));
-              } else {
+              } else if (context.transport() == Transport.GRPC) {
                 clazzes.add(ServiceClientClassComposer.instance().generate(context, s));
                 clazzes.add(ServiceSettingsClassComposer.instance().generate(context, s));
+              } else if (context.transport() == Transport.GRPC_REST) {
+                clazzes.add(
+                    com.google.api.generator.gapic.composer.grpcrest.ServiceClientClassComposer
+                        .instance()
+                        .generate(context, s));
+                clazzes.add(
+                    com.google.api.generator.gapic.composer.grpcrest.ServiceSettingsClassComposer
+                        .instance()
+                        .generate(context, s));
               }
             });
     return clazzes;
@@ -127,7 +153,10 @@ public class Composer {
         s -> {
           if (context.transport() == Transport.REST) {
             // REST transport tests donot not use mock services.
-          } else {
+          } else if (context.transport() == Transport.GRPC) {
+            clazzes.add(MockServiceClassComposer.instance().generate(context, s));
+            clazzes.add(MockServiceImplClassComposer.instance().generate(context, s));
+          } else if (context.transport() == Transport.GRPC_REST) {
             clazzes.add(MockServiceClassComposer.instance().generate(context, s));
             clazzes.add(MockServiceImplClassComposer.instance().generate(context, s));
           }
@@ -136,35 +165,25 @@ public class Composer {
   }
 
   public static List<GapicClass> generateTestClasses(GapicContext context) {
-    return context.services().stream()
-        .map(
+    List<GapicClass> clazzes = new ArrayList<>();
+    context
+        .services()
+        .forEach(
             s -> {
               if (context.transport() == Transport.REST) {
-                return com.google.api.generator.gapic.composer.rest.ServiceClientTestClassComposer
-                    .instance()
-                    .generate(context, s);
-              } else {
-                return ServiceClientTestClassComposer.instance().generate(context, s);
+                clazzes.add(
+                    com.google.api.generator.gapic.composer.rest.ServiceClientTestClassComposer
+                        .instance()
+                        .generate(context, s));
+              } else if (context.transport() == Transport.GRPC) {
+                clazzes.add(ServiceClientTestClassComposer.instance().generate(context, s));
+              } else if (context.transport() == Transport.GRPC_REST) {
+                clazzes.add(ServiceClientTestClassComposer.instance().generate(context, s));
+                clazzes.add(HttpJsonServiceClientTestClassComposer.instance().generate(context, s));
               }
-            })
-        .collect(Collectors.toList());
-  }
+            });
 
-  /** ====================== HELPERS ==================== */
-  // TODO(miraleung): Add method list.
-  private static GapicClass generateGenericClass(Kind kind, String name, Service service) {
-    String pakkage = service.pakkage();
-    if (kind.equals(Kind.STUB)) {
-      pakkage += ".stub";
-    }
-
-    ClassDefinition classDef =
-        ClassDefinition.builder()
-            .setPackageString(pakkage)
-            .setName(name)
-            .setScope(ScopeNode.PUBLIC)
-            .build();
-    return GapicClass.create(kind, classDef);
+    return clazzes;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
@@ -257,7 +257,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
               .setVariable(
                   Variable.builder()
                       .setName("operationsStub")
-                      .setType(getTransportContext().operationsStubType())
+                      .setType(getTransportContext().operationsStubTypes().get(0))
                       .build())
               .setIsDecl(true)
               .build());

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -109,12 +109,14 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
 
   @Override
   public GapicClass generate(GapicContext context, Service service) {
+    return generate(ClassNames.getServiceClientTestClassName(service), context, service);
+  }
+
+  protected GapicClass generate(String className, GapicContext context, Service service) {
     Map<String, ResourceName> resourceNames = context.helperResourceNames();
-    Map<String, Message> messageTypes = context.messages();
     String pakkage = service.pakkage();
     TypeStore typeStore = new TypeStore();
     addDynamicTypes(context, service, typeStore);
-    String className = ClassNames.getServiceClientTestClassName(service);
     GapicClass.Kind kind = Kind.MAIN;
 
     Map<String, VariableExpr> classMemberVarExprs =
@@ -196,7 +198,8 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
       TypeStore typeStore) {
     List<MethodDefinition> javaMethods = new ArrayList<>();
     javaMethods.add(
-        createStartStaticServerMethod(service, context, classMemberVarExprs, typeStore));
+        createStartStaticServerMethod(
+            service, context, classMemberVarExprs, typeStore, "newBuilder"));
     javaMethods.add(createStopServerMethod(service, classMemberVarExprs));
     javaMethods.add(createSetUpMethod(service, classMemberVarExprs, typeStore));
     javaMethods.add(createTearDownMethod(service, classMemberVarExprs));
@@ -207,7 +210,8 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
       Service service,
       GapicContext context,
       Map<String, VariableExpr> classMemberVarExprs,
-      TypeStore typeStore);
+      TypeStore typeStore,
+      String newBuilderMethod);
 
   protected abstract MethodDefinition createStopServerMethod(
       Service service, Map<String, VariableExpr> classMemberVarExprs);

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
@@ -62,11 +62,13 @@ import com.google.api.generator.gapic.model.Method.Stream;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.longrunning.Operation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -172,6 +174,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
     javaMethods.addAll(createSettingsGetterMethods(service, typeStore));
     javaMethods.add(createCreatorMethod(service, typeStore));
     javaMethods.addAll(createDefaultGetterMethods(service, typeStore));
+    javaMethods.addAll(createNewBuilderMethods(service, typeStore, "newBuilder", "createDefault"));
     javaMethods.addAll(createBuilderHelperMethods(service, typeStore));
     javaMethods.add(createConstructorMethod(service, typeStore));
     return javaMethods;
@@ -351,12 +354,19 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
                 "defaultCredentialsProviderBuilder",
                 typeMakerFn.apply(GoogleCredentialsProvider.Builder.class)),
             SettingsCommentComposer.DEFAULT_CREDENTIALS_PROVIDER_BUILDER_METHOD_COMMENT));
-    javaMethods.add(
-        methodMakerFn.apply(
-            methodStarterFn.apply(
-                getTransportContext().defaultTransportProviderBuilderName(),
-                typeMakerFn.apply(getTransportContext().instantiatingChannelProviderClass())),
-            SettingsCommentComposer.DEFAULT_TRANSPORT_PROVIDER_BUILDER_METHOD_COMMENT));
+
+    Iterator<String> providerBuilderNamesIt =
+        getTransportContext().defaultTransportProviderBuilderNames().iterator();
+    Iterator<Class<?>> channelProviderClassesIt =
+        getTransportContext().instantiatingChannelProviderBuilderClasses().iterator();
+    while (providerBuilderNamesIt.hasNext() && channelProviderClassesIt.hasNext()) {
+      javaMethods.add(
+          methodMakerFn.apply(
+              methodStarterFn.apply(
+                  providerBuilderNamesIt.next(),
+                  typeMakerFn.apply(channelProviderClassesIt.next())),
+              SettingsCommentComposer.DEFAULT_TRANSPORT_PROVIDER_BUILDER_METHOD_COMMENT));
+    }
 
     javaMethods.add(
         methodStarterFn
@@ -383,23 +393,31 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
     return javaMethods;
   }
 
-  private static List<MethodDefinition> createBuilderHelperMethods(
-      Service service, TypeStore typeStore) {
+  protected List<MethodDefinition> createNewBuilderMethods(
+      Service service,
+      TypeStore typeStore,
+      String newBuilderMethodName,
+      String createDefaultMethodName) {
     TypeNode builderType = typeStore.get(BUILDER_CLASS_NAME);
-    MethodDefinition newBuilderMethodOne =
+    return ImmutableList.of(
         MethodDefinition.builder()
             .setHeaderCommentStatements(SettingsCommentComposer.NEW_BUILDER_METHOD_COMMENT)
             .setScope(ScopeNode.PUBLIC)
             .setIsStatic(true)
             .setReturnType(builderType)
-            .setName("newBuilder")
+            .setName(newBuilderMethodName)
             .setReturnExpr(
                 MethodInvocationExpr.builder()
                     .setStaticReferenceType(builderType)
-                    .setMethodName("createDefault")
+                    .setMethodName(createDefaultMethodName)
                     .setReturnType(builderType)
                     .build())
-            .build();
+            .build());
+  }
+
+  private static List<MethodDefinition> createBuilderHelperMethods(
+      Service service, TypeStore typeStore) {
+    TypeNode builderType = typeStore.get(BUILDER_CLASS_NAME);
 
     VariableExpr clientContextVarExpr =
         VariableExpr.withVariable(
@@ -439,10 +457,10 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
                     .build())
             .build();
 
-    return Arrays.asList(newBuilderMethodOne, newBuilderMethodTwo, toBuilderMethod);
+    return Arrays.asList(newBuilderMethodTwo, toBuilderMethod);
   }
 
-  private static ClassDefinition createNestedBuilderClass(Service service, TypeStore typeStore) {
+  private ClassDefinition createNestedBuilderClass(Service service, TypeStore typeStore) {
     return ClassDefinition.builder()
         .setHeaderCommentStatements(
             SettingsCommentComposer.createBuilderClassComment(
@@ -466,11 +484,12 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
         .build();
   }
 
-  private static List<MethodDefinition> createNestedBuilderClassMethods(
+  private List<MethodDefinition> createNestedBuilderClassMethods(
       Service service, TypeStore typeStore) {
     List<MethodDefinition> javaMethods = new ArrayList<>();
     javaMethods.addAll(createNestedBuilderConstructorMethods(service, typeStore));
-    javaMethods.add(createNestedBuilderCreatorMethod(service, typeStore));
+    javaMethods.addAll(
+        createNestedBuilderCreatorMethods(service, typeStore, "newBuilder", "createDefault"));
     javaMethods.add(createNestedBuilderStubSettingsBuilderMethod(service, typeStore));
     javaMethods.add(createNestedBuilderApplyToAllUnaryMethod(service, typeStore));
     javaMethods.addAll(createNestedBuilderSettingsGetterMethods(service, typeStore));
@@ -557,23 +576,28 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
     return Arrays.asList(noArgCtor, clientContextCtor, settingsCtor, stubSettingsCtor);
   }
 
-  private static MethodDefinition createNestedBuilderCreatorMethod(
-      Service service, TypeStore typeStore) {
+  protected List<MethodDefinition> createNestedBuilderCreatorMethods(
+      Service service,
+      TypeStore typeStore,
+      String newBuilderMethodName,
+      String createDefaultMethodName) {
     MethodInvocationExpr ctorArg =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(
                 typeStore.get(ClassNames.getServiceStubSettingsClassName(service)))
-            .setMethodName("newBuilder")
+            .setMethodName(newBuilderMethodName)
             .build();
 
     TypeNode builderType = typeStore.get(BUILDER_CLASS_NAME);
-    return MethodDefinition.builder()
-        .setScope(ScopeNode.PRIVATE)
-        .setIsStatic(true)
-        .setReturnType(builderType)
-        .setName("createDefault")
-        .setReturnExpr(NewObjectExpr.builder().setType(builderType).setArguments(ctorArg).build())
-        .build();
+    return ImmutableList.of(
+        MethodDefinition.builder()
+            .setScope(ScopeNode.PRIVATE)
+            .setIsStatic(true)
+            .setReturnType(builderType)
+            .setName(createDefaultMethodName)
+            .setReturnExpr(
+                NewObjectExpr.builder().setType(builderType).setArguments(ctorArg).build())
+            .build());
   }
 
   private static MethodDefinition createNestedBuilderStubSettingsBuilderMethod(

--- a/src/main/java/com/google/api/generator/gapic/composer/common/TransportContext.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/TransportContext.java
@@ -19,6 +19,8 @@ import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.model.Transport;
 import com.google.auto.value.AutoValue;
+import java.util.List;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class TransportContext {
@@ -28,35 +30,46 @@ public abstract class TransportContext {
   // For AbstractServiceStubClassComposer
   public abstract Transport transport();
 
+  @Nullable
   public abstract String transportName();
 
+  @Nullable
   public abstract Class<?> callSettingsClass();
 
+  @Nullable
   public abstract TypeNode stubCallableFactoryType();
 
+  @Nullable
   public abstract Class<?> methodDescriptorClass();
 
-  public abstract TypeNode transportOperationsStubType();
+  public abstract List<TypeNode> transportOperationsStubTypes();
 
-  public abstract String transportOperationsStubName();
+  public abstract List<String> transportOperationsStubNames();
 
   // For AbstractServiceSettingsClassComposer
-  public abstract Class<?> instantiatingChannelProviderClass();
+  public abstract List<Class<?>> instantiatingChannelProviderClasses();
 
-  public abstract String defaultTransportProviderBuilderName();
+  public abstract List<Class<?>> instantiatingChannelProviderBuilderClasses();
+
+  public abstract List<String> defaultTransportProviderBuilderNames();
+
+  public abstract List<String> transportApiClientHeaderProviderBuilderNames();
 
   // For AbstractServiceStubSettingsClassComposer
-  public abstract TypeNode transportChannelType();
+  public abstract List<TypeNode> transportChannelTypes();
 
-  public abstract String transportGetterName();
+  public abstract List<String> transportGetterNames();
 
   // For AbstractServiceCallableFactoryClassComposer
+  @Nullable
   public abstract TypeNode transportCallSettingsType();
 
+  @Nullable
   public abstract TypeNode transportCallableFactoryType();
 
-  public abstract TypeNode operationsStubType();
+  public abstract List<TypeNode> operationsStubTypes();
 
+  @Nullable
   public abstract String transportCallSettingsName();
 
   // For RetrySettingsComposer
@@ -64,9 +77,9 @@ public abstract class TransportContext {
 
   public abstract TypeNode operationMetadataTransformerType();
 
-  public abstract TypeNode operationsClientType();
+  public abstract List<TypeNode> operationsClientTypes();
 
-  public abstract String operationsClientName();
+  public abstract List<String> operationsClientNames();
 
   protected static TypeNode classToType(Class<?> clazz) {
     return TypeNode.withReference(ConcreteReference.withClazz(clazz));
@@ -91,15 +104,21 @@ public abstract class TransportContext {
 
     public abstract Builder setMethodDescriptorClass(Class<?> methodDescriptorClass);
 
-    public abstract Builder setInstantiatingChannelProviderClass(
-        Class<?> instantiatingChannelProviderClass);
+    public abstract Builder setInstantiatingChannelProviderClasses(
+        List<Class<?>> instantiatingChannelProviderClasses);
 
-    public abstract Builder setDefaultTransportProviderBuilderName(
-        String defaultTransportProviderBuilderName);
+    public abstract Builder setInstantiatingChannelProviderBuilderClasses(
+        List<Class<?>> instantiatingChannelProviderBuilderClasses);
 
-    public abstract Builder setTransportChannelType(TypeNode transportChannelType);
+    public abstract Builder setDefaultTransportProviderBuilderNames(
+        List<String> defaultTransportProviderBuilderNames);
 
-    public abstract Builder setTransportGetterName(String transportGetterName);
+    public abstract Builder setTransportApiClientHeaderProviderBuilderNames(
+        List<String> transportApiClientHeaderProviderBuilderNames);
+
+    public abstract Builder setTransportChannelTypes(List<TypeNode> transportChannelTypes);
+
+    public abstract Builder setTransportGetterNames(List<String> transportGetterNames);
 
     public abstract Builder setTransportCallSettingsType(TypeNode transportCallSettingsType);
 
@@ -107,19 +126,19 @@ public abstract class TransportContext {
 
     public abstract Builder setTransportCallSettingsName(String transportCallSettingsName);
 
-    public abstract Builder setTransportOperationsStubType(TypeNode transportOperationsStubType);
+    public abstract Builder setTransportOperationsStubTypes(List<TypeNode> transportOperationsStubTypes);
 
-    public abstract Builder setTransportOperationsStubName(String transportOperationsStubName);
+    public abstract Builder setTransportOperationsStubNames(List<String> transportOperationsStubNames);
 
-    public abstract Builder setOperationsStubType(TypeNode operationsStubType);
+    public abstract Builder setOperationsStubTypes(List<TypeNode> operationsStubType);
 
     public abstract Builder setOperationResponseTransformerType(TypeNode operationResponseTransformerType);
 
     public abstract Builder setOperationMetadataTransformerType(TypeNode operationMetadataTransformerType);
 
-    public abstract Builder setOperationsClientType(TypeNode operationsClientType);
+    public abstract Builder setOperationsClientTypes(List<TypeNode> operationsClientTypes);
 
-    public abstract Builder setOperationsClientName(String operationsClientName);
+    public abstract Builder setOperationsClientNames(List<String> operationsClientNames);
 
     public abstract TransportContext build();
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcContext.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcContext.java
@@ -23,6 +23,7 @@ import com.google.api.gax.grpc.ProtoOperationTransformers;
 import com.google.api.generator.gapic.composer.common.TransportContext;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.model.Transport;
+import com.google.common.collect.ImmutableList;
 import com.google.longrunning.OperationsClient;
 import com.google.longrunning.stub.GrpcOperationsStub;
 import com.google.longrunning.stub.OperationsStub;
@@ -38,18 +39,24 @@ public abstract class GrpcContext extends TransportContext {
           .setCallSettingsClass(GrpcCallSettings.class)
           .setStubCallableFactoryType(classToType(GrpcStubCallableFactory.class))
           .setMethodDescriptorClass(MethodDescriptor.class)
-          .setTransportOperationsStubType(classToType(GrpcOperationsStub.class))
-          .setTransportOperationsStubName("operationsStub")
+          .setTransportOperationsStubTypes(ImmutableList.of(classToType(GrpcOperationsStub.class)))
+          .setTransportOperationsStubNames(ImmutableList.of("operationsStub"))
           // For grpc.ServiceSettingsClassComposer
-          .setInstantiatingChannelProviderClass(InstantiatingGrpcChannelProvider.Builder.class)
-          .setDefaultTransportProviderBuilderName("defaultGrpcTransportProviderBuilder")
+          .setInstantiatingChannelProviderClasses(
+              ImmutableList.of(InstantiatingGrpcChannelProvider.class))
+          .setInstantiatingChannelProviderBuilderClasses(
+              ImmutableList.of(InstantiatingGrpcChannelProvider.Builder.class))
+          .setDefaultTransportProviderBuilderNames(
+              ImmutableList.of("defaultGrpcTransportProviderBuilder"))
+          .setTransportApiClientHeaderProviderBuilderNames(
+              ImmutableList.of("defaultGrpcApiClientHeaderProviderBuilder"))
           // For grpc.ServiceStubSettingsClassComposer
-          .setTransportChannelType(classToType(GrpcTransportChannel.class))
-          .setTransportGetterName("getGrpcTransportName")
+          .setTransportChannelTypes(ImmutableList.of(classToType(GrpcTransportChannel.class)))
+          .setTransportGetterNames(ImmutableList.of("getGrpcTransportName"))
           // For grpc.GrpcServiceCallableFactoryClassComposer
           .setTransportCallSettingsType(classToType(GrpcCallSettings.class))
           .setTransportCallableFactoryType(classToType(GrpcCallableFactory.class))
-          .setOperationsStubType(classToType(OperationsStub.class))
+          .setOperationsStubTypes(ImmutableList.of(classToType(OperationsStub.class)))
           .setTransportCallSettingsName("grpcCallSettings")
           // For RetrySettingsComposer
           .setOperationResponseTransformerType(
@@ -57,8 +64,8 @@ public abstract class GrpcContext extends TransportContext {
           .setOperationMetadataTransformerType(
               classToType(ProtoOperationTransformers.MetadataTransformer.class))
           // For ServiceClientClassComposer
-          .setOperationsClientType(classToType(OperationsClient.class))
-          .setOperationsClientName("operationsClient")
+          .setOperationsClientTypes(ImmutableList.of(classToType(OperationsClient.class)))
+          .setOperationsClientNames(ImmutableList.of("operationsClient"))
           .build();
 
   public static TransportContext instance() {

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -143,7 +143,8 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
       Service service,
       GapicContext context,
       Map<String, VariableExpr> classMemberVarExprs,
-      TypeStore typeStore) {
+      TypeStore typeStore,
+      String newBuilderMethod) {
     VariableExpr serviceHelperVarExpr = classMemberVarExprs.get(SERVICE_HELPER_VAR_NAME);
     Function<Service, VariableExpr> serviceToVarExprFn =
         s -> classMemberVarExprs.get(getMockServiceVarName(s));

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/BUILD.bazel
@@ -3,14 +3,14 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "composer_files",
+    name = "grpcrest_files",
     srcs = glob(["*.java"]),
 )
 
 java_library(
-    name = "composer",
+    name = "grpcrest",
     srcs = [
-        ":composer_files",
+        ":grpcrest_files",
     ],
     deps = [
         "//:service_config_java_proto",
@@ -20,8 +20,6 @@ java_library(
         "//src/main/java/com/google/api/generator/gapic/composer/comment",
         "//src/main/java/com/google/api/generator/gapic/composer/common",
         "//src/main/java/com/google/api/generator/gapic/composer/defaultvalue",
-        "//src/main/java/com/google/api/generator/gapic/composer/grpc",
-        "//src/main/java/com/google/api/generator/gapic/composer/grpcrest",
         "//src/main/java/com/google/api/generator/gapic/composer/resourcename",
         "//src/main/java/com/google/api/generator/gapic/composer/rest",
         "//src/main/java/com/google/api/generator/gapic/composer/samplecode",
@@ -32,13 +30,18 @@ java_library(
         "//src/main/java/com/google/api/generator/util",
         "@com_google_api_api_common//jar",
         "@com_google_api_gax_java//gax",
+        "@com_google_api_gax_java//gax:gax_testlib",
         "@com_google_api_gax_java//gax-grpc:gax_grpc",
+        "@com_google_api_gax_java//gax-grpc:gax_grpc_testlib",
+        "@com_google_api_gax_java//gax-httpjson:gax_httpjson",
+        "@com_google_api_gax_java//gax-httpjson:gax_httpjson_testlib",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_googleapis//gapic/metadata:metadata_java_proto",
         "@com_google_googleapis//google/api:api_java_proto",
         "@com_google_googleapis//google/longrunning:longrunning_java_proto",
         "@com_google_googleapis//google/rpc:rpc_java_proto",
         "@com_google_guava_guava//jar",
+        "@com_google_http_client_google_http_client//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@com_google_protobuf//java/core",

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/GrpcRestContext.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/GrpcRestContext.java
@@ -1,0 +1,95 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.grpc.ProtoOperationTransformers;
+import com.google.api.gax.httpjson.HttpJsonTransportChannel;
+import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
+import com.google.api.generator.gapic.composer.common.TransportContext;
+import com.google.api.generator.gapic.composer.utils.ClassNames;
+import com.google.api.generator.gapic.model.Transport;
+import com.google.common.collect.ImmutableList;
+import com.google.longrunning.OperationsClient;
+import com.google.longrunning.stub.GrpcOperationsStub;
+import com.google.longrunning.stub.OperationsStub;
+
+public abstract class GrpcRestContext extends TransportContext {
+  private static final TransportContext INSTANCE =
+      GrpcRestContext.builder()
+          .setClassNames(new ClassNames("Grpc", "HttpJson"))
+          .setTransport(Transport.GRPC_REST)
+          .setTransportName(null)
+          // For grpcrest.GrpcServiceStubClassComposer
+          .setCallSettingsClass(null)
+          .setStubCallableFactoryType(null)
+          .setMethodDescriptorClass(null)
+          .setTransportOperationsStubTypes(
+              ImmutableList.of(
+                  classToType(GrpcOperationsStub.class), classToType(HttpJsonOperationsStub.class)))
+          .setTransportOperationsStubNames(
+              ImmutableList.of("operationsStub", "httpJsonOperationsStub"))
+          // For grpcrest.ServiceSettingsClassComposer
+          .setInstantiatingChannelProviderClasses(
+              ImmutableList.of(
+                  InstantiatingGrpcChannelProvider.class,
+                  InstantiatingHttpJsonChannelProvider.class))
+          .setInstantiatingChannelProviderBuilderClasses(
+              ImmutableList.of(
+                  InstantiatingGrpcChannelProvider.Builder.class,
+                  InstantiatingHttpJsonChannelProvider.Builder.class))
+          .setDefaultTransportProviderBuilderNames(
+              ImmutableList.of(
+                  "defaultGrpcTransportProviderBuilder", "defaultHttpJsonTransportProviderBuilder"))
+          .setTransportApiClientHeaderProviderBuilderNames(
+              ImmutableList.of(
+                  "defaultGrpcApiClientHeaderProviderBuilder",
+                  "defaultHttpJsonApiClientHeaderProviderBuilder"))
+          // For grpcrest.ServiceStubSettingsClassComposer
+          .setTransportChannelTypes(
+              ImmutableList.of(
+                  classToType(GrpcTransportChannel.class),
+                  classToType(HttpJsonTransportChannel.class)))
+          .setTransportGetterNames(
+              ImmutableList.of("getGrpcTransportName", "getHttpJsonTransportName"))
+          // For grpcrest.GrpcServiceCallableFactoryClassComposer
+          .setTransportCallSettingsType(null)
+          .setTransportCallableFactoryType(null)
+          .setOperationsStubTypes(
+              ImmutableList.of(
+                  classToType(OperationsStub.class), classToType(BackgroundResource.class)))
+          .setTransportCallSettingsName(null)
+          // For RetrySettingsComposer
+          // TODO: fix when LRO for REST RE FIXED
+          .setOperationResponseTransformerType(
+              classToType(ProtoOperationTransformers.ResponseTransformer.class))
+          .setOperationMetadataTransformerType(
+              classToType(ProtoOperationTransformers.MetadataTransformer.class))
+          // For ServiceClientClassComposer
+          .setOperationsClientTypes(
+              ImmutableList.of(
+                  classToType(OperationsClient.class),
+                  classToType(com.google.api.gax.httpjson.longrunning.OperationsClient.class)))
+          .setOperationsClientNames(
+              ImmutableList.of("operationsClient", "httpJsonOperationsClient"))
+          .build();
+
+  public static TransportContext instance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposer.java
@@ -1,0 +1,57 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import com.google.api.generator.engine.ast.MethodDefinition;
+import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.gapic.composer.common.AbstractServiceClientTestClassComposer;
+import com.google.api.generator.gapic.composer.rest.ServiceClientTestClassComposer;
+import com.google.api.generator.gapic.composer.store.TypeStore;
+import com.google.api.generator.gapic.model.GapicClass;
+import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.gapic.model.Service;
+import java.util.Map;
+
+public class HttpJsonServiceClientTestClassComposer extends ServiceClientTestClassComposer {
+  private static final HttpJsonServiceClientTestClassComposer INSTANCE =
+      new HttpJsonServiceClientTestClassComposer();
+
+  protected HttpJsonServiceClientTestClassComposer() {
+    super();
+  }
+
+  public static AbstractServiceClientTestClassComposer instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  protected GapicClass generate(String className, GapicContext context, Service service) {
+    return super.generate(
+        getTransportContext().classNames().getServiceClientTestClassNames(service).get(0),
+        context,
+        service);
+  }
+
+  @Override
+  protected MethodDefinition createStartStaticServerMethod(
+      Service service,
+      GapicContext context,
+      Map<String, VariableExpr> classMemberVarExprs,
+      TypeStore typeStore,
+      String newBuilderMethod) {
+    return super.createStartStaticServerMethod(
+        service, context, classMemberVarExprs, typeStore, "newHttpJsonBuilder");
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceStubClassComposer.java
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import com.google.api.generator.engine.ast.MethodDefinition;
+import com.google.api.generator.gapic.composer.store.TypeStore;
+import com.google.api.generator.gapic.model.Service;
+import java.util.List;
+
+public class HttpJsonServiceStubClassComposer
+    extends com.google.api.generator.gapic.composer.rest.HttpJsonServiceStubClassComposer {
+  private static final HttpJsonServiceStubClassComposer INSTANCE =
+      new HttpJsonServiceStubClassComposer();
+
+  protected HttpJsonServiceStubClassComposer() {
+    super();
+  }
+
+  public static HttpJsonServiceStubClassComposer instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  protected List<MethodDefinition> createStaticCreatorMethods(
+      Service service, TypeStore typeStore, String newBuilderMethod) {
+    return super.createStaticCreatorMethods(service, typeStore, "newHttpJsonBuilder");
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposer.java
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.model;
+package com.google.api.generator.gapic.composer.grpcrest;
 
-public enum Transport {
-  REST,
-  GRPC,
-  GRPC_REST;
+import com.google.api.generator.gapic.composer.common.AbstractServiceClientClassComposer;
 
-  /**
-   * Parse command line transport argument in the format `grpc+rest`.
-   *
-   * @param name name of the transport. Valid inputs are "grpc", "rest", "grpc+rest"
-   * @return the {@code Transport} enum matching the command line argument
-   */
-  public static Transport parse(String name) {
-    return valueOf(name.replace('+', '_').toUpperCase());
+public class ServiceClientClassComposer extends AbstractServiceClientClassComposer {
+  private static final ServiceClientClassComposer INSTANCE = new ServiceClientClassComposer();
+
+  protected ServiceClientClassComposer() {
+    super(GrpcRestContext.instance());
+  }
+
+  public static ServiceClientClassComposer instance() {
+    return INSTANCE;
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceSettingsClassComposer.java
@@ -1,0 +1,68 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import com.google.api.generator.engine.ast.MethodDefinition;
+import com.google.api.generator.gapic.composer.common.AbstractServiceSettingsClassComposer;
+import com.google.api.generator.gapic.composer.store.TypeStore;
+import com.google.api.generator.gapic.model.Service;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ServiceSettingsClassComposer extends AbstractServiceSettingsClassComposer {
+  private static final ServiceSettingsClassComposer INSTANCE = new ServiceSettingsClassComposer();
+
+  protected ServiceSettingsClassComposer() {
+    super(GrpcRestContext.instance());
+  }
+
+  public static ServiceSettingsClassComposer instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  protected List<MethodDefinition> createNestedBuilderCreatorMethods(
+      Service service,
+      TypeStore typeStore,
+      String newBuilderMethodName,
+      String createDefaultMethodName) {
+    List<MethodDefinition> methods = new ArrayList<>();
+
+    methods.addAll(
+        super.createNestedBuilderCreatorMethods(service, typeStore, "newBuilder", "createDefault"));
+    methods.addAll(
+        super.createNestedBuilderCreatorMethods(
+            service, typeStore, "newHttpJsonBuilder", "createHttpJsonDefault"));
+
+    return methods;
+  }
+
+  @Override
+  protected List<MethodDefinition> createNewBuilderMethods(
+      Service service,
+      TypeStore typeStore,
+      String newBuilderMethodName,
+      String createDefaultMethodName) {
+    List<MethodDefinition> methods = new ArrayList<>();
+
+    methods.addAll(
+        super.createNewBuilderMethods(service, typeStore, "newBuilder", "createDefault"));
+    methods.addAll(
+        super.createNewBuilderMethods(
+            service, typeStore, "newHttpJsonBuilder", "createHttpJsonDefault"));
+
+    return methods;
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubClassComposer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import com.google.api.generator.engine.ast.MethodDefinition;
+import com.google.api.generator.engine.ast.ReturnExpr;
+import com.google.api.generator.engine.ast.ScopeNode;
+import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.engine.ast.ValueExpr;
+import com.google.api.generator.gapic.composer.common.AbstractServiceStubClassComposer;
+import com.google.api.generator.gapic.composer.store.TypeStore;
+
+public class ServiceStubClassComposer extends AbstractServiceStubClassComposer {
+  private static final ServiceStubClassComposer INSTANCE = new ServiceStubClassComposer();
+
+  protected ServiceStubClassComposer() {
+    super(GrpcRestContext.instance());
+  }
+
+  public static ServiceStubClassComposer instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  protected MethodDefinition createOperationsStubGetterMethodDefinition(
+      TypeNode returnType, String methodName, TypeStore typeStore) {
+    return MethodDefinition.builder()
+        .setScope(ScopeNode.PUBLIC)
+        .setReturnType(returnType)
+        .setName(methodName)
+        .setReturnExpr(ReturnExpr.withExpr(ValueExpr.createNullExpr()))
+        .build();
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceCallableFactoryClassComposer.java
@@ -67,7 +67,7 @@ public class HttpJsonServiceCallableFactoryClassComposer
                 .copyAndSetGenerics(
                     Arrays.asList(
                         MESSAGE_TYPE.reference(),
-                        getTransportContext().operationsStubType().reference()))));
+                        getTransportContext().operationsStubTypes().get(0).reference()))));
   }
 
   @Override

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/RestContext.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/RestContext.java
@@ -27,6 +27,7 @@ import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
 import com.google.api.generator.gapic.composer.common.TransportContext;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.model.Transport;
+import com.google.common.collect.ImmutableList;
 
 public abstract class RestContext extends TransportContext {
   private static final TransportContext INSTANCE =
@@ -38,19 +39,26 @@ public abstract class RestContext extends TransportContext {
           .setCallSettingsClass(HttpJsonCallSettings.class)
           .setStubCallableFactoryType(classToType(HttpJsonStubCallableFactory.class))
           .setMethodDescriptorClass(ApiMethodDescriptor.class)
-          .setTransportOperationsStubType(classToType(HttpJsonOperationsStub.class))
-          .setTransportOperationsStubName("httpJsonOperationsStub")
+          .setTransportOperationsStubTypes(
+              ImmutableList.of(classToType(HttpJsonOperationsStub.class)))
+          .setTransportOperationsStubNames(ImmutableList.of("httpJsonOperationsStub"))
           // For httpjson.ServiceSettingsClassComposer
-          .setInstantiatingChannelProviderClass(InstantiatingHttpJsonChannelProvider.Builder.class)
-          .setDefaultTransportProviderBuilderName("defaultHttpJsonTransportProviderBuilder")
+          .setInstantiatingChannelProviderClasses(
+              ImmutableList.of(InstantiatingHttpJsonChannelProvider.class))
+          .setInstantiatingChannelProviderBuilderClasses(
+              ImmutableList.of(InstantiatingHttpJsonChannelProvider.Builder.class))
+          .setDefaultTransportProviderBuilderNames(
+              ImmutableList.of("defaultHttpJsonTransportProviderBuilder"))
+          .setTransportApiClientHeaderProviderBuilderNames(
+              ImmutableList.of("defaultHttpJsonApiClientHeaderProviderBuilder"))
           // For httpjson.ServiceStubSettingsClassComposer
-          .setTransportChannelType(classToType(HttpJsonTransportChannel.class))
-          .setTransportGetterName("getHttpJsonTransportName")
+          .setTransportChannelTypes(ImmutableList.of(classToType(HttpJsonTransportChannel.class)))
+          .setTransportGetterNames(ImmutableList.of("getHttpJsonTransportName"))
           // For httpjson.HttpJsonServiceCallableFactoryClassComposer
           .setTransportCallSettingsType(classToType(HttpJsonCallSettings.class))
           .setTransportCallableFactoryType(classToType(HttpJsonCallableFactory.class))
           // TODO: set to com.google.api.gax.httpjson.longrunning.stub.OperationsStub.class
-          .setOperationsStubType(classToType(BackgroundResource.class))
+          .setOperationsStubTypes(ImmutableList.of(classToType(BackgroundResource.class)))
           .setTransportCallSettingsName("httpJsonCallSettings")
           // For RetrySettingsComposer
           .setOperationResponseTransformerType(
@@ -58,8 +66,8 @@ public abstract class RestContext extends TransportContext {
           .setOperationMetadataTransformerType(
               classToType(ProtoOperationTransformers.MetadataTransformer.class))
           // For ServiceClientClassComposer
-          .setOperationsClientType(classToType(OperationsClient.class))
-          .setOperationsClientName("httpJsonOperationsClient")
+          .setOperationsClientTypes(ImmutableList.of(classToType(OperationsClient.class)))
+          .setOperationsClientNames(ImmutableList.of("httpJsonOperationsClient"))
           .build();
 
   public static TransportContext instance() {

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
@@ -73,7 +73,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     super(RestContext.instance());
   }
 
-  public static ServiceClientTestClassComposer instance() {
+  public static AbstractServiceClientTestClassComposer instance() {
     return INSTANCE;
   }
 
@@ -126,7 +126,8 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
       Service service,
       GapicContext context,
       Map<String, VariableExpr> classMemberVarExprs,
-      TypeStore typeStore) {
+      TypeStore typeStore,
+      String newBuilderMethod) {
 
     VariableExpr mockServiceVarExpr = classMemberVarExprs.get(MOCK_SERVICE_VAR_NAME);
     VariableExpr clientVarExpr = classMemberVarExprs.get(CLIENT_VAR_NAME);
@@ -168,7 +169,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     Expr settingsBuilderExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(settingsType)
-            .setMethodName("newBuilder")
+            .setMethodName(newBuilderMethod)
             .build();
 
     Expr transportChannelProviderExpr =

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceStubSettingsClassComposer.java
@@ -17,23 +17,16 @@ package com.google.api.generator.gapic.composer.rest;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
-import com.google.api.gax.rpc.ApiClientHeaderProvider;
-import com.google.api.generator.engine.ast.AnnotationNode;
-import com.google.api.generator.engine.ast.ConcreteReference;
 import com.google.api.generator.engine.ast.MethodDefinition;
 import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.ScopeNode;
-import com.google.api.generator.engine.ast.StringObjectValue;
 import com.google.api.generator.engine.ast.TypeNode;
-import com.google.api.generator.engine.ast.ValueExpr;
-import com.google.api.generator.engine.ast.Variable;
-import com.google.api.generator.engine.ast.VariableExpr;
-import com.google.api.generator.gapic.composer.comment.SettingsCommentComposer;
 import com.google.api.generator.gapic.composer.common.AbstractServiceStubSettingsClassComposer;
 import com.google.api.generator.gapic.composer.store.TypeStore;
-import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.model.Service;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class ServiceStubSettingsClassComposer extends AbstractServiceStubSettingsClassComposer {
   private static final ServiceStubSettingsClassComposer INSTANCE =
@@ -58,94 +51,16 @@ public class ServiceStubSettingsClassComposer extends AbstractServiceStubSetting
   }
 
   @Override
-  protected MethodDefinition createDefaultTransportTransportProviderBuilderMethod() {
-    // Create the defaultHttpJsonTransportProviderBuilder method.
-    TypeNode returnType =
-        TypeNode.withReference(
-            ConcreteReference.withClazz(InstantiatingHttpJsonChannelProvider.Builder.class));
-    MethodInvocationExpr transportChannelProviderBuilderExpr =
-        MethodInvocationExpr.builder()
-            .setStaticReferenceType(
-                FIXED_REST_TYPESTORE.get(
-                    InstantiatingHttpJsonChannelProvider.class.getSimpleName()))
-            .setMethodName("newBuilder")
-            .setReturnType(returnType)
-            .build();
-    return MethodDefinition.builder()
-        .setHeaderCommentStatements(
-            SettingsCommentComposer.DEFAULT_TRANSPORT_PROVIDER_BUILDER_METHOD_COMMENT)
-        .setScope(ScopeNode.PUBLIC)
-        .setIsStatic(true)
-        .setReturnType(returnType)
-        .setName("defaultHttpJsonTransportProviderBuilder")
-        .setReturnExpr(transportChannelProviderBuilderExpr)
-        .build();
-  }
-
-  @Override
-  protected MethodDefinition createDefaultApiClientHeaderProviderBuilderMethod(
+  protected List<MethodDefinition> createApiClientHeaderProviderBuilderMethods(
       Service service, TypeStore typeStore) {
-    // Create the defaultApiClientHeaderProviderBuilder method.
-    TypeNode returnType =
-        TypeNode.withReference(ConcreteReference.withClazz(ApiClientHeaderProvider.Builder.class));
-    MethodInvocationExpr returnExpr =
-        MethodInvocationExpr.builder()
-            .setStaticReferenceType(FIXED_TYPESTORE.get("ApiClientHeaderProvider"))
-            .setMethodName("newBuilder")
-            .build();
-
-    MethodInvocationExpr versionArgExpr =
-        MethodInvocationExpr.builder()
-            .setStaticReferenceType(FIXED_TYPESTORE.get("GaxProperties"))
-            .setMethodName("getLibraryVersion")
-            .setArguments(
-                VariableExpr.builder()
-                    .setVariable(
-                        Variable.builder().setType(TypeNode.CLASS_OBJECT).setName("class").build())
-                    .setStaticReferenceType(
-                        typeStore.get(ClassNames.getServiceStubSettingsClassName(service)))
-                    .build())
-            .build();
-
-    returnExpr =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(returnExpr)
-            .setMethodName("setGeneratedLibToken")
-            .setArguments(ValueExpr.withValue(StringObjectValue.withValue("gapic")), versionArgExpr)
-            .build();
-    returnExpr =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(returnExpr)
-            .setMethodName("setTransportToken")
-            .setArguments(
-                MethodInvocationExpr.builder()
-                    .setStaticReferenceType(
-                        FIXED_REST_TYPESTORE.get(GaxHttpJsonProperties.class.getSimpleName()))
-                    .setMethodName("getHttpJsonTokenName")
-                    .build(),
-                MethodInvocationExpr.builder()
-                    .setStaticReferenceType(
-                        FIXED_REST_TYPESTORE.get(GaxHttpJsonProperties.class.getSimpleName()))
-                    .setMethodName("getHttpJsonVersion")
-                    .build())
-            .setReturnType(returnType)
-            .build();
-
-    AnnotationNode annotation =
-        AnnotationNode.builder()
-            .setType(FIXED_TYPESTORE.get("BetaApi"))
-            .setDescription(
-                "The surface for customizing headers is not stable yet and may change in the"
-                    + " future.")
-            .build();
-    return MethodDefinition.builder()
-        .setAnnotations(Arrays.asList(annotation))
-        .setScope(ScopeNode.PUBLIC)
-        .setIsStatic(true)
-        .setReturnType(returnType)
-        .setName("defaultApiClientHeaderProviderBuilder")
-        .setReturnExpr(returnExpr)
-        .build();
+    return Collections.singletonList(
+        createApiClientHeaderProviderBuilderMethod(
+            service,
+            typeStore,
+            "defaultApiClientHeaderProviderBuilder",
+            FIXED_REST_TYPESTORE.get(GaxHttpJsonProperties.class.getSimpleName()),
+            "getHttpJsonTokenName",
+            "getHttpJsonVersion"));
   }
 
   @Override

--- a/src/main/java/com/google/api/generator/gapic/composer/utils/ClassNames.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/utils/ClassNames.java
@@ -15,6 +15,9 @@
 package com.google.api.generator.gapic.composer.utils;
 
 import com.google.api.generator.gapic.model.Service;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /** Provides Gapic class names. */
 public class ClassNames {
@@ -23,6 +26,7 @@ public class ClassNames {
   private static final String MOCK_SERVICE_IMPL_CLASS_NAME_PATTERN = "Mock%sImpl";
   private static final String SERVICE_CLIENT_CLASS_NAME_PATTERN = "%sClient";
   private static final String SERVICE_CLIENT_TEST_CLASS_NAME_PATTERN = "%sClientTest";
+  private static final String SERVICE_CLIENT_TRANSPORT_TEST_CLASS_NAME_PATTERN = "%sClient%sTest";
   private static final String SERVICE_SETTINGS_CLASS_NAME_PATTERN = "%sSettings";
   private static final String SERVICE_STUB_SETTINGS_CLASS_NAME_PATTERN = "%sStubSettings";
   private static final String SERVICE_STUB_CLASS_NAME_PATTERN = "%sStub";
@@ -30,10 +34,10 @@ public class ClassNames {
   private static final String TRANSPORT_SERVICE_CALLABLE_FACTORY_CLASS_NAME_PATTERN =
       "%s%sCallableFactory";
 
-  private final String transportPrefix;
+  private final List<String> transportPrefixes;
 
-  public ClassNames(String transportPrefix) {
-    this.transportPrefix = transportPrefix;
+  public ClassNames(String... transportPrefixes) {
+    this.transportPrefixes = Arrays.asList(transportPrefixes);
   }
 
   public static String getServiceClientClassName(Service service) {
@@ -59,21 +63,48 @@ public class ClassNames {
   }
 
   public String getTransportServiceCallableFactoryClassName(Service service) {
-    return String.format(
-        TRANSPORT_SERVICE_CALLABLE_FACTORY_CLASS_NAME_PATTERN,
-        transportPrefix,
-        monolithBackwardsCompatibleName(service.name()));
+    return getTransportServiceCallableFactoryClassNames(service).get(0);
+  }
+
+  public List<String> getTransportServiceCallableFactoryClassNames(Service service) {
+    return transportPrefixes.stream()
+        .map(
+            prefix ->
+                String.format(
+                    TRANSPORT_SERVICE_CALLABLE_FACTORY_CLASS_NAME_PATTERN,
+                    prefix,
+                    monolithBackwardsCompatibleName(service.name())))
+        .collect(Collectors.toList());
   }
 
   public String getTransportServiceStubClassName(Service service) {
-    return String.format(
-        TRANSPORT_SERVICE_STUB_CLASS_NAME_PATTERN,
-        transportPrefix,
-        monolithBackwardsCompatibleName(service.name()));
+    return getTransportServiceStubClassNames(service).get(0);
+  }
+
+  public List<String> getTransportServiceStubClassNames(Service service) {
+    return transportPrefixes.stream()
+        .map(
+            prefix ->
+                String.format(
+                    TRANSPORT_SERVICE_STUB_CLASS_NAME_PATTERN,
+                    prefix,
+                    monolithBackwardsCompatibleName(service.name())))
+        .collect(Collectors.toList());
   }
 
   public static String getServiceClientTestClassName(Service service) {
     return String.format(SERVICE_CLIENT_TEST_CLASS_NAME_PATTERN, service.overriddenName());
+  }
+
+  public List<String> getServiceClientTestClassNames(Service service) {
+    return transportPrefixes.stream()
+        .map(
+            prefix ->
+                String.format(
+                    SERVICE_CLIENT_TRANSPORT_TEST_CLASS_NAME_PATTERN,
+                    service.overriddenName(),
+                    prefix))
+        .collect(Collectors.toList());
   }
 
   public static String getMockServiceClassName(Service service) {

--- a/src/test/java/com/google/api/generator/gapic/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/BUILD.bazel
@@ -6,6 +6,7 @@ filegroup(
         "//src/test/java/com/google/api/generator/gapic/composer:composer_files",
         "//src/test/java/com/google/api/generator/gapic/composer/defaultvalue:defaultvalue_files",
         "//src/test/java/com/google/api/generator/gapic/composer/grpc:grpc_files",
+        #        "//src/test/java/com/google/api/generator/gapic/composer/grpcrest:grpcrest_files",
         "//src/test/java/com/google/api/generator/gapic/composer/resourcename:resourcename_files",
         "//src/test/java/com/google/api/generator/gapic/composer/rest:rest_files",
         "//src/test/java/com/google/api/generator/gapic/composer/samplecode:samplecode_files",


### PR DESCRIPTION
1) Fully backward compatible with grpc-only GAPIC
2) Strictly speaking not fully backward compatible with rest-only REGAPIC (but is compatible for practical cases). See below for details.
3) Introduces the concept of default transport (is necessary to preserve backward-compabitility). The default behavior assumes `grpc` transport.
4) Strictly speaking `rest` client is not backward compatible with `grpc+rest` (but is compatible for practical cases).