### PR TITLE
Remove warnings (unused vars, dead code, missing annotations, missing generic reference, etc)

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/AnnotationNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/AnnotationNode.java
@@ -25,7 +25,7 @@ public abstract class AnnotationNode implements AstNode {
   public static AnnotationNode DEPRECATED =
       AnnotationNode.builder().setType(annotationType(Deprecated.class)).build();
 
-  private static TypeNode annotationType(Class clazz) {
+  private static TypeNode annotationType(Class<?> clazz) {
     return TypeNode.withReference(ConcreteReference.withClazz(clazz));
   }
 

--- a/src/main/java/com/google/api/generator/engine/ast/ArithmeticOperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ArithmeticOperationExpr.java
@@ -24,8 +24,10 @@ public abstract class ArithmeticOperationExpr implements OperationExpr {
 
   public abstract Expr rhsExpr();
 
+  @Override
   public abstract OperatorKind operatorKind();
 
+  @Override
   public abstract TypeNode type();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/AssignmentOperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/AssignmentOperationExpr.java
@@ -23,6 +23,7 @@ public abstract class AssignmentOperationExpr implements OperationExpr {
 
   public abstract Expr valueExpr();
 
+  @Override
   public abstract OperatorKind operatorKind();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/BlockComment.java
+++ b/src/main/java/com/google/api/generator/engine/ast/BlockComment.java
@@ -18,6 +18,7 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class BlockComment implements Comment {
+  @Override
   public abstract String comment();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ConcreteReference.java
@@ -32,10 +32,10 @@ public abstract class ConcreteReference implements Reference {
   private static final String RIGHT_ANGLE = ">";
   private static final String QUESTION_MARK = "?";
 
-  private static final Class WILDCARD_CLAZZ = ReferenceWildcard.class;
+  private static final Class<?> WILDCARD_CLAZZ = ReferenceWildcard.class;
 
   // Private.
-  abstract Class clazz();
+  abstract Class<?> clazz();
 
   @Override
   public void accept(AstNodeVisitor visitor) {
@@ -105,7 +105,7 @@ public abstract class ConcreteReference implements Reference {
     }
     // The innermost type will be the last element in the list.
     ImmutableList.Builder<String> listBuilder = new ImmutableList.Builder<>();
-    Class currentClz = clazz();
+    Class<?> currentClz = clazz();
     while (currentClz.getEnclosingClass() != null) {
       listBuilder.add(currentClz.getEnclosingClass().getSimpleName());
       currentClz = currentClz.getEnclosingClass();
@@ -198,7 +198,7 @@ public abstract class ConcreteReference implements Reference {
     return toBuilder().setGenerics(generics).build();
   }
 
-  public static ConcreteReference withClazz(Class clazz) {
+  public static ConcreteReference withClazz(Class<?> clazz) {
     return builder().setClazz(clazz).build();
   }
 
@@ -222,7 +222,7 @@ public abstract class ConcreteReference implements Reference {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setClazz(Class clazz);
+    public abstract Builder setClazz(Class<?> clazz);
 
     public abstract Builder setUseFullName(boolean useFullName);
 
@@ -239,7 +239,7 @@ public abstract class ConcreteReference implements Reference {
     public abstract ConcreteReference autoBuild();
 
     // Private.
-    abstract Class clazz();
+    abstract Class<?> clazz();
 
     abstract ImmutableList<Reference> generics();
 

--- a/src/main/java/com/google/api/generator/engine/ast/EnumRefExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/EnumRefExpr.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 public abstract class EnumRefExpr implements Expr {
   public abstract IdentifierNode identifier();
 
+  @Override
   public abstract TypeNode type();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/Expr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/Expr.java
@@ -17,5 +17,6 @@ package com.google.api.generator.engine.ast;
 public interface Expr extends AstNode {
   TypeNode type();
 
+  @Override
   void accept(AstNodeVisitor visitor);
 }

--- a/src/main/java/com/google/api/generator/engine/ast/LogicalOperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/LogicalOperationExpr.java
@@ -24,6 +24,7 @@ public abstract class LogicalOperationExpr implements OperationExpr {
 
   public abstract Expr rhsExpr();
 
+  @Override
   public abstract OperatorKind operatorKind();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/MethodDefinition.java
+++ b/src/main/java/com/google/api/generator/engine/ast/MethodDefinition.java
@@ -248,16 +248,14 @@ public abstract class MethodDefinition implements AstNode {
       ImmutableList<AnnotationNode> processedAnnotations = annotations();
       if (isOverride()) {
         processedAnnotations =
-            ImmutableList
-                .<AnnotationNode>builder()
+            ImmutableList.<AnnotationNode>builder()
                 .addAll(annotations())
                 .add(AnnotationNode.OVERRIDE)
                 .build();
       }
       // Remove duplicates while maintaining insertion order.
       setAnnotations(
-          new LinkedHashSet<>(processedAnnotations)
-              .stream().collect(Collectors.toList()));
+          new LinkedHashSet<>(processedAnnotations).stream().collect(Collectors.toList()));
 
       MethodDefinition method = autoBuild();
 

--- a/src/main/java/com/google/api/generator/engine/ast/MethodDefinition.java
+++ b/src/main/java/com/google/api/generator/engine/ast/MethodDefinition.java
@@ -244,11 +244,11 @@ public abstract class MethodDefinition implements AstNode {
             "Abstract methods cannot be static, final, or private");
       }
 
-      // If this method overrides another, ensure that the Override annotaiton is the last one.
+      // If this method overrides another, ensure that the Override annotation is the last one.
       ImmutableList<AnnotationNode> processedAnnotations = annotations();
       if (isOverride()) {
         processedAnnotations =
-            annotations()
+            ImmutableList
                 .<AnnotationNode>builder()
                 .addAll(annotations())
                 .add(AnnotationNode.OVERRIDE)
@@ -256,7 +256,7 @@ public abstract class MethodDefinition implements AstNode {
       }
       // Remove duplicates while maintaining insertion order.
       setAnnotations(
-          new LinkedHashSet<AnnotationNode>(processedAnnotations)
+          new LinkedHashSet<>(processedAnnotations)
               .stream().collect(Collectors.toList()));
 
       MethodDefinition method = autoBuild();

--- a/src/main/java/com/google/api/generator/engine/ast/NewObjectExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/NewObjectExpr.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 @AutoValue
 public abstract class NewObjectExpr implements Expr {
+  @Override
   public abstract TypeNode type();
 
   public abstract ImmutableList<Expr> arguments();

--- a/src/main/java/com/google/api/generator/engine/ast/ObjectValue.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ObjectValue.java
@@ -15,7 +15,9 @@
 package com.google.api.generator.engine.ast;
 
 public interface ObjectValue extends Value {
+  @Override
   TypeNode type();
 
+  @Override
   String value();
 }

--- a/src/main/java/com/google/api/generator/engine/ast/OperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/OperationExpr.java
@@ -18,7 +18,9 @@ public interface OperationExpr extends Expr {
 
   OperatorKind operatorKind();
 
+  @Override
   TypeNode type();
 
+  @Override
   void accept(AstNodeVisitor visitor);
 }

--- a/src/main/java/com/google/api/generator/engine/ast/Reference.java
+++ b/src/main/java/com/google/api/generator/engine/ast/Reference.java
@@ -19,6 +19,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public interface Reference extends AstNode {
+  @Override
   void accept(AstNodeVisitor visitor);
 
   ImmutableList<Reference> generics();

--- a/src/main/java/com/google/api/generator/engine/ast/ReferenceConstructorExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/ReferenceConstructorExpr.java
@@ -28,6 +28,7 @@ public abstract class ReferenceConstructorExpr implements Expr {
     SUPER
   }
 
+  @Override
   public abstract TypeNode type();
 
   public abstract KeywordKind keywordKind();
@@ -73,7 +74,7 @@ public abstract class ReferenceConstructorExpr implements Expr {
     public ReferenceConstructorExpr build() {
       ReferenceConstructorExpr referenceConstructorExpr = autoBuild();
       Preconditions.checkState(
-          referenceConstructorExpr.type().isReferenceType(referenceConstructorExpr.type()),
+          TypeNode.isReferenceType(referenceConstructorExpr.type()),
           "A this/super constructor must have a reference type.");
 
       NodeValidator.checkNoNullElements(

--- a/src/main/java/com/google/api/generator/engine/ast/RelationalOperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/RelationalOperationExpr.java
@@ -23,6 +23,7 @@ public abstract class RelationalOperationExpr implements OperationExpr {
 
   public abstract Expr rhsExpr();
 
+  @Override
   public abstract OperatorKind operatorKind();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/Statement.java
+++ b/src/main/java/com/google/api/generator/engine/ast/Statement.java
@@ -15,5 +15,6 @@
 package com.google.api.generator.engine.ast;
 
 public interface Statement extends AstNode {
+  @Override
   void accept(AstNodeVisitor visitor);
 }

--- a/src/main/java/com/google/api/generator/engine/ast/StringObjectValue.java
+++ b/src/main/java/com/google/api/generator/engine/ast/StringObjectValue.java
@@ -20,6 +20,7 @@ import com.google.common.escape.Escapers;
 
 @AutoValue
 public abstract class StringObjectValue implements ObjectValue {
+  @Override
   public abstract String value();
 
   @Override

--- a/src/main/java/com/google/api/generator/engine/ast/TypeNode.java
+++ b/src/main/java/com/google/api/generator/engine/ast/TypeNode.java
@@ -112,7 +112,7 @@ public abstract class TypeNode implements AstNode, Comparable<TypeNode> {
       return -1;
     }
 
-    if (this.equals(TypeNode.NULL)) {
+    if (equals(TypeNode.NULL)) {
       // Can't self-compare, so we don't need to check whether the other one is TypeNode.NULL.
       return other.isPrimitiveType() ? 1 : -1;
     }
@@ -161,7 +161,7 @@ public abstract class TypeNode implements AstNode, Comparable<TypeNode> {
     return TypeNode.builder().setTypeKind(TypeKind.OBJECT).setReference(reference).build();
   }
 
-  public static TypeNode withExceptionClazz(Class clazz) {
+  public static TypeNode withExceptionClazz(Class<?> clazz) {
     Preconditions.checkState(Exception.class.isAssignableFrom(clazz));
     return withReference(ConcreteReference.withClazz(clazz));
   }
@@ -200,11 +200,11 @@ public abstract class TypeNode implements AstNode, Comparable<TypeNode> {
   }
 
   public boolean isProtoPrimitiveType() {
-    return isPrimitiveType() || this.equals(TypeNode.STRING) || this.equals(TypeNode.BYTESTRING);
+    return isPrimitiveType() || equals(TypeNode.STRING) || equals(TypeNode.BYTESTRING);
   }
 
   public boolean isSupertypeOrEquals(TypeNode other) {
-    boolean oneTypeIsNull = this.equals(TypeNode.NULL) ^ other.equals(TypeNode.NULL);
+    boolean oneTypeIsNull = equals(TypeNode.NULL) ^ other.equals(TypeNode.NULL);
     return !isPrimitiveType()
         && !other.isPrimitiveType()
         && isArray() == other.isArray()
@@ -254,20 +254,6 @@ public abstract class TypeNode implements AstNode, Comparable<TypeNode> {
       return Objects.equals(this, BOXED_TYPE_MAP.get(other));
     }
     return Objects.equals(other, BOXED_TYPE_MAP.get(this));
-  }
-
-  private static TypeNode createPrimitiveType(TypeKind typeKind) {
-    if (!isPrimitiveType(typeKind)) {
-      throw new IllegalArgumentException("Object is not a primitive type.");
-    }
-    return TypeNode.builder().setTypeKind(typeKind).build();
-  }
-
-  private static TypeNode createPrimitiveArrayType(TypeKind typeKind) {
-    if (typeKind.equals(TypeKind.OBJECT)) {
-      throw new IllegalArgumentException("Object is not a primitive type.");
-    }
-    return TypeNode.builder().setTypeKind(typeKind).setIsArray(true).build();
   }
 
   private static boolean isPrimitiveType(TypeKind typeKind) {

--- a/src/main/java/com/google/api/generator/engine/ast/UnaryOperationExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/UnaryOperationExpr.java
@@ -22,10 +22,13 @@ public abstract class UnaryOperationExpr implements OperationExpr {
 
   public abstract Expr expr();
 
+  @Override
   public abstract OperatorKind operatorKind();
 
+  @Override
   public abstract TypeNode type();
 
+  @Override
   public void accept(AstNodeVisitor visitor) {
     visitor.visit(this);
   }

--- a/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
@@ -123,8 +123,7 @@ public class ImportWriterVisitor implements AstNodeVisitor {
       updateShortNames();
     }
     return importShortNames.contains(shortName)
-        && imports
-            .stream()
+        && imports.stream()
             .filter(s -> s.equals(String.format("%s.%s", pakkage, shortName)))
             .findFirst()
             .orElse("")

--- a/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
@@ -74,7 +74,6 @@ import javax.annotation.Nullable;
 
 public class ImportWriterVisitor implements AstNodeVisitor {
   private static final String DOT = ".";
-  private static final String NEWLINE = "\n";
   private static final String PKG_JAVA_LANG = "java.lang";
 
   private final Set<String> staticImports = new TreeSet<>();
@@ -94,7 +93,7 @@ public class ImportWriterVisitor implements AstNodeVisitor {
 
   public void initialize(@Nonnull String currentPackage) {
     this.currentPackage = currentPackage;
-    this.currentClassName = null;
+    currentClassName = null;
   }
 
   public void initialize(@Nonnull String currentPackage, @Nonnull String currentClassName) {
@@ -124,7 +123,8 @@ public class ImportWriterVisitor implements AstNodeVisitor {
       updateShortNames();
     }
     return importShortNames.contains(shortName)
-        && imports.stream()
+        && imports
+            .stream()
             .filter(s -> s.equals(String.format("%s.%s", pakkage, shortName)))
             .findFirst()
             .orElse("")

--- a/src/main/java/com/google/api/generator/engine/writer/JavaWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/JavaWriterVisitor.java
@@ -81,7 +81,6 @@ public class JavaWriterVisitor implements AstNodeVisitor {
   private static final String BLOCK_COMMENT_START = "/*";
   private static final String BLOCK_COMMENT_END = "*/";
   private static final String DOT = ".";
-  private static final String ESCAPED_QUOTE = "\"";
   private static final String EQUALS = "=";
   private static final String LEFT_ANGLE = "<";
   private static final String LEFT_BRACE = "{";
@@ -751,6 +750,7 @@ public class JavaWriterVisitor implements AstNodeVisitor {
   }
 
   /** =============================== COMMENT =============================== */
+  @Override
   public void visit(LineComment lineComment) {
     // Split comments by new line and add `//` to each line.
     String formattedSource =
@@ -759,6 +759,7 @@ public class JavaWriterVisitor implements AstNodeVisitor {
     buffer.append(formattedSource);
   }
 
+  @Override
   public void visit(BlockComment blockComment) {
     // Split comments by new line and embrace the comment block with `/* */`.
     StringBuilder sourceComment = new StringBuilder();
@@ -772,6 +773,7 @@ public class JavaWriterVisitor implements AstNodeVisitor {
     buffer.append(JavaFormatter.format(sourceComment.toString()));
   }
 
+  @Override
   public void visit(JavaDocComment javaDocComment) {
     StringBuilder sourceComment = new StringBuilder();
     sourceComment.append(JAVADOC_COMMENT_START).append(NEWLINE);
@@ -865,7 +867,6 @@ public class JavaWriterVisitor implements AstNodeVisitor {
       buffer.append(THROWS);
       space();
 
-      int numExceptionsThrown = methodDefinition.throwsExceptions().size();
       Iterator<TypeNode> exceptionIter = methodDefinition.throwsExceptions().iterator();
       while (exceptionIter.hasNext()) {
         TypeNode exceptionType = exceptionIter.next();

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 
 public class ServiceClientCommentComposer {
   // Tokens.
-  private static final String COLON = ":";
   private static final String EMPTY_STRING = "";
   private static final String API_EXCEPTION_TYPE_NAME = "com.google.api.gax.rpc.ApiException";
   private static final String EXCEPTION_CONDITION = "if the remote call fails";

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/SettingsCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/SettingsCommentComposer.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 public class SettingsCommentComposer {
   private static final String COLON = ":";
 
-  private static final String STUB_PATTERN = "%sStub";
   private static final String BUILDER_CLASS_DOC_PATTERN = "Builder for %s.";
   private static final String CALL_SETTINGS_METHOD_DOC_PATTERN =
       "Returns the object with the settings used for calls to %s.";

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
@@ -131,13 +131,11 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -159,8 +157,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*transportCallSettingsTemplateObjects=*/ Arrays.asList(
             requestTemplateName, responseTemplateName),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -176,13 +173,11 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*returnCallableKindName=*/ "Unary",
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -274,8 +269,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
             .setMethodName(methodName)
             .setStaticReferenceType(getTransportContext().transportCallableFactoryType())
             .setArguments(
-                arguments
-                    .stream()
+                arguments.stream()
                     .map(v -> v.toBuilder().setIsDecl(false).build())
                     .collect(Collectors.toList()))
             .setReturnType(returnType)

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
@@ -131,11 +131,13 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -157,7 +159,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*transportCallSettingsTemplateObjects=*/ Arrays.asList(
             requestTemplateName, responseTemplateName),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -173,11 +176,13 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
         /*returnCallableKindName=*/ "Unary",
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*transportCallSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -269,7 +274,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
             .setMethodName(methodName)
             .setStaticReferenceType(getTransportContext().transportCallableFactoryType())
             .setArguments(
-                arguments.stream()
+                arguments
+                    .stream()
                     .map(v -> v.toBuilder().setIsDecl(false).build())
                     .collect(Collectors.toList()))
             .setReturnType(returnType)
@@ -289,7 +295,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
   }
 
   private static TypeStore createTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             // Gax-java classes.
             BatchingCallSettings.class,

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
@@ -108,9 +108,6 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
   private static final Reference LIST_REFERENCE = ConcreteReference.withClazz(List.class);
   private static final Reference MAP_REFERENCE = ConcreteReference.withClazz(Map.class);
 
-  private static final TypeNode OBJECTS_TYPE =
-      TypeNode.withReference(ConcreteReference.withClazz(Objects.class));
-
   private enum CallableMethodKind {
     REGULAR,
     LRO,
@@ -237,7 +234,9 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
       }
     }
 
-    return fieldNameToTypes.entrySet().stream()
+    return fieldNameToTypes
+        .entrySet()
+        .stream()
         .map(
             e -> {
               String varName = e.getKey();
@@ -363,7 +362,6 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
     TypeNode stubSettingsType = typeStore.get(ClassNames.getServiceStubSettingsClassName(service));
     TypeNode exceptionType = typeStore.get("IOException");
 
-    TypeNode settingsType = typeStore.get(settingsName);
     VariableExpr settingsVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("settings").setType(typeStore.get(settingsName)).build());
@@ -418,7 +416,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setArguments(settingsVarExpr.toBuilder().setIsDecl(true).build())
             .setThrowsExceptions(Arrays.asList(exceptionType))
             .setBody(
-                ctorAssignmentExprs.stream()
+                ctorAssignmentExprs
+                    .stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .build());
@@ -451,7 +450,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(thisClassType)
             .setArguments(stubVarExpr.toBuilder().setIsDecl(true).build())
             .setBody(
-                ctorAssignmentExprs.stream()
+                ctorAssignmentExprs
+                    .stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .build());
@@ -515,10 +515,11 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
 
     if (hasLroClient) {
       Iterator<String> opClientNamesIt = getTransportContext().operationsClientNames().iterator();
-      Iterator<TypeNode> opClientTypesIt =  getTransportContext().operationsClientTypes().iterator();
+      Iterator<TypeNode> opClientTypesIt = getTransportContext().operationsClientTypes().iterator();
 
       while (opClientNamesIt.hasNext() && opClientTypesIt.hasNext()) {
-        String opClientMethodName = String.format("get%s", JavaStyle.toUpperCamelCase(opClientNamesIt.next()));
+        String opClientMethodName =
+            String.format("get%s", JavaStyle.toUpperCamelCase(opClientNamesIt.next()));
         getOperationsClientMethodNames.add(opClientMethodName);
         methodNameToTypes.put(opClientMethodName, opClientTypesIt.next());
       }
@@ -530,7 +531,9 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
                 "A restructuring of stub classes is planned, so this may break in the future")
             .build();
 
-    return methodNameToTypes.entrySet().stream()
+    return methodNameToTypes
+        .entrySet()
+        .stream()
         .map(
             e -> {
               String methodName = e.getKey();
@@ -589,7 +592,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
         grpcRpcToJavaMethodMetadata
             .get(method.name())
             .addAll(
-                generatedMethods.stream()
+                generatedMethods
+                    .stream()
                     .map(m -> javaMethodNameFn.apply(m))
                     .collect(Collectors.toList()));
         javaMethods.addAll(generatedMethods);
@@ -657,11 +661,11 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
                           lro.responseType().reference(), lro.metadataType().reference())));
     }
 
-    String methodInputTypeName = methodInputType.reference().name();
     for (List<MethodArgument> signature : method.methodSignatures()) {
       // Get the argument list.
       List<VariableExpr> arguments =
-          signature.stream()
+          signature
+              .stream()
               .map(
                   methodArg ->
                       VariableExpr.builder()
@@ -1052,7 +1056,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(TypeNode.BOOLEAN)
             .setName("awaitTermination")
             .setArguments(
-                arguments.stream()
+                arguments
+                    .stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setThrowsExceptions(Arrays.asList(typeStore.get("InterruptedException")))
@@ -1196,12 +1201,6 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
     VariableExpr inputVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("input").setType(methodPageType).build());
-    TypeNode anonClassType =
-        TypeNode.withReference(
-            ConcreteReference.builder()
-                .setClazz(ApiFunction.class)
-                .setGenerics(Arrays.asList(methodPageType.reference(), thisClassType.reference()))
-                .build());
 
     // Overrides ApiFunction.apply.
     // (https://github.com/googleapis/api-common-java/blob/debf25960dea0367b0d3b5e16d57d76c1d01947e/src/main/java/com/google/api/core/ApiFunction.java).
@@ -1240,7 +1239,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(returnType)
             .setName("createAsync")
             .setArguments(
-                Arrays.asList(contextVarExpr, futureResponseVarExpr).stream()
+                Arrays.asList(contextVarExpr, futureResponseVarExpr)
+                    .stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setBody(Arrays.asList(ExprStatement.withExpr(futurePageAssignExpr)))
@@ -1341,7 +1341,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setScope(ScopeNode.PRIVATE)
             .setReturnType(classType)
             .setArguments(
-                Arrays.asList(contextVarExpr, responseVarExpr).stream()
+                Arrays.asList(contextVarExpr, responseVarExpr)
+                    .stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setBody(
@@ -1373,7 +1374,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(classType)
             .setName("createPage")
             .setArguments(
-                Arrays.asList(contextVarExpr, responseVarExpr).stream()
+                Arrays.asList(contextVarExpr, responseVarExpr)
+                    .stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(
@@ -1405,7 +1407,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(futurePageType)
             .setName("createPageAsync")
             .setArguments(
-                Arrays.asList(contextVarExpr, futureResponseVarExpr).stream()
+                Arrays.asList(contextVarExpr, futureResponseVarExpr)
+                    .stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(
@@ -1482,7 +1485,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setScope(ScopeNode.PRIVATE)
             .setReturnType(classType)
             .setArguments(
-                Arrays.asList(pagesVarExpr, collectionSizeVarExpr).stream()
+                Arrays.asList(pagesVarExpr, collectionSizeVarExpr)
+                    .stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setBody(
@@ -1519,7 +1523,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(classType)
             .setName("createCollection")
             .setArguments(
-                Arrays.asList(pagesVarExpr, collectionSizeVarExpr).stream()
+                Arrays.asList(pagesVarExpr, collectionSizeVarExpr)
+                    .stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(
@@ -1562,7 +1567,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
         rootFields.add(rootField);
       }
       Trie<Field> updatedTrie =
-          rootFieldToTrie.containsKey(rootField) ? rootFieldToTrie.get(rootField) : new Trie();
+          rootFieldToTrie.containsKey(rootField) ? rootFieldToTrie.get(rootField) : new Trie<>();
       List<Field> nestedFieldsWithChild = new ArrayList<>(arg.nestedFields());
       nestedFieldsWithChild.add(arg.field());
       updatedTrie.insert(nestedFieldsWithChild);
@@ -1661,7 +1666,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
   }
 
   private static TypeStore createTypes(Service service, Map<String, Message> messageTypes) {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             AbstractPagedListResponse.class,
             ApiFunction.class,
@@ -1711,7 +1716,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
       }
       typeStore.putAll(
           service.pakkage(),
-          Arrays.asList("%sPagedResponse", "%sPage", "%sFixedSizeCollection").stream()
+          Arrays.asList("%sPagedResponse", "%sPage", "%sFixedSizeCollection")
+              .stream()
               .map(p -> String.format(p, JavaStyle.toUpperCamelCase(method.name())))
               .collect(Collectors.toList()),
           true,
@@ -1721,7 +1727,9 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),
@@ -1760,15 +1768,6 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
   private static boolean isProtoEmptyType(TypeNode type) {
     return type.reference().pakkage().equals("com.google.protobuf")
         && type.reference().name().equals("Empty");
-  }
-
-  private static void updateGapicMetadata(
-      GapicContext context, String protoPackage, String javaPackage) {
-    context.updateGapicMetadata(
-        context.gapicMetadata().toBuilder()
-            .setProtoPackage(protoPackage)
-            .setLibraryPackage(javaPackage)
-            .build());
   }
 
   private static void updateGapicMetadata(

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
@@ -234,9 +234,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
       }
     }
 
-    return fieldNameToTypes
-        .entrySet()
-        .stream()
+    return fieldNameToTypes.entrySet().stream()
         .map(
             e -> {
               String varName = e.getKey();
@@ -416,8 +414,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setArguments(settingsVarExpr.toBuilder().setIsDecl(true).build())
             .setThrowsExceptions(Arrays.asList(exceptionType))
             .setBody(
-                ctorAssignmentExprs
-                    .stream()
+                ctorAssignmentExprs.stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .build());
@@ -450,8 +447,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(thisClassType)
             .setArguments(stubVarExpr.toBuilder().setIsDecl(true).build())
             .setBody(
-                ctorAssignmentExprs
-                    .stream()
+                ctorAssignmentExprs.stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .build());
@@ -531,9 +527,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
                 "A restructuring of stub classes is planned, so this may break in the future")
             .build();
 
-    return methodNameToTypes
-        .entrySet()
-        .stream()
+    return methodNameToTypes.entrySet().stream()
         .map(
             e -> {
               String methodName = e.getKey();
@@ -592,8 +586,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
         grpcRpcToJavaMethodMetadata
             .get(method.name())
             .addAll(
-                generatedMethods
-                    .stream()
+                generatedMethods.stream()
                     .map(m -> javaMethodNameFn.apply(m))
                     .collect(Collectors.toList()));
         javaMethods.addAll(generatedMethods);
@@ -664,8 +657,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
     for (List<MethodArgument> signature : method.methodSignatures()) {
       // Get the argument list.
       List<VariableExpr> arguments =
-          signature
-              .stream()
+          signature.stream()
               .map(
                   methodArg ->
                       VariableExpr.builder()
@@ -1056,8 +1048,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(TypeNode.BOOLEAN)
             .setName("awaitTermination")
             .setArguments(
-                arguments
-                    .stream()
+                arguments.stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setThrowsExceptions(Arrays.asList(typeStore.get("InterruptedException")))
@@ -1239,8 +1230,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(returnType)
             .setName("createAsync")
             .setArguments(
-                Arrays.asList(contextVarExpr, futureResponseVarExpr)
-                    .stream()
+                Arrays.asList(contextVarExpr, futureResponseVarExpr).stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setBody(Arrays.asList(ExprStatement.withExpr(futurePageAssignExpr)))
@@ -1341,8 +1331,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setScope(ScopeNode.PRIVATE)
             .setReturnType(classType)
             .setArguments(
-                Arrays.asList(contextVarExpr, responseVarExpr)
-                    .stream()
+                Arrays.asList(contextVarExpr, responseVarExpr).stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setBody(
@@ -1374,8 +1363,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(classType)
             .setName("createPage")
             .setArguments(
-                Arrays.asList(contextVarExpr, responseVarExpr)
-                    .stream()
+                Arrays.asList(contextVarExpr, responseVarExpr).stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(
@@ -1407,8 +1395,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(futurePageType)
             .setName("createPageAsync")
             .setArguments(
-                Arrays.asList(contextVarExpr, futureResponseVarExpr)
-                    .stream()
+                Arrays.asList(contextVarExpr, futureResponseVarExpr).stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(
@@ -1485,8 +1472,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setScope(ScopeNode.PRIVATE)
             .setReturnType(classType)
             .setArguments(
-                Arrays.asList(pagesVarExpr, collectionSizeVarExpr)
-                    .stream()
+                Arrays.asList(pagesVarExpr, collectionSizeVarExpr).stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setBody(
@@ -1523,8 +1509,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             .setReturnType(classType)
             .setName("createCollection")
             .setArguments(
-                Arrays.asList(pagesVarExpr, collectionSizeVarExpr)
-                    .stream()
+                Arrays.asList(pagesVarExpr, collectionSizeVarExpr).stream()
                     .map(e -> e.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(
@@ -1716,8 +1701,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
       }
       typeStore.putAll(
           service.pakkage(),
-          Arrays.asList("%sPagedResponse", "%sPage", "%sFixedSizeCollection")
-              .stream()
+          Arrays.asList("%sPagedResponse", "%sPage", "%sFixedSizeCollection").stream()
               .map(p -> String.format(p, JavaStyle.toUpperCamelCase(method.name())))
               .collect(Collectors.toList()),
           true,
@@ -1727,9 +1711,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -151,9 +151,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
 
     // Static fields go first.
     fieldDeclStatements.addAll(
-        classMemberVarExprs
-            .values()
-            .stream()
+        classMemberVarExprs.values().stream()
             .filter(v -> isMockVarExprFn.apply(v))
             .map(
                 v ->
@@ -166,9 +164,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
             .collect(Collectors.toList()));
 
     fieldDeclStatements.addAll(
-        classMemberVarExprs
-            .values()
-            .stream()
+        classMemberVarExprs.values().stream()
             .filter(v -> !isMockVarExprFn.apply(v))
             .map(
                 v ->
@@ -235,9 +231,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
         String mixinServiceName = method.mixedInApiName().substring(dotIndex + 1);
         String mixinServiceProtoPackage = method.mixedInApiName().substring(0, dotIndex);
         Optional<Service> mixinServiceOpt =
-            context
-                .mixinServices()
-                .stream()
+            context.mixinServices().stream()
                 .filter(
                     s ->
                         s.name().equals(mixinServiceName)
@@ -830,8 +824,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
     TryCatchStatement tryCatchBlock =
         TryCatchStatement.builder()
             .setTryBody(
-                tryBodyExprs
-                    .stream()
+                tryBodyExprs.stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .addCatch(catchExceptionVarExpr.toBuilder().setIsDecl(true).build(), catchBody)
@@ -891,9 +884,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
@@ -133,7 +133,9 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
         service.methods().isEmpty()
             ? Optional.empty()
             : Optional.of(
-                service.methods().stream()
+                service
+                    .methods()
+                    .stream()
                     .filter(m -> m.stream() == Stream.NONE && !m.hasLro() && !m.isPaged())
                     .findFirst()
                     .orElse(service.methods().get(0)));
@@ -324,7 +326,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
                         .build());
     BiFunction<MethodDefinition.Builder, CommentStatement, MethodDefinition> methodMakerFn =
         (methodDefBuilder, comment) -> methodDefBuilder.setHeaderCommentStatements(comment).build();
-    Function<Class, TypeNode> typeMakerFn =
+    Function<Class<?>, TypeNode> typeMakerFn =
         c -> TypeNode.withReference(ConcreteReference.withClazz(c));
 
     List<MethodDefinition> javaMethods = new ArrayList<>();
@@ -750,7 +752,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             ApiClientHeaderProvider.class,
             ApiFunction.class,
@@ -793,7 +795,9 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),
@@ -815,7 +819,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
     Preconditions.checkState(
         protoMethod.hasLro(),
         String.format("Cannot get OperationCallSettings on non-LRO method %s", protoMethod.name()));
-    Class callSettingsClazz =
+    Class<?> callSettingsClazz =
         isBuilder ? OperationCallSettings.Builder.class : OperationCallSettings.class;
     return TypeNode.withReference(
         ConcreteReference.builder()
@@ -838,7 +842,8 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
 
   private static TypeNode getCallSettingsTypeHelper(
       Method protoMethod, TypeStore typeStore, boolean isBuilder) {
-    Class callSettingsClazz = isBuilder ? UnaryCallSettings.Builder.class : UnaryCallSettings.class;
+    Class<?> callSettingsClazz =
+        isBuilder ? UnaryCallSettings.Builder.class : UnaryCallSettings.class;
     if (protoMethod.isPaged()) {
       callSettingsClazz = isBuilder ? PagedCallSettings.Builder.class : PagedCallSettings.class;
     } else if (protoMethod.isBatching()) {

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
@@ -133,9 +133,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
         service.methods().isEmpty()
             ? Optional.empty()
             : Optional.of(
-                service
-                    .methods()
-                    .stream()
+                service.methods().stream()
                     .filter(m -> m.stream() == Stream.NONE && !m.hasLro() && !m.isPaged())
                     .findFirst()
                     .orElse(service.methods().get(0)));
@@ -795,9 +793,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
@@ -249,9 +249,7 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
 public abstract class AbstractServiceStubClassComposer implements ClassComposer {
-  private static final String DOT = ".";
   private static final String PAGED_RESPONSE_TYPE_NAME_PATTERN = "%sPagedResponse";
 
   private final TransportContext transportContext;
@@ -210,7 +209,9 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
       String methodName =
           String.format("get%s", JavaStyle.toUpperCamelCase(operationStubNameIt.next()));
 
-      getters.add(createOperationsStubGetterMethodDefinition(operationStubTypeIt.next(), methodName, typeStore));
+      getters.add(
+          createOperationsStubGetterMethodDefinition(
+              operationStubTypeIt.next(), methodName, typeStore));
     }
 
     return getters;
@@ -229,7 +230,7 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
   }
 
   private static TypeStore createTypes(Service service, Map<String, Message> messageTypes) {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             BackgroundResource.class,
             BetaApi.class,
@@ -248,7 +249,9 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),
@@ -259,7 +262,10 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
   }
 
   protected MethodDefinition createCallableGetterMethodDefinition(
-      TypeNode returnType, String methodName, List<AnnotationNode> annotations, TypeStore typeStore) {
+      TypeNode returnType,
+      String methodName,
+      List<AnnotationNode> annotations,
+      TypeStore typeStore) {
     return MethodDefinition.builder()
         .setScope(ScopeNode.PUBLIC)
         .setAnnotations(annotations)
@@ -289,9 +295,5 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
                         .setMessageExpr(String.format("Not implemented: %s()", methodName))
                         .build())))
         .build();
-  }
-
-  private static String getClientClassName(Service service) {
-    return String.format("%sClient", service.overriddenName());
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -373,9 +373,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
         service.methods().isEmpty()
             ? Optional.empty()
             : Optional.of(
-                service
-                    .methods()
-                    .stream()
+                service.methods().stream()
                     .filter(m -> m.stream() == Stream.NONE && !m.hasLro() && !m.isPaged())
                     .findFirst()
                     .orElse(service.methods().get(0)));
@@ -451,8 +449,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // Assign DEFAULT_SERVICE_SCOPES.
     statements.add(SettingsCommentComposer.DEFAULT_SCOPES_COMMENT);
     VariableExpr defaultServiceScopesDeclVarExpr =
-        DEFAULT_SERVICE_SCOPES_VAR_EXPR
-            .toBuilder()
+        DEFAULT_SERVICE_SCOPES_VAR_EXPR.toBuilder()
             .setIsDecl(true)
             .setScope(ScopeNode.PRIVATE)
             .setIsStatic(true)
@@ -489,9 +486,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
     // Declare settings members.
     statements.addAll(
-        methodSettingsMemberVarExprs
-            .values()
-            .stream()
+        methodSettingsMemberVarExprs.values().stream()
             .map(
                 v ->
                     exprToStatementFn.apply(
@@ -644,8 +639,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(method.inputType())
             .setName("injectToken")
             .setArguments(
-                Arrays.asList(payloadVarExpr, strTokenVarExpr)
-                    .stream()
+                Arrays.asList(payloadVarExpr, strTokenVarExpr).stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(returnExpr)
@@ -674,8 +668,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(method.inputType())
             .setName("injectPageSize")
             .setArguments(
-                Arrays.asList(payloadVarExpr, pageSizeVarExpr)
-                    .stream()
+                Arrays.asList(payloadVarExpr, pageSizeVarExpr).stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(returnExpr)
@@ -806,8 +799,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // Declare and assign the variable.
     return AssignmentExpr.builder()
         .setVariableExpr(
-            pagedListDescVarExpr
-                .toBuilder()
+            pagedListDescVarExpr.toBuilder()
                 .setIsDecl(true)
                 .setScope(ScopeNode.PRIVATE)
                 .setIsStatic(true)
@@ -946,8 +938,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
     return AssignmentExpr.builder()
         .setVariableExpr(
-            pagedListResponseFactoryVarExpr
-                .toBuilder()
+            pagedListResponseFactoryVarExpr.toBuilder()
                 .setIsDecl(true)
                 .setScope(ScopeNode.PRIVATE)
                 .setIsStatic(true)
@@ -993,9 +984,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
               .setReturnExpr(e.getValue())
               .build();
         };
-    return methodSettingsMemberVarExprs
-        .entrySet()
-        .stream()
+    return methodSettingsMemberVarExprs.entrySet().stream()
         .map(e -> varToMethodFn.apply(e))
         .collect(Collectors.toList());
   }
@@ -1272,9 +1261,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
                         .build())
                 .build();
     bodyStatements.addAll(
-        methodSettingsMemberVarExprs
-            .entrySet()
-            .stream()
+        methodSettingsMemberVarExprs.entrySet().stream()
             .map(e -> ExprStatement.withExpr(varInitExprFn.apply(e)))
             .collect(Collectors.toList()));
 
@@ -1299,8 +1286,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             ConcreteReference.builder()
                 .setClazz(StubSettings.Builder.class)
                 .setGenerics(
-                    Arrays.asList(typeStore.get(thisClassName), typeStore.get(className))
-                        .stream()
+                    Arrays.asList(typeStore.get(thisClassName), typeStore.get(className)).stream()
                         .map(t -> t.reference())
                         .collect(Collectors.toList()))
                 .build());
@@ -1350,9 +1336,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
     // Declare all the settings fields.
     exprs.addAll(
-        nestedMethodSettingsMemberVarExprs
-            .values()
-            .stream()
+        nestedMethodSettingsMemberVarExprs.values().stream()
             .map(v -> varDeclFn.apply(v))
             .collect(Collectors.toList()));
 
@@ -1550,9 +1534,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     ctorBodyStatements.add(EMPTY_LINE_STATEMENT);
 
     ctorBodyStatements.addAll(
-        nestedMethodSettingsMemberVarExprs
-            .entrySet()
-            .stream()
+        nestedMethodSettingsMemberVarExprs.entrySet().stream()
             .map(
                 e -> {
                   // TODO(miraleung): Extract this into another method.
@@ -1661,9 +1643,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
                             .generics())
                     .setMethodName("of")
                     .setArguments(
-                        nestedMethodSettingsMemberVarExprs
-                            .values()
-                            .stream()
+                        nestedMethodSettingsMemberVarExprs.values().stream()
                             .filter(
                                 v ->
                                     isUnaryCallSettingsBuilderFn.apply(v.type())
@@ -1709,9 +1689,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // TODO(cleanup): Technically this should actually use the outer class's <method>Settings
     // members to avoid decoupling variable names.
     ctorBodyStatements.addAll(
-        nestedMethodSettingsMemberVarExprs
-            .values()
-            .stream()
+        nestedMethodSettingsMemberVarExprs.values().stream()
             .map(
                 v ->
                     ExprStatement.withExpr(
@@ -2072,9 +2050,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),
@@ -2126,8 +2102,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             ConcreteReference.builder()
                 .setClazz(ImmutableMap.class)
                 .setGenerics(
-                    Arrays.asList(TypeNode.STRING, immutableSetType)
-                        .stream()
+                    Arrays.asList(TypeNode.STRING, immutableSetType).stream()
                         .map(t -> t.reference())
                         .collect(Collectors.toList()))
                 .build());
@@ -2144,8 +2119,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             ConcreteReference.builder()
                 .setClazz(ImmutableMap.class)
                 .setGenerics(
-                    Arrays.asList(TypeNode.STRING, FIXED_TYPESTORE.get("RetrySettings"))
-                        .stream()
+                    Arrays.asList(TypeNode.STRING, FIXED_TYPESTORE.get("RetrySettings")).stream()
                         .map(t -> t.reference())
                         .collect(Collectors.toList()))
                 .build());

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -373,7 +373,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
         service.methods().isEmpty()
             ? Optional.empty()
             : Optional.of(
-                service.methods().stream()
+                service
+                    .methods()
+                    .stream()
                     .filter(m -> m.stream() == Stream.NONE && !m.hasLro() && !m.isPaged())
                     .findFirst()
                     .orElse(service.methods().get(0)));
@@ -449,7 +451,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // Assign DEFAULT_SERVICE_SCOPES.
     statements.add(SettingsCommentComposer.DEFAULT_SCOPES_COMMENT);
     VariableExpr defaultServiceScopesDeclVarExpr =
-        DEFAULT_SERVICE_SCOPES_VAR_EXPR.toBuilder()
+        DEFAULT_SERVICE_SCOPES_VAR_EXPR
+            .toBuilder()
             .setIsDecl(true)
             .setScope(ScopeNode.PRIVATE)
             .setIsStatic(true)
@@ -486,7 +489,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
     // Declare settings members.
     statements.addAll(
-        methodSettingsMemberVarExprs.values().stream()
+        methodSettingsMemberVarExprs
+            .values()
+            .stream()
             .map(
                 v ->
                     exprToStatementFn.apply(
@@ -639,7 +644,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(method.inputType())
             .setName("injectToken")
             .setArguments(
-                Arrays.asList(payloadVarExpr, strTokenVarExpr).stream()
+                Arrays.asList(payloadVarExpr, strTokenVarExpr)
+                    .stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(returnExpr)
@@ -668,7 +674,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .setReturnType(method.inputType())
             .setName("injectPageSize")
             .setArguments(
-                Arrays.asList(payloadVarExpr, pageSizeVarExpr).stream()
+                Arrays.asList(payloadVarExpr, pageSizeVarExpr)
+                    .stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setReturnExpr(returnExpr)
@@ -799,7 +806,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // Declare and assign the variable.
     return AssignmentExpr.builder()
         .setVariableExpr(
-            pagedListDescVarExpr.toBuilder()
+            pagedListDescVarExpr
+                .toBuilder()
                 .setIsDecl(true)
                 .setScope(ScopeNode.PRIVATE)
                 .setIsStatic(true)
@@ -938,7 +946,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
     return AssignmentExpr.builder()
         .setVariableExpr(
-            pagedListResponseFactoryVarExpr.toBuilder()
+            pagedListResponseFactoryVarExpr
+                .toBuilder()
                 .setIsDecl(true)
                 .setScope(ScopeNode.PRIVATE)
                 .setIsStatic(true)
@@ -984,7 +993,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
               .setReturnExpr(e.getValue())
               .build();
         };
-    return methodSettingsMemberVarExprs.entrySet().stream()
+    return methodSettingsMemberVarExprs
+        .entrySet()
+        .stream()
         .map(e -> varToMethodFn.apply(e))
         .collect(Collectors.toList());
   }
@@ -1261,7 +1272,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
                         .build())
                 .build();
     bodyStatements.addAll(
-        methodSettingsMemberVarExprs.entrySet().stream()
+        methodSettingsMemberVarExprs
+            .entrySet()
+            .stream()
             .map(e -> ExprStatement.withExpr(varInitExprFn.apply(e)))
             .collect(Collectors.toList()));
 
@@ -1278,7 +1291,6 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
       Service service, @Nullable GapicServiceConfig serviceConfig, TypeStore typeStore) {
     // TODO(miraleung): Robustify this against a null serviceConfig.
     String thisClassName = ClassNames.getServiceStubSettingsClassName(service);
-    TypeNode outerThisClassType = typeStore.get(thisClassName);
 
     String className = "Builder";
 
@@ -1287,7 +1299,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             ConcreteReference.builder()
                 .setClazz(StubSettings.Builder.class)
                 .setGenerics(
-                    Arrays.asList(typeStore.get(thisClassName), typeStore.get(className)).stream()
+                    Arrays.asList(typeStore.get(thisClassName), typeStore.get(className))
+                        .stream()
                         .map(t -> t.reference())
                         .collect(Collectors.toList()))
                 .build());
@@ -1337,7 +1350,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
     // Declare all the settings fields.
     exprs.addAll(
-        nestedMethodSettingsMemberVarExprs.values().stream()
+        nestedMethodSettingsMemberVarExprs
+            .values()
+            .stream()
             .map(v -> varDeclFn.apply(v))
             .collect(Collectors.toList()));
 
@@ -1535,7 +1550,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     ctorBodyStatements.add(EMPTY_LINE_STATEMENT);
 
     ctorBodyStatements.addAll(
-        nestedMethodSettingsMemberVarExprs.entrySet().stream()
+        nestedMethodSettingsMemberVarExprs
+            .entrySet()
+            .stream()
             .map(
                 e -> {
                   // TODO(miraleung): Extract this into another method.
@@ -1644,7 +1661,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
                             .generics())
                     .setMethodName("of")
                     .setArguments(
-                        nestedMethodSettingsMemberVarExprs.values().stream()
+                        nestedMethodSettingsMemberVarExprs
+                            .values()
+                            .stream()
                             .filter(
                                 v ->
                                     isUnaryCallSettingsBuilderFn.apply(v.type())
@@ -1690,7 +1709,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // TODO(cleanup): Technically this should actually use the outer class's <method>Settings
     // members to avoid decoupling variable names.
     ctorBodyStatements.addAll(
-        nestedMethodSettingsMemberVarExprs.values().stream()
+        nestedMethodSettingsMemberVarExprs
+            .values()
+            .stream()
             .map(
                 v ->
                     ExprStatement.withExpr(
@@ -1982,7 +2003,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             ApiCallContext.class,
             ApiClientHeaderProvider.class,
@@ -2051,7 +2072,9 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),
@@ -2103,7 +2126,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             ConcreteReference.builder()
                 .setClazz(ImmutableMap.class)
                 .setGenerics(
-                    Arrays.asList(TypeNode.STRING, immutableSetType).stream()
+                    Arrays.asList(TypeNode.STRING, immutableSetType)
+                        .stream()
                         .map(t -> t.reference())
                         .collect(Collectors.toList()))
                 .build());
@@ -2120,7 +2144,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             ConcreteReference.builder()
                 .setClazz(ImmutableMap.class)
                 .setGenerics(
-                    Arrays.asList(TypeNode.STRING, FIXED_TYPESTORE.get("RetrySettings")).stream()
+                    Arrays.asList(TypeNode.STRING, FIXED_TYPESTORE.get("RetrySettings"))
+                        .stream()
                         .map(t -> t.reference())
                         .collect(Collectors.toList()))
                 .build());
@@ -2140,7 +2165,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
       TypeStore typeStore,
       boolean isBatchingSettings,
       final boolean isSettingsBuilder) {
-    Function<Class, TypeNode> typeMakerFn =
+    Function<Class<?>, TypeNode> typeMakerFn =
         clz -> TypeNode.withReference(ConcreteReference.withClazz(clz));
     // Default: No streaming.
     TypeNode callSettingsType =

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -254,9 +254,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   protected List<Statement> createMethodDescriptorVariableDecls(
       Service service, Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs) {
-    return service
-        .methods()
-        .stream()
+    return service.methods().stream()
         .map(
             m ->
                 createMethodDescriptorVariableDecl(
@@ -266,9 +264,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   private static List<Statement> createClassMemberFieldDeclarations(
       Map<String, VariableExpr> fieldNameToVarExprs) {
-    return fieldNameToVarExprs
-        .values()
-        .stream()
+    return fieldNameToVarExprs.values().stream()
         .map(
             v ->
                 ExprStatement.withExpr(
@@ -282,9 +278,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   protected Map<String, VariableExpr> createProtoMethodNameToDescriptorClassMembers(
       Service service, Class<?> descriptorClass) {
-    return service
-        .methods()
-        .stream()
+    return service.methods().stream()
         .collect(
             Collectors.toMap(
                 Method::name,
@@ -429,8 +423,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                 .setReturnType(creatorMethodReturnType)
                 .setName("create")
                 .setArguments(
-                    argList
-                        .stream()
+                    argList.stream()
                         .map(v -> v.toBuilder().setIsDecl(true).build())
                         .collect(Collectors.toList()))
                 .setThrowsExceptions(
@@ -570,9 +563,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     secondCtorExprs.add(
         AssignmentExpr.builder()
             .setVariableExpr(
-                classMemberVarExprs
-                    .get("callableFactory")
-                    .toBuilder()
+                classMemberVarExprs.get("callableFactory").toBuilder()
                     .setExprReferenceExpr(thisExpr)
                     .build())
             .setValueExpr(callableFactoryVarExpr)
@@ -601,9 +592,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
     // Transport settings local variables.
     Map<String, VariableExpr> javaStyleMethodNameToTransportSettingsVarExprs =
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .collect(
                 Collectors.toMap(
                     m -> JavaStyle.toLowerCamelCase(m.name()),
@@ -626,9 +615,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                                 .build())));
 
     secondCtorExprs.addAll(
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .map(
                 m ->
                     createTransportSettingsInitExpr(
@@ -644,9 +631,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
     // Initialize <method>Callable variables.
     secondCtorExprs.addAll(
-        callableClassMemberVarExprs
-            .entrySet()
-            .stream()
+        callableClassMemberVarExprs.entrySet().stream()
             .map(
                 e ->
                     createCallableInitExpr(
@@ -796,9 +781,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   private static List<MethodDefinition> createCallableGetterMethods(
       Map<String, VariableExpr> callableClassMemberVarExprs) {
-    return callableClassMemberVarExprs
-        .entrySet()
-        .stream()
+    return callableClassMemberVarExprs.entrySet().stream()
         .map(
             e ->
                 MethodDefinition.builder()
@@ -930,8 +913,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
             .apply("awaitTermination")
             .setReturnType(TypeNode.BOOLEAN)
             .setArguments(
-                awaitTerminationArgs
-                    .stream()
+                awaitTerminationArgs.stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setThrowsExceptions(Arrays.asList(FIXED_TYPESTORE.get("InterruptedException")))
@@ -940,8 +922,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                     .setExprReferenceExpr(backgroundResourcesVarExpr)
                     .setMethodName("awaitTermination")
                     .setArguments(
-                        awaitTerminationArgs
-                            .stream()
+                        awaitTerminationArgs.stream()
                             .map(v -> (Expr) v)
                             .collect(Collectors.toList()))
                     .setReturnType(TypeNode.BOOLEAN)
@@ -964,9 +945,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service
-            .methods()
-            .stream()
+        service.methods().stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -48,6 +48,7 @@ import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.gapic.composer.comment.StubCommentComposer;
 import com.google.api.generator.gapic.composer.store.TypeStore;
+import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.composer.utils.PackageChecker;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicClass.Kind;
@@ -101,7 +102,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             BackgroundResource.class,
             BackgroundResourceAggregation.class,
@@ -181,8 +182,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
             .setAnnotations(createClassAnnotations(service))
             .setScope(ScopeNode.PUBLIC)
             .setName(className)
-            .setExtendsType(
-                typeStore.get(getTransportContext().classNames().getServiceStubClassName(service)))
+            .setExtendsType(typeStore.get(ClassNames.getServiceStubClassName(service)))
             .setStatements(classStatements)
             .setMethods(
                 createClassMethods(
@@ -211,7 +211,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     String methodName =
         String.format(
             "get%s",
-            JavaStyle.toUpperCamelCase(getTransportContext().transportOperationsStubNames().get(0)));
+            JavaStyle.toUpperCamelCase(
+                getTransportContext().transportOperationsStubNames().get(0)));
 
     return Arrays.asList(
         MethodDefinition.builder()
@@ -253,7 +254,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   protected List<Statement> createMethodDescriptorVariableDecls(
       Service service, Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs) {
-    return service.methods().stream()
+    return service
+        .methods()
+        .stream()
         .map(
             m ->
                 createMethodDescriptorVariableDecl(
@@ -263,7 +266,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   private static List<Statement> createClassMemberFieldDeclarations(
       Map<String, VariableExpr> fieldNameToVarExprs) {
-    return fieldNameToVarExprs.values().stream()
+    return fieldNameToVarExprs
+        .values()
+        .stream()
         .map(
             v ->
                 ExprStatement.withExpr(
@@ -277,7 +282,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   protected Map<String, VariableExpr> createProtoMethodNameToDescriptorClassMembers(
       Service service, Class<?> descriptorClass) {
-    return service.methods().stream()
+    return service
+        .methods()
+        .stream()
         .collect(
             Collectors.toMap(
                 Method::name,
@@ -401,14 +408,16 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
         createGetMethodDescriptorsMethod(service, typeStore, protoMethodNameToDescriptorVarExprs));
     javaMethods.addAll(
         createOperationsStubGetterMethod(
-            service, classMemberVarExprs.get(getTransportContext().transportOperationsStubNames().get(0))));
+            service,
+            classMemberVarExprs.get(getTransportContext().transportOperationsStubNames().get(0))));
     javaMethods.addAll(createCallableGetterMethods(callableClassMemberVarExprs));
     javaMethods.addAll(
         createStubOverrideMethods(classMemberVarExprs.get(BACKGROUND_RESOURCES_MEMBER_NAME)));
     return javaMethods;
   }
 
-  protected List<MethodDefinition> createStaticCreatorMethods(Service service, TypeStore typeStore, String newBuilderMethod) {
+  protected List<MethodDefinition> createStaticCreatorMethods(
+      Service service, TypeStore typeStore, String newBuilderMethod) {
     TypeNode creatorMethodReturnType =
         typeStore.get(getTransportContext().classNames().getTransportServiceStubClassName(service));
     Function<List<VariableExpr>, MethodDefinition.Builder> creatorMethodStarterFn =
@@ -420,7 +429,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                 .setReturnType(creatorMethodReturnType)
                 .setName("create")
                 .setArguments(
-                    argList.stream()
+                    argList
+                        .stream()
                         .map(v -> v.toBuilder().setIsDecl(true).build())
                         .collect(Collectors.toList()))
                 .setThrowsExceptions(
@@ -431,8 +441,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
         argList ->
             NewObjectExpr.builder().setType(creatorMethodReturnType).setArguments(argList).build();
 
-    TypeNode stubSettingsType =
-        typeStore.get(getTransportContext().classNames().getServiceStubSettingsClassName(service));
+    TypeNode stubSettingsType = typeStore.get(ClassNames.getServiceStubSettingsClassName(service));
     VariableExpr settingsVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("settings").setType(stubSettingsType).build());
@@ -494,8 +503,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
       Map<String, VariableExpr> classMemberVarExprs,
       Map<String, VariableExpr> callableClassMemberVarExprs,
       Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs) {
-    TypeNode stubSettingsType =
-        typeStore.get(getTransportContext().classNames().getServiceStubSettingsClassName(service));
+    TypeNode stubSettingsType = typeStore.get(ClassNames.getServiceStubSettingsClassName(service));
     VariableExpr settingsVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("settings").setType(stubSettingsType).build());
@@ -562,12 +570,15 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     secondCtorExprs.add(
         AssignmentExpr.builder()
             .setVariableExpr(
-                classMemberVarExprs.get("callableFactory").toBuilder()
+                classMemberVarExprs
+                    .get("callableFactory")
+                    .toBuilder()
                     .setExprReferenceExpr(thisExpr)
                     .build())
             .setValueExpr(callableFactoryVarExpr)
             .build());
-    VariableExpr operationsStubClassVarExpr = classMemberVarExprs.get(getTransportContext().transportOperationsStubNames().get(0));
+    VariableExpr operationsStubClassVarExpr =
+        classMemberVarExprs.get(getTransportContext().transportOperationsStubNames().get(0));
     if (generateOperationsStubLogic(service)) {
       secondCtorExprs.add(
           AssignmentExpr.builder()
@@ -575,7 +586,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                   operationsStubClassVarExpr.toBuilder().setExprReferenceExpr(thisExpr).build())
               .setValueExpr(
                   MethodInvocationExpr.builder()
-                      .setStaticReferenceType(getTransportContext().transportOperationsStubTypes().get(0))
+                      .setStaticReferenceType(
+                          getTransportContext().transportOperationsStubTypes().get(0))
                       .setMethodName("create")
                       .setArguments(Arrays.asList(clientContextVarExpr, callableFactoryVarExpr))
                       .setReturnType(operationsStubClassVarExpr.type())
@@ -589,7 +601,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
     // Transport settings local variables.
     Map<String, VariableExpr> javaStyleMethodNameToTransportSettingsVarExprs =
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .collect(
                 Collectors.toMap(
                     m -> JavaStyle.toLowerCamelCase(m.name()),
@@ -612,7 +626,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                                 .build())));
 
     secondCtorExprs.addAll(
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .map(
                 m ->
                     createTransportSettingsInitExpr(
@@ -628,7 +644,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
     // Initialize <method>Callable variables.
     secondCtorExprs.addAll(
-        callableClassMemberVarExprs.entrySet().stream()
+        callableClassMemberVarExprs
+            .entrySet()
+            .stream()
             .map(
                 e ->
                     createCallableInitExpr(
@@ -778,7 +796,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   private static List<MethodDefinition> createCallableGetterMethods(
       Map<String, VariableExpr> callableClassMemberVarExprs) {
-    return callableClassMemberVarExprs.entrySet().stream()
+    return callableClassMemberVarExprs
+        .entrySet()
+        .stream()
         .map(
             e ->
                 MethodDefinition.builder()
@@ -910,7 +930,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
             .apply("awaitTermination")
             .setReturnType(TypeNode.BOOLEAN)
             .setArguments(
-                awaitTerminationArgs.stream()
+                awaitTerminationArgs
+                    .stream()
                     .map(v -> v.toBuilder().setIsDecl(true).build())
                     .collect(Collectors.toList()))
             .setThrowsExceptions(Arrays.asList(FIXED_TYPESTORE.get("InterruptedException")))
@@ -919,7 +940,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
                     .setExprReferenceExpr(backgroundResourcesVarExpr)
                     .setMethodName("awaitTermination")
                     .setArguments(
-                        awaitTerminationArgs.stream()
+                        awaitTerminationArgs
+                            .stream()
                             .map(v -> (Expr) v)
                             .collect(Collectors.toList()))
                     .setReturnType(TypeNode.BOOLEAN)
@@ -934,20 +956,22 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
         stubPakkage,
         Arrays.asList(
             getTransportContext().classNames().getTransportServiceStubClassName(service),
-            getTransportContext().classNames().getServiceStubSettingsClassName(service),
-            getTransportContext().classNames().getServiceStubClassName(service),
+            ClassNames.getServiceStubSettingsClassName(service),
+            ClassNames.getServiceStubClassName(service),
             getTransportContext()
                 .classNames()
                 .getTransportServiceCallableFactoryClassName(service)));
     // Pagination types.
     typeStore.putAll(
         service.pakkage(),
-        service.methods().stream()
+        service
+            .methods()
+            .stream()
             .filter(m -> m.isPaged())
             .map(m -> String.format(PAGED_RESPONSE_TYPE_NAME_PATTERN, m.name()))
             .collect(Collectors.toList()),
         true,
-        getTransportContext().classNames().getServiceClientClassName(service));
+        ClassNames.getServiceClientClassName(service));
     return typeStore;
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/common/BatchingDescriptorComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/BatchingDescriptorComposer.java
@@ -230,8 +230,7 @@ public class BatchingDescriptorComposer {
             .setStatements(
                 Arrays.asList(
                     ExprStatement.withExpr(
-                        builderVarExpr
-                            .toBuilder()
+                        builderVarExpr.toBuilder()
                             .setIsDecl(true)
                             .setScope(ScopeNode.PRIVATE)
                             .build())))
@@ -358,8 +357,7 @@ public class BatchingDescriptorComposer {
               forIndexVarExpr,
               initValueExpr,
               subresponseCountVarExpr,
-              innerSubresponseForExprs
-                  .stream()
+              innerSubresponseForExprs.stream()
                   .map(e -> ExprStatement.withExpr(e))
                   .collect(Collectors.toList()));
 
@@ -439,8 +437,7 @@ public class BatchingDescriptorComposer {
         .setReturnType(TypeNode.VOID)
         .setName("splitResponse")
         .setArguments(
-            Arrays.asList(batchResponseVarExpr, batchVarExpr)
-                .stream()
+            Arrays.asList(batchResponseVarExpr, batchVarExpr).stream()
                 .map(v -> v.toBuilder().setIsDecl(true).build())
                 .collect(Collectors.toList()))
         .setBody(bodyStatements)
@@ -489,8 +486,7 @@ public class BatchingDescriptorComposer {
         .setReturnType(TypeNode.VOID)
         .setName("splitException")
         .setArguments(
-            Arrays.asList(throwableVarExpr, batchVarExpr)
-                .stream()
+            Arrays.asList(throwableVarExpr, batchVarExpr).stream()
                 .map(v -> v.toBuilder().setIsDecl(true).build())
                 .collect(Collectors.toList()))
         .setBody(Arrays.asList(forStatement))

--- a/src/main/java/com/google/api/generator/gapic/composer/common/BatchingDescriptorComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/BatchingDescriptorComposer.java
@@ -66,7 +66,6 @@ public class BatchingDescriptorComposer {
   private static final TypeNode PARTITION_KEY_TYPE = toType(PartitionKey.class);
 
   private static final String ADD_ALL_METHOD_PATTERN = "addAll%s";
-  private static final String BATCH_FOO_INDEX_PATTERN = "batch%sIndex";
   private static final String GET_LIST_METHOD_PATTERN = "get%sList";
   private static final String GET_COUNT_METHOD_PATTERN = "get%sCount";
 
@@ -272,8 +271,6 @@ public class BatchingDescriptorComposer {
         VariableExpr.withVariable(
             Variable.builder().setType(batchedRequestIssuerType).setName("responder").build());
 
-    String upperCamelBatchedFieldName =
-        JavaStyle.toUpperCamelCase(batchingSettings.batchedFieldName());
     VariableExpr batchMessageIndexVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setType(TypeNode.INT).setName("batchMessageIndex").build());
@@ -361,7 +358,8 @@ public class BatchingDescriptorComposer {
               forIndexVarExpr,
               initValueExpr,
               subresponseCountVarExpr,
-              innerSubresponseForExprs.stream()
+              innerSubresponseForExprs
+                  .stream()
                   .map(e -> ExprStatement.withExpr(e))
                   .collect(Collectors.toList()));
 
@@ -441,7 +439,8 @@ public class BatchingDescriptorComposer {
         .setReturnType(TypeNode.VOID)
         .setName("splitResponse")
         .setArguments(
-            Arrays.asList(batchResponseVarExpr, batchVarExpr).stream()
+            Arrays.asList(batchResponseVarExpr, batchVarExpr)
+                .stream()
                 .map(v -> v.toBuilder().setIsDecl(true).build())
                 .collect(Collectors.toList()))
         .setBody(bodyStatements)
@@ -490,7 +489,8 @@ public class BatchingDescriptorComposer {
         .setReturnType(TypeNode.VOID)
         .setName("splitException")
         .setArguments(
-            Arrays.asList(throwableVarExpr, batchVarExpr).stream()
+            Arrays.asList(throwableVarExpr, batchVarExpr)
+                .stream()
                 .map(v -> v.toBuilder().setIsDecl(true).build())
                 .collect(Collectors.toList()))
         .setBody(Arrays.asList(forStatement))
@@ -541,7 +541,7 @@ public class BatchingDescriptorComposer {
         .build();
   }
 
-  private static TypeNode toType(Class clazz) {
+  private static TypeNode toType(Class<?> clazz) {
     return TypeNode.withReference(ConcreteReference.withClazz(clazz));
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
@@ -474,7 +474,8 @@ public class RetrySettingsComposer {
             .setGenerics(Arrays.asList(STATUS_CODE_CODE_TYPE.reference()))
             .setMethodName("newArrayList")
             .setArguments(
-                retryCodes.stream()
+                retryCodes
+                    .stream()
                     .map(c -> toStatusCodeEnumRefExpr(c))
                     .collect(Collectors.toList()))
             .build();
@@ -711,7 +712,7 @@ public class RetrySettingsComposer {
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             BatchingSettings.class,
             org.threeten.bp.Duration.class,

--- a/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
@@ -474,8 +474,7 @@ public class RetrySettingsComposer {
             .setGenerics(Arrays.asList(STATUS_CODE_CODE_TYPE.reference()))
             .setMethodName("newArrayList")
             .setArguments(
-                retryCodes
-                    .stream()
+                retryCodes.stream()
                     .map(c -> toStatusCodeEnumRefExpr(c))
                     .collect(Collectors.toList()))
             .build();

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
@@ -40,7 +40,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
-import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,8 +53,6 @@ public class DefaultValueComposer {
   private static TypeNode OPERATION_TYPE =
       TypeNode.withReference(ConcreteReference.withClazz(Operation.class));
   private static TypeNode ANY_TYPE = TypeNode.withReference(ConcreteReference.withClazz(Any.class));
-  private static TypeNode BYTESTRING_TYPE =
-      TypeNode.withReference(ConcreteReference.withClazz(ByteString.class));
 
   public static Expr createDefaultValue(
       MethodArgument methodArg,
@@ -237,14 +234,16 @@ public class DefaultValueComposer {
               "of%sName",
               String.join(
                   "",
-                  patternPlaceholderTokens.stream()
+                  patternPlaceholderTokens
+                      .stream()
                       .map(s -> JavaStyle.toUpperCamelCase(s))
                       .collect(Collectors.toList())));
     }
 
     TypeNode resourceNameJavaType = resourceName.type();
     List<Expr> argExprs =
-        patternPlaceholderTokens.stream()
+        patternPlaceholderTokens
+            .stream()
             .map(
                 s ->
                     ValueExpr.withValue(

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
@@ -234,16 +234,14 @@ public class DefaultValueComposer {
               "of%sName",
               String.join(
                   "",
-                  patternPlaceholderTokens
-                      .stream()
+                  patternPlaceholderTokens.stream()
                       .map(s -> JavaStyle.toUpperCamelCase(s))
                       .collect(Collectors.toList())));
     }
 
     TypeNode resourceNameJavaType = resourceName.type();
     List<Expr> argExprs =
-        patternPlaceholderTokens
-            .stream()
+        patternPlaceholderTokens.stream()
             .map(
                 s ->
                     ValueExpr.withValue(

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
@@ -45,6 +45,7 @@ public class GrpcServiceCallableFactoryClassComposer
     return Arrays.asList(getTransportContext().stubCallableFactoryType());
   }
 
+  @Override
   protected List<MethodDefinition> createClassMethods(TypeStore typeStore) {
     List<MethodDefinition> classMethods = new ArrayList<>(super.createClassMethods(typeStore));
     classMethods.addAll(
@@ -55,6 +56,7 @@ public class GrpcServiceCallableFactoryClassComposer
     return classMethods;
   }
 
+  @Override
   protected MethodDefinition createUnaryCallableMethod(TypeStore typeStore) {
     String methodVariantName = "Unary";
     String requestTemplateName = "RequestT";
@@ -66,15 +68,18 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
 
+  @Override
   protected MethodDefinition createPagedCallableMethod(TypeStore typeStore) {
     String methodVariantName = "Paged";
     String requestTemplateName = "RequestT";
@@ -92,7 +97,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*grpcCallSettingsTemplateObjects=*/ Arrays.asList(
             requestTemplateName, responseTemplateName),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -112,7 +118,8 @@ public class GrpcServiceCallableFactoryClassComposer
         /*methodVariantName=*/ methodVariantName,
         /*grpcCallSettingsTemplateObjects=*/ Arrays.asList(requestTemplateName, OPERATION_TYPE),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -128,11 +135,13 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ "Streaming",
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -148,11 +157,13 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -168,11 +179,13 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ "Streaming",
-        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames
+            .stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceCallableFactoryClassComposer.java
@@ -68,13 +68,11 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -97,8 +95,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*grpcCallSettingsTemplateObjects=*/ Arrays.asList(
             requestTemplateName, responseTemplateName),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -118,8 +115,7 @@ public class GrpcServiceCallableFactoryClassComposer
         /*methodVariantName=*/ methodVariantName,
         /*grpcCallSettingsTemplateObjects=*/ Arrays.asList(requestTemplateName, OPERATION_TYPE),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -135,13 +131,11 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ "Streaming",
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -157,13 +151,11 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ methodVariantName,
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }
@@ -179,13 +171,11 @@ public class GrpcServiceCallableFactoryClassComposer
         /*returnCallableKindName=*/ methodVariantName,
         /*returnCallableTemplateNames=*/ methodTemplateNames,
         /*methodVariantName=*/ methodVariantName,
-        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*grpcCallSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()),
         /*callSettingsVariantName=*/ "Streaming",
-        /*callSettingsTemplateObjects=*/ methodTemplateNames
-            .stream()
+        /*callSettingsTemplateObjects=*/ methodTemplateNames.stream()
             .map(n -> (Object) n)
             .collect(Collectors.toList()));
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -72,7 +72,7 @@ public class GrpcServiceStubClassComposer extends AbstractTransportServiceStubCl
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             GrpcCallSettings.class,
             GrpcOperationsStub.class,
@@ -254,9 +254,6 @@ public class GrpcServiceStubClassComposer extends AbstractTransportServiceStubCl
     VariableExpr paramsVarExpr =
         VariableExpr.withVariable(
             Variable.builder().setName("params").setType(paramsVarType).build());
-    VariableExpr reqeustVarExpr =
-        VariableExpr.withVariable(
-            Variable.builder().setName("request").setType(method.inputType()).build());
 
     Expr paramsAssignExpr =
         AssignmentExpr.builder()

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/MockServiceClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/MockServiceClassComposer.java
@@ -234,7 +234,7 @@ public class MockServiceClassComposer implements ClassComposer {
   }
 
   private static TypeStore createTypes(Service service) {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             AbstractMessage.class, BetaApi.class, Generated.class, ServerServiceDefinition.class);
     TypeStore typeStore = new TypeStore(concreteClazzes);

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/MockServiceImplClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/MockServiceImplClassComposer.java
@@ -98,7 +98,10 @@ public class MockServiceImplClassComposer implements ClassComposer {
 
     // Use the full name java.lang.Object if there is a proto message that is also named "Object".
     // Affects GCS.
-    if (context.messages().keySet().stream()
+    if (context
+        .messages()
+        .keySet()
+        .stream()
         .anyMatch(s -> s.equals("Object") || s.endsWith(".Object"))) {
       javaObjectReference =
           ConcreteReference.builder().setClazz(Object.class).setUseFullName(true).build();
@@ -271,7 +274,9 @@ public class MockServiceImplClassComposer implements ClassComposer {
   }
 
   private static List<MethodDefinition> createProtoMethodOverrides(Service service) {
-    return service.methods().stream()
+    return service
+        .methods()
+        .stream()
         .filter(m -> !m.isMixin()) // Mixin APIs will get their own generated mocks.
         .map(m -> createGenericProtoMethodOverride(m))
         .collect(Collectors.toList());
@@ -596,7 +601,7 @@ public class MockServiceImplClassComposer implements ClassComposer {
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             AbstractMessage.class,
             ArrayList.class,
@@ -646,7 +651,8 @@ public class MockServiceImplClassComposer implements ClassComposer {
                     .setIsGeneric(true)
                     .build())
             .build();
-    return Arrays.asList(assignRequestVarExpr, assignResponsesVarExpr).stream()
+    return Arrays.asList(assignRequestVarExpr, assignResponsesVarExpr)
+        .stream()
         .map(e -> ExprStatement.withExpr(e))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/MockServiceImplClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/MockServiceImplClassComposer.java
@@ -98,10 +98,7 @@ public class MockServiceImplClassComposer implements ClassComposer {
 
     // Use the full name java.lang.Object if there is a proto message that is also named "Object".
     // Affects GCS.
-    if (context
-        .messages()
-        .keySet()
-        .stream()
+    if (context.messages().keySet().stream()
         .anyMatch(s -> s.equals("Object") || s.endsWith(".Object"))) {
       javaObjectReference =
           ConcreteReference.builder().setClazz(Object.class).setUseFullName(true).build();
@@ -274,9 +271,7 @@ public class MockServiceImplClassComposer implements ClassComposer {
   }
 
   private static List<MethodDefinition> createProtoMethodOverrides(Service service) {
-    return service
-        .methods()
-        .stream()
+    return service.methods().stream()
         .filter(m -> !m.isMixin()) // Mixin APIs will get their own generated mocks.
         .map(m -> createGenericProtoMethodOverride(m))
         .collect(Collectors.toList());
@@ -651,8 +646,7 @@ public class MockServiceImplClassComposer implements ClassComposer {
                     .setIsGeneric(true)
                     .build())
             .build();
-    return Arrays.asList(assignRequestVarExpr, assignResponsesVarExpr)
-        .stream()
+    return Arrays.asList(assignRequestVarExpr, assignResponsesVarExpr).stream()
         .map(e -> ExprStatement.withExpr(e))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -96,7 +96,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             GaxGrpcProperties.class,
             LocalChannelProvider.class,
@@ -127,7 +127,9 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     fields.put(CLIENT_VAR_NAME, typeStore.get(ClassNames.getServiceClientClassName(service)));
     fields.put(CHANNEL_PROVIDER_VAR_NAME, FIXED_GRPC_TYPESTORE.get("LocalChannelProvider"));
 
-    return fields.entrySet().stream()
+    return fields
+        .entrySet()
+        .stream()
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey,
@@ -163,7 +165,9 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     // Careful: Java 8 and 11 make different ordering choices if this set is not explicitly sorted.
     // Context: https://github.com/googleapis/gapic-generator-java/pull/750
     for (Service mixinService :
-        context.mixinServices().stream()
+        context
+            .mixinServices()
+            .stream()
             .sorted((s1, s2) -> s2.name().compareTo(s1.name()))
             .collect(Collectors.toList())) {
       varInitExprs.add(serviceToVarInitExprFn.apply(mixinService));
@@ -1044,7 +1048,8 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     TryCatchStatement tryCatchBlock =
         TryCatchStatement.builder()
             .setTryBody(
-                tryBodyExprs.stream()
+                tryBodyExprs
+                    .stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .addCatch(

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -127,9 +127,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     fields.put(CLIENT_VAR_NAME, typeStore.get(ClassNames.getServiceClientClassName(service)));
     fields.put(CHANNEL_PROVIDER_VAR_NAME, FIXED_GRPC_TYPESTORE.get("LocalChannelProvider"));
 
-    return fields
-        .entrySet()
-        .stream()
+    return fields.entrySet().stream()
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey,
@@ -165,9 +163,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     // Careful: Java 8 and 11 make different ordering choices if this set is not explicitly sorted.
     // Context: https://github.com/googleapis/gapic-generator-java/pull/750
     for (Service mixinService :
-        context
-            .mixinServices()
-            .stream()
+        context.mixinServices().stream()
             .sorted((s1, s2) -> s2.name().compareTo(s1.name()))
             .collect(Collectors.toList())) {
       varInitExprs.add(serviceToVarInitExprFn.apply(mixinService));
@@ -1048,8 +1044,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     TryCatchStatement tryCatchBlock =
         TryCatchStatement.builder()
             .setTryBody(
-                tryBodyExprs
-                    .stream()
+                tryBodyExprs.stream()
                     .map(e -> ExprStatement.withExpr(e))
                     .collect(Collectors.toList()))
             .addCatch(

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposer.java
@@ -51,7 +51,7 @@ public class ServiceStubSettingsClassComposer extends AbstractServiceStubSetting
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             GaxGrpcProperties.class,
             GrpcTransportChannel.class,

--- a/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
@@ -98,7 +98,10 @@ public class ResourceNameHelperClassComposer {
     TypeStore typeStore = createDynamicTypes(resourceName, tokenHierarchies);
     // Use the full name java.lang.Object if there is a proto message that is also named "Object".
     // Affects GCS.
-    if (context.messages().keySet().stream()
+    if (context
+        .messages()
+        .keySet()
+        .stream()
         .anyMatch(s -> s.equals("Object") || s.endsWith(".Object"))) {
       javaObjectReference =
           ConcreteReference.builder().setClazz(Object.class).setUseFullName(true).build();
@@ -166,7 +169,8 @@ public class ResourceNameHelperClassComposer {
 
   private static List<VariableExpr> createTemplateClassMembers(
       List<List<String>> tokenHierarchies) {
-    return tokenHierarchies.stream()
+    return tokenHierarchies
+        .stream()
         .map(
             ts ->
                 VariableExpr.withVariable(
@@ -185,11 +189,13 @@ public class ResourceNameHelperClassComposer {
       List<List<String>> tokenHierarchies) {
     // PubSub special-case handling - exclude _deleted-topic_.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
     Set<String> tokenSet = getTokenSet(processedTokenHierarchies);
-    return tokenSet.stream()
+    return tokenSet
+        .stream()
         .collect(
             Collectors.toMap(
                 t -> t,
@@ -262,11 +268,13 @@ public class ResourceNameHelperClassComposer {
         v -> v.toBuilder().setIsDecl(true).setScope(ScopeNode.PRIVATE).setIsFinal(true).build();
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
     memberVars.addAll(
-        getTokenSet(processedTokenHierarchies).stream()
+        getTokenSet(processedTokenHierarchies)
+            .stream()
             .map(t -> toFinalDeclFn.apply(patternTokenVarExprs.get(t)))
             .collect(Collectors.toList()));
     return memberVars.stream().map(e -> ExprStatement.withExpr(e)).collect(Collectors.toList());
@@ -333,7 +341,8 @@ public class ResourceNameHelperClassComposer {
 
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
     boolean hasDeletedTopicPattern = tokenHierarchies.size() > processedTokenHierarchies.size();
@@ -348,7 +357,8 @@ public class ResourceNameHelperClassComposer {
             .setScope(ScopeNode.PROTECTED)
             .setReturnType(thisClassType)
             .setBody(
-                getTokenSet(processedTokenHierarchies).stream()
+                getTokenSet(processedTokenHierarchies)
+                    .stream()
                     .map(t -> ExprStatement.withExpr(assignTokenToNullExpr.apply(t)))
                     .collect(Collectors.toList()))
             .build());
@@ -404,7 +414,8 @@ public class ResourceNameHelperClassComposer {
               .setReturnType(thisClassType)
               .setArguments(Arrays.asList(builderArgExpr.toBuilder().setIsDecl(true).build()))
               .setBody(
-                  bodyExprs.stream()
+                  bodyExprs
+                      .stream()
                       .map(e -> ExprStatement.withExpr(e))
                       .collect(Collectors.toList()))
               .build());
@@ -443,7 +454,8 @@ public class ResourceNameHelperClassComposer {
                       .build())
               .build());
       specialCtorBodyExprs.addAll(
-          getTokenSet(processedTokenHierarchies).stream()
+          getTokenSet(processedTokenHierarchies)
+              .stream()
               .map(t -> assignTokenToNullExpr.apply(t))
               .collect(Collectors.toList()));
 
@@ -453,7 +465,8 @@ public class ResourceNameHelperClassComposer {
               .setReturnType(thisClassType)
               .setArguments(Arrays.asList(fixedValueVarExpr.toBuilder().setIsDecl(true).build()))
               .setBody(
-                  specialCtorBodyExprs.stream()
+                  specialCtorBodyExprs
+                      .stream()
                       .map(e -> ExprStatement.withExpr(e))
                       .collect(Collectors.toList()))
               .build());
@@ -466,10 +479,12 @@ public class ResourceNameHelperClassComposer {
       Map<String, VariableExpr> patternTokenVarExprs, List<List<String>> tokenHierarchies) {
     // PubSub special-case handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
-    return getTokenSet(processedTokenHierarchies).stream()
+    return getTokenSet(processedTokenHierarchies)
+        .stream()
         .map(
             t ->
                 MethodDefinition.builder()
@@ -657,7 +672,8 @@ public class ResourceNameHelperClassComposer {
                 .build();
       }
       List<VariableExpr> methodArgs =
-          tokens.stream()
+          tokens
+              .stream()
               .map(t -> patternTokenVarExprs.get(t).toBuilder().setIsDecl(true).build())
               .collect(Collectors.toList());
       javaMethods.add(
@@ -773,7 +789,9 @@ public class ResourceNameHelperClassComposer {
       body.add(ExprStatement.withExpr(matchMapAssignExpr));
 
       List<Expr> ofMethodArgExprs =
-          tokenHierarchies.get(0).stream()
+          tokenHierarchies
+              .get(0)
+              .stream()
               .map(
                   t ->
                       MethodInvocationExpr.builder()
@@ -835,7 +853,8 @@ public class ResourceNameHelperClassComposer {
           MethodInvocationExpr.builder()
               .setMethodName(String.format(ofMethodNamePattern, concatToUpperCamelCaseName(tokens)))
               .setArguments(
-                  tokens.stream()
+                  tokens
+                      .stream()
                       .map(
                           t ->
                               MethodInvocationExpr.builder()
@@ -852,7 +871,8 @@ public class ResourceNameHelperClassComposer {
       ReturnExpr subReturnExpr = ReturnExpr.withExpr(ofMethodExpr);
 
       List<Statement> ifStatements =
-          Arrays.asList(matchMapAssignExpr, subReturnExpr).stream()
+          Arrays.asList(matchMapAssignExpr, subReturnExpr)
+              .stream()
               .map(e -> ExprStatement.withExpr(e))
               .collect(Collectors.toList());
       if (i == 0) {
@@ -1137,7 +1157,8 @@ public class ResourceNameHelperClassComposer {
 
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
@@ -1192,7 +1213,6 @@ public class ResourceNameHelperClassComposer {
             .build();
 
     // Outer if-block.
-    Expr thisExpr = ValueExpr.withValue(ThisObjectValue.withType(thisClassType));
     IfStatement outerIfStatement =
         IfStatement.builder()
             .setConditionExpr(fieldValuesMapNullCheckExpr)
@@ -1349,7 +1369,8 @@ public class ResourceNameHelperClassComposer {
 
     // PubSub special-case handling - exclude _deleted-topic_.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
@@ -1447,7 +1468,8 @@ public class ResourceNameHelperClassComposer {
 
     // PubSub special-case handling - exclude _deleted-topic_.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
@@ -1463,7 +1485,8 @@ public class ResourceNameHelperClassComposer {
     }
     // Add the multiply and xor assignment operation exprs for tokens.
     Set<String> tokenSet = getTokenSet(processedTokenHierarchies);
-    tokenSet.stream()
+    tokenSet
+        .stream()
         .forEach(
             token -> {
               VariableExpr tokenVarExpr =
@@ -1538,7 +1561,8 @@ public class ResourceNameHelperClassComposer {
     String className = isDefaultClass ? "Builder" : getBuilderTypeName(tokens);
     // Class member declarations.
     List<VariableExpr> classMemberVarExprs =
-        tokens.stream()
+        tokens
+            .stream()
             .map(
                 t ->
                     VariableExpr.withVariable(
@@ -1548,7 +1572,8 @@ public class ResourceNameHelperClassComposer {
                             .build()))
             .collect(Collectors.toList());
     List<Statement> classMemberDecls =
-        classMemberVarExprs.stream()
+        classMemberVarExprs
+            .stream()
             .map(
                 v ->
                     ExprStatement.withExpr(
@@ -1572,7 +1597,6 @@ public class ResourceNameHelperClassComposer {
     for (int i = 0; i < tokens.size(); i++) {
       String token = tokens.get(i);
       String upperCamelTokenName = JavaStyle.toUpperCamelCase(token);
-      String lowerCamelTokenName = JavaStyle.toLowerCamelCase(token);
       VariableExpr currClassTokenVarExpr = classMemberVarExprs.get(i);
 
       // Getter.
@@ -1648,8 +1672,6 @@ public class ResourceNameHelperClassComposer {
       }
 
       for (int i = 0; i < tokens.size(); i++) {
-        String token = tokens.get(i);
-        String lowerCamelTokenName = JavaStyle.toLowerCamelCase(token);
         VariableExpr currClassTokenVarExpr =
             classMemberVarExprs.get(i).toBuilder().setExprReferenceExpr(thisExpr).build();
         builderCtorBodyExprs.add(
@@ -1669,7 +1691,8 @@ public class ResourceNameHelperClassComposer {
               .setReturnType(thisClassType)
               .setArguments(outerClassVarExpr.toBuilder().setIsDecl(true).build())
               .setBody(
-                  builderCtorBodyExprs.stream()
+                  builderCtorBodyExprs
+                      .stream()
                       .map(e -> ExprStatement.withExpr(e))
                       .collect(Collectors.toList()))
               .build();
@@ -1713,7 +1736,7 @@ public class ResourceNameHelperClassComposer {
   }
 
   private static TypeStore createStaticTypes() {
-    List<Class> concreteClazzes =
+    List<Class<?>> concreteClazzes =
         Arrays.asList(
             ArrayList.class,
             BetaApi.class,
@@ -1738,14 +1761,17 @@ public class ResourceNameHelperClassComposer {
 
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies.stream()
+        tokenHierarchies
+            .stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
     if (processedTokenHierarchies.size() > 1) {
       typeStore.putAll(
           resourceName.pakkage(),
-          tokenHierarchies.subList(1, tokenHierarchies.size()).stream()
+          tokenHierarchies
+              .subList(1, tokenHierarchies.size())
+              .stream()
               .map(ts -> getBuilderTypeName(ts))
               .collect(Collectors.toList()));
     }
@@ -1765,7 +1791,9 @@ public class ResourceNameHelperClassComposer {
     memberVars.put(
         "pathTemplate", TypeNode.withReference(ConcreteReference.withClazz(PathTemplate.class)));
     memberVars.put("fixedValue", TypeNode.STRING);
-    return memberVars.entrySet().stream()
+    return memberVars
+        .entrySet()
+        .stream()
         .map(e -> Variable.builder().setName(e.getKey()).setType(e.getValue()).build())
         .collect(Collectors.toMap(v -> v.identifier().name(), v -> VariableExpr.withVariable(v)));
   }
@@ -1792,7 +1820,8 @@ public class ResourceNameHelperClassComposer {
 
   @VisibleForTesting
   static Set<String> getTokenSet(List<List<String>> tokenHierarchy) {
-    return tokenHierarchy.stream()
+    return tokenHierarchy
+        .stream()
         .flatMap(tokens -> tokens.stream())
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
@@ -98,10 +98,7 @@ public class ResourceNameHelperClassComposer {
     TypeStore typeStore = createDynamicTypes(resourceName, tokenHierarchies);
     // Use the full name java.lang.Object if there is a proto message that is also named "Object".
     // Affects GCS.
-    if (context
-        .messages()
-        .keySet()
-        .stream()
+    if (context.messages().keySet().stream()
         .anyMatch(s -> s.equals("Object") || s.endsWith(".Object"))) {
       javaObjectReference =
           ConcreteReference.builder().setClazz(Object.class).setUseFullName(true).build();
@@ -169,8 +166,7 @@ public class ResourceNameHelperClassComposer {
 
   private static List<VariableExpr> createTemplateClassMembers(
       List<List<String>> tokenHierarchies) {
-    return tokenHierarchies
-        .stream()
+    return tokenHierarchies.stream()
         .map(
             ts ->
                 VariableExpr.withVariable(
@@ -189,13 +185,11 @@ public class ResourceNameHelperClassComposer {
       List<List<String>> tokenHierarchies) {
     // PubSub special-case handling - exclude _deleted-topic_.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
     Set<String> tokenSet = getTokenSet(processedTokenHierarchies);
-    return tokenSet
-        .stream()
+    return tokenSet.stream()
         .collect(
             Collectors.toMap(
                 t -> t,
@@ -268,13 +262,11 @@ public class ResourceNameHelperClassComposer {
         v -> v.toBuilder().setIsDecl(true).setScope(ScopeNode.PRIVATE).setIsFinal(true).build();
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
     memberVars.addAll(
-        getTokenSet(processedTokenHierarchies)
-            .stream()
+        getTokenSet(processedTokenHierarchies).stream()
             .map(t -> toFinalDeclFn.apply(patternTokenVarExprs.get(t)))
             .collect(Collectors.toList()));
     return memberVars.stream().map(e -> ExprStatement.withExpr(e)).collect(Collectors.toList());
@@ -341,8 +333,7 @@ public class ResourceNameHelperClassComposer {
 
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
     boolean hasDeletedTopicPattern = tokenHierarchies.size() > processedTokenHierarchies.size();
@@ -357,8 +348,7 @@ public class ResourceNameHelperClassComposer {
             .setScope(ScopeNode.PROTECTED)
             .setReturnType(thisClassType)
             .setBody(
-                getTokenSet(processedTokenHierarchies)
-                    .stream()
+                getTokenSet(processedTokenHierarchies).stream()
                     .map(t -> ExprStatement.withExpr(assignTokenToNullExpr.apply(t)))
                     .collect(Collectors.toList()))
             .build());
@@ -414,8 +404,7 @@ public class ResourceNameHelperClassComposer {
               .setReturnType(thisClassType)
               .setArguments(Arrays.asList(builderArgExpr.toBuilder().setIsDecl(true).build()))
               .setBody(
-                  bodyExprs
-                      .stream()
+                  bodyExprs.stream()
                       .map(e -> ExprStatement.withExpr(e))
                       .collect(Collectors.toList()))
               .build());
@@ -454,8 +443,7 @@ public class ResourceNameHelperClassComposer {
                       .build())
               .build());
       specialCtorBodyExprs.addAll(
-          getTokenSet(processedTokenHierarchies)
-              .stream()
+          getTokenSet(processedTokenHierarchies).stream()
               .map(t -> assignTokenToNullExpr.apply(t))
               .collect(Collectors.toList()));
 
@@ -465,8 +453,7 @@ public class ResourceNameHelperClassComposer {
               .setReturnType(thisClassType)
               .setArguments(Arrays.asList(fixedValueVarExpr.toBuilder().setIsDecl(true).build()))
               .setBody(
-                  specialCtorBodyExprs
-                      .stream()
+                  specialCtorBodyExprs.stream()
                       .map(e -> ExprStatement.withExpr(e))
                       .collect(Collectors.toList()))
               .build());
@@ -479,12 +466,10 @@ public class ResourceNameHelperClassComposer {
       Map<String, VariableExpr> patternTokenVarExprs, List<List<String>> tokenHierarchies) {
     // PubSub special-case handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
-    return getTokenSet(processedTokenHierarchies)
-        .stream()
+    return getTokenSet(processedTokenHierarchies).stream()
         .map(
             t ->
                 MethodDefinition.builder()
@@ -672,8 +657,7 @@ public class ResourceNameHelperClassComposer {
                 .build();
       }
       List<VariableExpr> methodArgs =
-          tokens
-              .stream()
+          tokens.stream()
               .map(t -> patternTokenVarExprs.get(t).toBuilder().setIsDecl(true).build())
               .collect(Collectors.toList());
       javaMethods.add(
@@ -789,9 +773,7 @@ public class ResourceNameHelperClassComposer {
       body.add(ExprStatement.withExpr(matchMapAssignExpr));
 
       List<Expr> ofMethodArgExprs =
-          tokenHierarchies
-              .get(0)
-              .stream()
+          tokenHierarchies.get(0).stream()
               .map(
                   t ->
                       MethodInvocationExpr.builder()
@@ -853,8 +835,7 @@ public class ResourceNameHelperClassComposer {
           MethodInvocationExpr.builder()
               .setMethodName(String.format(ofMethodNamePattern, concatToUpperCamelCaseName(tokens)))
               .setArguments(
-                  tokens
-                      .stream()
+                  tokens.stream()
                       .map(
                           t ->
                               MethodInvocationExpr.builder()
@@ -871,8 +852,7 @@ public class ResourceNameHelperClassComposer {
       ReturnExpr subReturnExpr = ReturnExpr.withExpr(ofMethodExpr);
 
       List<Statement> ifStatements =
-          Arrays.asList(matchMapAssignExpr, subReturnExpr)
-              .stream()
+          Arrays.asList(matchMapAssignExpr, subReturnExpr).stream()
               .map(e -> ExprStatement.withExpr(e))
               .collect(Collectors.toList());
       if (i == 0) {
@@ -1157,8 +1137,7 @@ public class ResourceNameHelperClassComposer {
 
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
@@ -1369,8 +1348,7 @@ public class ResourceNameHelperClassComposer {
 
     // PubSub special-case handling - exclude _deleted-topic_.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
@@ -1468,8 +1446,7 @@ public class ResourceNameHelperClassComposer {
 
     // PubSub special-case handling - exclude _deleted-topic_.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(ts -> !ts.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
@@ -1485,8 +1462,7 @@ public class ResourceNameHelperClassComposer {
     }
     // Add the multiply and xor assignment operation exprs for tokens.
     Set<String> tokenSet = getTokenSet(processedTokenHierarchies);
-    tokenSet
-        .stream()
+    tokenSet.stream()
         .forEach(
             token -> {
               VariableExpr tokenVarExpr =
@@ -1561,8 +1537,7 @@ public class ResourceNameHelperClassComposer {
     String className = isDefaultClass ? "Builder" : getBuilderTypeName(tokens);
     // Class member declarations.
     List<VariableExpr> classMemberVarExprs =
-        tokens
-            .stream()
+        tokens.stream()
             .map(
                 t ->
                     VariableExpr.withVariable(
@@ -1572,8 +1547,7 @@ public class ResourceNameHelperClassComposer {
                             .build()))
             .collect(Collectors.toList());
     List<Statement> classMemberDecls =
-        classMemberVarExprs
-            .stream()
+        classMemberVarExprs.stream()
             .map(
                 v ->
                     ExprStatement.withExpr(
@@ -1691,8 +1665,7 @@ public class ResourceNameHelperClassComposer {
               .setReturnType(thisClassType)
               .setArguments(outerClassVarExpr.toBuilder().setIsDecl(true).build())
               .setBody(
-                  builderCtorBodyExprs
-                      .stream()
+                  builderCtorBodyExprs.stream()
                       .map(e -> ExprStatement.withExpr(e))
                       .collect(Collectors.toList()))
               .build();
@@ -1761,17 +1734,14 @@ public class ResourceNameHelperClassComposer {
 
     // Special-cased PubSub handling.
     List<List<String>> processedTokenHierarchies =
-        tokenHierarchies
-            .stream()
+        tokenHierarchies.stream()
             .filter(tokens -> !tokens.contains(ResourceNameConstants.DELETED_TOPIC_LITERAL))
             .collect(Collectors.toList());
 
     if (processedTokenHierarchies.size() > 1) {
       typeStore.putAll(
           resourceName.pakkage(),
-          tokenHierarchies
-              .subList(1, tokenHierarchies.size())
-              .stream()
+          tokenHierarchies.subList(1, tokenHierarchies.size()).stream()
               .map(ts -> getBuilderTypeName(ts))
               .collect(Collectors.toList()));
     }
@@ -1791,9 +1761,7 @@ public class ResourceNameHelperClassComposer {
     memberVars.put(
         "pathTemplate", TypeNode.withReference(ConcreteReference.withClazz(PathTemplate.class)));
     memberVars.put("fixedValue", TypeNode.STRING);
-    return memberVars
-        .entrySet()
-        .stream()
+    return memberVars.entrySet().stream()
         .map(e -> Variable.builder().setName(e.getKey()).setType(e.getValue()).build())
         .collect(Collectors.toMap(v -> v.identifier().name(), v -> VariableExpr.withVariable(v)));
   }
@@ -1820,8 +1788,7 @@ public class ResourceNameHelperClassComposer {
 
   @VisibleForTesting
   static Set<String> getTokenSet(List<List<String>> tokenHierarchy) {
-    return tokenHierarchy
-        .stream()
+    return tokenHierarchy.stream()
         .flatMap(tokens -> tokens.stream())
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -592,6 +592,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
     return Collections.singletonList(expr);
   }
 
+  @Override
   protected Optional<String> getCallableCreatorMethodName(TypeNode callableVarExprType) {
     final String typeName = callableVarExprType.reference().name();
     String streamName = "Unary";

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
@@ -101,18 +101,14 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     fields.put(
         MOCK_SERVICE_VAR_NAME, FIXED_REST_TYPESTORE.get(MockHttpService.class.getSimpleName()));
     fields.put(CLIENT_VAR_NAME, typeStore.get(ClassNames.getServiceClientClassName(service)));
-    return fields
-        .entrySet()
-        .stream()
+    return fields.entrySet().stream()
         .collect(Collectors.toMap(e -> e.getKey(), e -> varExprFn.apply(e.getKey(), e.getValue())));
   }
 
   @Override
   protected List<Statement> createClassMemberFieldDecls(
       Map<String, VariableExpr> classMemberVarExprs) {
-    return classMemberVarExprs
-        .values()
-        .stream()
+    return classMemberVarExprs.values().stream()
         .map(
             v ->
                 ExprStatement.withExpr(
@@ -241,8 +237,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
         .setThrowsExceptions(Arrays.asList(FIXED_TYPESTORE.get("IOException")))
         .setIsStatic(true)
         .setBody(
-            Arrays.asList(initMockServiceExpr, initLocalSettingsExpr, initClientExpr)
-                .stream()
+            Arrays.asList(initMockServiceExpr, initLocalSettingsExpr, initClientExpr).stream()
                 .map(e -> ExprStatement.withExpr(e))
                 .collect(Collectors.toList()))
         .build();

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
@@ -62,7 +62,6 @@ import java.util.stream.Collectors;
 
 public class ServiceClientTestClassComposer extends AbstractServiceClientTestClassComposer {
   private static final String MOCK_SERVICE_VAR_NAME = "mockService";
-  private static final String METHOD_DESCRIPTOR_NAME_PATTERN = "%sMethodDescriptor";
 
   private static final ServiceClientTestClassComposer INSTANCE =
       new ServiceClientTestClassComposer();
@@ -102,14 +101,18 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     fields.put(
         MOCK_SERVICE_VAR_NAME, FIXED_REST_TYPESTORE.get(MockHttpService.class.getSimpleName()));
     fields.put(CLIENT_VAR_NAME, typeStore.get(ClassNames.getServiceClientClassName(service)));
-    return fields.entrySet().stream()
+    return fields
+        .entrySet()
+        .stream()
         .collect(Collectors.toMap(e -> e.getKey(), e -> varExprFn.apply(e.getKey(), e.getValue())));
   }
 
   @Override
   protected List<Statement> createClassMemberFieldDecls(
       Map<String, VariableExpr> classMemberVarExprs) {
-    return classMemberVarExprs.values().stream()
+    return classMemberVarExprs
+        .values()
+        .stream()
         .map(
             v ->
                 ExprStatement.withExpr(
@@ -238,7 +241,8 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
         .setThrowsExceptions(Arrays.asList(FIXED_TYPESTORE.get("IOException")))
         .setIsStatic(true)
         .setBody(
-            Arrays.asList(initMockServiceExpr, initLocalSettingsExpr, initClientExpr).stream()
+            Arrays.asList(initMockServiceExpr, initLocalSettingsExpr, initClientExpr)
+                .stream()
                 .map(e -> ExprStatement.withExpr(e))
                 .collect(Collectors.toList()))
         .build();

--- a/src/main/java/com/google/api/generator/gapic/composer/store/TypeStore.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/store/TypeStore.java
@@ -28,13 +28,14 @@ public class TypeStore {
 
   public TypeStore() {}
 
-  public TypeStore(List<Class> concreteClasses) {
+  public TypeStore(List<Class<?>> concreteClasses) {
     putConcreteClassses(concreteClasses);
   }
 
-  private void putConcreteClassses(List<Class> concreteClasses) {
+  private void putConcreteClassses(List<Class<?>> concreteClasses) {
     store.putAll(
-        concreteClasses.stream()
+        concreteClasses
+            .stream()
             .collect(
                 Collectors.toMap(
                     Class::getSimpleName,
@@ -71,7 +72,7 @@ public class TypeStore {
                 .build()));
   }
 
-  public void putAll(List<Class> concreteClasses) {
+  public void putAll(List<Class<?>> concreteClasses) {
     putConcreteClassses(concreteClasses);
   }
 
@@ -87,7 +88,9 @@ public class TypeStore {
 
   public void putMessageTypes(String pakkage, Map<String, Message> messages) {
     store.putAll(
-        messages.entrySet().stream()
+        messages
+            .entrySet()
+            .stream()
             // Short-term hack for messages that have nested subtypes with colliding names. This
             // should work as long as there isn't heavy usage of fully-qualified nested subtypes in
             // general. A long-term fix would involve adding a custom type-store that handles

--- a/src/main/java/com/google/api/generator/gapic/composer/store/TypeStore.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/store/TypeStore.java
@@ -34,8 +34,7 @@ public class TypeStore {
 
   private void putConcreteClassses(List<Class<?>> concreteClasses) {
     store.putAll(
-        concreteClasses
-            .stream()
+        concreteClasses.stream()
             .collect(
                 Collectors.toMap(
                     Class::getSimpleName,
@@ -88,9 +87,7 @@ public class TypeStore {
 
   public void putMessageTypes(String pakkage, Map<String, Message> messages) {
     store.putAll(
-        messages
-            .entrySet()
-            .stream()
+        messages.entrySet().stream()
             // Short-term hack for messages that have nested subtypes with colliding names. This
             // should work as long as there isn't heavy usage of fully-qualified nested subtypes in
             // general. A long-term fix would involve adding a custom type-store that handles

--- a/src/main/java/com/google/api/generator/gapic/protoparser/MethodSignatureParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/MethodSignatureParser.java
@@ -91,7 +91,9 @@ public class MethodSignatureParser {
         argumentNames.add(actualArgumentName);
         argumentNameToOverloads.put(
             actualArgumentName,
-            argumentTypes.entrySet().stream()
+            argumentTypes
+                .entrySet()
+                .stream()
                 .map(
                     e ->
                         MethodArgument.builder()
@@ -110,7 +112,8 @@ public class MethodSignatureParser {
     // Make the method signature order deterministic, which helps with unit testing and per-version
     // diffs.
     List<List<MethodArgument>> sortedMethodSignatures =
-        signatures.stream()
+        signatures
+            .stream()
             .sorted(
                 (s1, s2) -> {
                   // Sort by number of arguments first.
@@ -208,7 +211,8 @@ public class MethodSignatureParser {
       outputArgResourceNames.addAll(resourceNameArgs);
       typeToField.put(TypeNode.STRING, field);
       typeToField.putAll(
-          resourceNameArgs.stream()
+          resourceNameArgs
+              .stream()
               .collect(
                   Collectors.toMap(
                       r -> r.type(),
@@ -221,7 +225,9 @@ public class MethodSignatureParser {
                               .build())));
       // Only resource name helpers should have more than one entry.
       if (typeToField.size() > 1) {
-        typeToField.entrySet().stream()
+        typeToField
+            .entrySet()
+            .stream()
             .forEach(
                 e -> {
                   // Skip string-only variants or ResourceName generics.
@@ -283,16 +289,5 @@ public class MethodSignatureParser {
         patternsToResourceNames,
         argumentFieldPathAcc,
         outputArgResourceNames);
-  }
-
-  private static Map<String, ResourceName> createPatternResourceNameMap(
-      Map<String, ResourceName> resourceNames) {
-    Map<String, ResourceName> patternsToResourceNames = new HashMap<>();
-    for (ResourceName resourceName : resourceNames.values()) {
-      for (String pattern : resourceName.patterns()) {
-        patternsToResourceNames.put(pattern, resourceName);
-      }
-    }
-    return patternsToResourceNames;
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/protoparser/MethodSignatureParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/MethodSignatureParser.java
@@ -91,9 +91,7 @@ public class MethodSignatureParser {
         argumentNames.add(actualArgumentName);
         argumentNameToOverloads.put(
             actualArgumentName,
-            argumentTypes
-                .entrySet()
-                .stream()
+            argumentTypes.entrySet().stream()
                 .map(
                     e ->
                         MethodArgument.builder()
@@ -112,8 +110,7 @@ public class MethodSignatureParser {
     // Make the method signature order deterministic, which helps with unit testing and per-version
     // diffs.
     List<List<MethodArgument>> sortedMethodSignatures =
-        signatures
-            .stream()
+        signatures.stream()
             .sorted(
                 (s1, s2) -> {
                   // Sort by number of arguments first.
@@ -211,8 +208,7 @@ public class MethodSignatureParser {
       outputArgResourceNames.addAll(resourceNameArgs);
       typeToField.put(TypeNode.STRING, field);
       typeToField.putAll(
-          resourceNameArgs
-              .stream()
+          resourceNameArgs.stream()
               .collect(
                   Collectors.toMap(
                       r -> r.type(),
@@ -225,9 +221,7 @@ public class MethodSignatureParser {
                               .build())));
       // Only resource name helpers should have more than one entry.
       if (typeToField.size() > 1) {
-        typeToField
-            .entrySet()
-            .stream()
+        typeToField.entrySet().stream()
             .forEach(
                 e -> {
                   // Skip string-only variants or ResourceName generics.

--- a/src/main/java/com/google/api/generator/gapic/protoparser/TypeParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/TypeParser.java
@@ -37,8 +37,6 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 public class TypeParser {
-  private static final String DOT = ".";
-
   private static Reference REFERENCE_BYTE_STRING = ConcreteReference.withClazz(ByteString.class);
   private static TypeNode TYPE_NODE_BYTE_STRING = TypeNode.withReference(REFERENCE_BYTE_STRING);
 
@@ -245,8 +243,6 @@ public class TypeParser {
 
   @VisibleForTesting
   static TypeNode createListType(FieldDescriptor field) {
-    JavaType protoFieldType = field.getJavaType();
-
     Reference listReference =
         ConcreteReference.builder()
             .setClazz(List.class)
@@ -259,7 +255,6 @@ public class TypeParser {
   static TypeNode createMapType(FieldDescriptor field) {
     Preconditions.checkState(
         field.isMapField(), "createMapType can only be called on map-type fields");
-    JavaType protoJavaType = field.getJavaType();
 
     Descriptor type = field.getMessageType();
     FieldDescriptor keyField = type.findFieldByName("key");

--- a/src/main/java/com/google/api/generator/util/Trie.java
+++ b/src/main/java/com/google/api/generator/util/Trie.java
@@ -24,17 +24,17 @@ import java.util.function.Function;
  * A common-prefix trie. T represents the type of each "char" in a word (which is a T-typed list).
  */
 public class Trie<T> {
-  private class Node<T> {
-    final T chr;
+  private class Node<U> {
+    final U chr;
     // Maintain insertion order to enable deterministic test output.
-    Map<T, Node<T>> children = new LinkedHashMap<>();
+    Map<U, Node<U>> children = new LinkedHashMap<>();
     boolean isLeaf;
 
     Node() {
       chr = null;
     }
 
-    Node(T chr) {
+    Node(U chr) {
       this.chr = chr;
     }
   }
@@ -42,18 +42,18 @@ public class Trie<T> {
   private Node<T> root;
 
   public Trie() {
-    root = new Node();
+    root = new Node<>();
   }
 
   public void insert(List<T> word) {
     Map<T, Node<T>> children = root.children;
     for (int i = 0; i < word.size(); i++) {
       T chr = word.get(i);
-      Node t;
+      Node<T> t;
       if (children.containsKey(chr)) {
         t = children.get(chr);
       } else {
-        t = new Node(chr);
+        t = new Node<>(chr);
         children.put(chr, t);
       }
       children = t.children;
@@ -65,7 +65,7 @@ public class Trie<T> {
 
   /** Returns true if the word is in the trie. */
   public boolean search(List<T> word) {
-    Node node = searchNode(word);
+    Node<T> node = searchNode(word);
     return node != null && node.isLeaf;
   }
 
@@ -119,11 +119,10 @@ public class Trie<T> {
     return parentPostprocFn.apply(node.chr, baseValue, leafReducedValue);
   }
 
-  private Node searchNode(List<T> word) {
+  private Node<T> searchNode(List<T> word) {
     Map<T, Node<T>> children = root.children;
-    Node t = null;
-    for (int i = 0; i < word.size(); i++) {
-      T chr = word.get(i);
+    Node<T> t = null;
+    for (T chr : word) {
       if (children.containsKey(chr)) {
         t = children.get(chr);
         children = t.children;


### PR DESCRIPTION
Doesn't change the code behavior. Purely removing warnings and code smells.

- unused local and private variables, and private methods
- missing `@Override` annotations
- missing generic reference
- invalid static method reference
- etc.