### PR TITLE
fix: revert gradle version used for the bazel-generated assembly packages

### DIFF
--- a/rules_java_gapic/resources/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/rules_java_gapic/resources/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION


The new 7.x verison of gradle is incompatible with the used gradle build scripts format.