### PR TITLE
Update gax-java to latest 2.7.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,7 +33,7 @@ jvm_maven_import_external(
 # which in its turn, prioritizes actual generated clients runtime dependencies
 # over the generator dependencies.
 
-_gax_java_version = "2.4.0"
+_gax_java_version = "2.7.0"
 
 http_archive(
     name = "com_google_api_gax_java",


### PR DESCRIPTION
We should be fine without upgrading this, but it's always good to keep this up-to-date.