### PR TITLE
feat: Add google.api.routing annotation support (WIP)

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -59,9 +59,9 @@ def gapic_generator_java_repositories():
     _maybe(
         http_archive,
         name = "com_google_googleapis",
-        strip_prefix = "googleapis-ba30d8097582039ac4cc4e21b4e4baa426423075",
+        strip_prefix = "googleapis-987192dfddeb79d3262b9f9f7dbf092827f931ac",
         urls = [
-            "https://github.com/googleapis/googleapis/archive/ba30d8097582039ac4cc4e21b4e4baa426423075.zip",
+            "https://github.com/googleapis/googleapis/archive/987192dfddeb79d3262b9f9f7dbf092827f931ac.zip",
         ],
     )
 

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -307,7 +307,11 @@ public class GrpcServiceStubClassComposer extends AbstractTransportServiceStubCl
               .setExprReferenceExpr(paramsVarExpr)
               .setMethodName("put")
               .setArguments(
-                  ValueExpr.withValue(StringObjectValue.withValue(httpBindingFieldBinding.name())),
+                  ValueExpr.withValue(
+                      StringObjectValue.withValue(
+                          httpBindingFieldBinding.alias() != null
+                              ? httpBindingFieldBinding.alias()
+                              : httpBindingFieldBinding.name())),
                   valueOfExpr)
               .build();
       bodyExprs.add(paramsPutExpr);

--- a/src/main/java/com/google/api/generator/gapic/model/HttpBindings.java
+++ b/src/main/java/com/google/api/generator/gapic/model/HttpBindings.java
@@ -35,8 +35,10 @@ public abstract class HttpBindings {
 
     public abstract boolean isOptional();
 
-    public static HttpBinding create(String name, boolean isOptional) {
-      return new AutoValue_HttpBindings_HttpBinding(name, isOptional);
+    public abstract String alias();
+
+    public static HttpBinding create(String name, boolean isOptional, String alias) {
+      return new AutoValue_HttpBindings_HttpBinding(name, isOptional, alias);
     }
 
     // Do not forget to keep it in sync with equals() implementation.

--- a/src/main/java/com/google/api/generator/gapic/protoparser/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/BUILD.bazel
@@ -27,6 +27,7 @@ java_library(
         "//src/main/java/com/google/api/generator/gapic/model",
         "//src/main/java/com/google/api/generator/gapic/utils",
         "@com_google_api_api_common//jar",
+        "@com_google_api_grpc_proto_google_common_protos",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_code_gson//jar",
         "@com_google_googleapis//google/api:api_java_proto",

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcTestingStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcTestingStub.golden
@@ -221,7 +221,7 @@ public class GrpcTestingStub extends TestingStub {
             .setParamsExtractor(
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("name", String.valueOf(request.getName()));
+                  params.put("rename", String.valueOf(request.getName()));
                   return params.build();
                 })
             .build();

--- a/src/test/java/com/google/api/generator/gapic/protoparser/HttpRuleParserTest.java
+++ b/src/test/java/com/google/api/generator/gapic/protoparser/HttpRuleParserTest.java
@@ -91,4 +91,23 @@ public class HttpRuleParserTest {
     assertThrows(
         IllegalStateException.class, () -> HttpRuleParser.parse(rpcMethod, inputMessage, messages));
   }
+
+  @Test
+  public void parseRoutingAnnotation_alias() {
+    FileDescriptor testingFileDescriptor = TestingOuterClass.getDescriptor();
+    ServiceDescriptor testingService = testingFileDescriptor.getServices().get(0);
+    assertEquals("Testing", testingService.getName());
+
+    Map<String, Message> messages = Parser.parseMessages(testingFileDescriptor);
+
+    // GetTest method.
+    MethodDescriptor rpcMethod = testingService.getMethods().get(5);
+    Message inputMessage = messages.get("com.google.showcase.v1beta1.GetTestRequest");
+    HttpBindings httpBindings = HttpRuleParser.parse(rpcMethod, inputMessage, messages);
+    assertThat(
+            httpBindings.pathParameters().stream()
+                .map(binding -> binding.name() + " -> " + binding.alias())
+                .collect(Collectors.toList()))
+        .containsExactly("name -> rename");
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/testdata/BUILD.bazel
+++ b/src/test/java/com/google/api/generator/gapic/testdata/BUILD.bazel
@@ -54,6 +54,7 @@ proto_library(
     ],
     deps = [
         "@com_google_googleapis//google/api:annotations_proto",
+        "@com_google_googleapis//google/api:routing_proto",
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",

--- a/src/test/java/com/google/api/generator/gapic/testdata/testing.proto
+++ b/src/test/java/com/google/api/generator/gapic/testdata/testing.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 import "google/api/annotations.proto";
+import "google/api/routing.proto";
 import "google/api/client.proto";
 import "google/api/resource.proto";
 import "google/protobuf/empty.proto";
@@ -77,6 +78,12 @@ service Testing {
   rpc GetTest(GetTestRequest) returns (Test) {
     option (google.api.http) = {
       get: "/v1beta1/{name=tests/*}"
+    };
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "name"
+        path_template: "/v1beta1/{rename=tests/*}"
+        }
     };
     option (google.api.method_signature) = "name";
   }

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -57,7 +57,7 @@ import javax.annotation.Generated;
  *       `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  * </ul>
  *
- * <p>Note that location_id must be refering to a GCP `region`; for example:
+ * <p>Note that location_id must be referring to a GCP `region`; for example:
  *
  * <ul>
  *   <li>`projects/redpepper-1290/locations/us-central1/instances/my-redis`
@@ -472,7 +472,7 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The creation is executed asynchronously and callers may check the returned operation to
    * track its progress. Once the operation is completed the Redis instance will be fully
-   * functional. Completed longrunning.Operation will contain the new instance object in the
+   * functional. The completed longrunning.Operation will contain the new instance object in the
    * response field.
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
@@ -524,7 +524,7 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The creation is executed asynchronously and callers may check the returned operation to
    * track its progress. Once the operation is completed the Redis instance will be fully
-   * functional. Completed longrunning.Operation will contain the new instance object in the
+   * functional. The completed longrunning.Operation will contain the new instance object in the
    * response field.
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
@@ -576,7 +576,7 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The creation is executed asynchronously and callers may check the returned operation to
    * track its progress. Once the operation is completed the Redis instance will be fully
-   * functional. Completed longrunning.Operation will contain the new instance object in the
+   * functional. The completed longrunning.Operation will contain the new instance object in the
    * response field.
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
@@ -612,7 +612,7 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The creation is executed asynchronously and callers may check the returned operation to
    * track its progress. Once the operation is completed the Redis instance will be fully
-   * functional. Completed longrunning.Operation will contain the new instance object in the
+   * functional. The completed longrunning.Operation will contain the new instance object in the
    * response field.
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
@@ -649,7 +649,7 @@ public class CloudRedisClient implements BackgroundResource {
    *
    * <p>The creation is executed asynchronously and callers may check the returned operation to
    * track its progress. Once the operation is completed the Redis instance will be fully
-   * functional. Completed longrunning.Operation will contain the new instance object in the
+   * functional. The completed longrunning.Operation will contain the new instance object in the
    * response field.
    *
    * <p>The returned operation is automatically deleted after a few hours, so there is no need to
@@ -696,7 +696,8 @@ public class CloudRedisClient implements BackgroundResource {
    * @param updateMask Required. Mask of fields to update. At least one path must be supplied in
    *     this field. The elements of the repeated paths field may only include these fields from
    *     [Instance][google.cloud.redis.v1beta1.Instance]:
-   *     <p>&#42; `displayName` &#42; `labels` &#42; `memorySizeGb` &#42; `redisConfig`
+   *     <p>&#42; `displayName` &#42; `labels` &#42; `memorySizeGb` &#42; `redisConfig` &#42;
+   *     `replica_count`
    * @param instance Required. Update description. Only fields specified in update_mask are updated.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
@@ -1164,7 +1165,7 @@ public class CloudRedisClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Initiates a failover of the master node to current replica node for a specific STANDARD tier
+   * Initiates a failover of the primary node to current replica node for a specific STANDARD tier
    * Cloud Memorystore for Redis instance.
    *
    * <p>Sample code:
@@ -1197,7 +1198,7 @@ public class CloudRedisClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Initiates a failover of the master node to current replica node for a specific STANDARD tier
+   * Initiates a failover of the primary node to current replica node for a specific STANDARD tier
    * Cloud Memorystore for Redis instance.
    *
    * <p>Sample code:
@@ -1230,7 +1231,7 @@ public class CloudRedisClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Initiates a failover of the master node to current replica node for a specific STANDARD tier
+   * Initiates a failover of the primary node to current replica node for a specific STANDARD tier
    * Cloud Memorystore for Redis instance.
    *
    * <p>Sample code:
@@ -1255,7 +1256,7 @@ public class CloudRedisClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Initiates a failover of the master node to current replica node for a specific STANDARD tier
+   * Initiates a failover of the primary node to current replica node for a specific STANDARD tier
    * Cloud Memorystore for Redis instance.
    *
    * <p>Sample code:
@@ -1280,7 +1281,7 @@ public class CloudRedisClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Initiates a failover of the master node to current replica node for a specific STANDARD tier
+   * Initiates a failover of the primary node to current replica node for a specific STANDARD tier
    * Cloud Memorystore for Redis instance.
    *
    * <p>Sample code:

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
@@ -35,6 +35,7 @@ import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -194,6 +195,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     mockCloudRedis.addResponse(expectedResponse);
 
@@ -247,6 +252,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     mockCloudRedis.addResponse(expectedResponse);
 
@@ -300,6 +309,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -367,6 +380,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -434,6 +451,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -498,6 +519,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -562,6 +587,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -626,6 +655,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -690,6 +723,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -754,6 +791,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -820,6 +861,10 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
             .build();
     Operation resultOperation =
         Operation.newBuilder()

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/package-info.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/package-info.java
@@ -15,7 +15,9 @@
  */
 
 /**
- * The interfaces provided are listed below, along with usage samples.
+ * A client to Google Cloud Memorystore for Redis API
+ *
+ * <p>The interfaces provided are listed below, along with usage samples.
  *
  * <p>======================= CloudRedisClient =======================
  *
@@ -34,7 +36,7 @@
  *       `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
  * </ul>
  *
- * <p>Note that location_id must be refering to a GCP `region`; for example:
+ * <p>Note that location_id must be referring to a GCP `region`; for example:
  *
  * <ul>
  *   <li>`projects/redpepper-1290/locations/us-central1/instances/my-redis`

--- a/test/integration/goldens/storage/com/google/storage/v2/StorageClient.java
+++ b/test/integration/goldens/storage/com/google/storage/v2/StorageClient.java
@@ -29,7 +29,21 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
- * Service Description: Manages Google Cloud Storage resources.
+ * Service Description: ## API Overview and Naming Syntax
+ *
+ * <p>The GCS gRPC API allows applications to read and write data through the abstractions of
+ * buckets and objects. For a description of these abstractions please see
+ * https://cloud.google.com/storage/docs.
+ *
+ * <p>Resources are named as follows: - Projects are referred to as they are defined by the Resource
+ * Manager API, using strings like `projects/123456` or `projects/my-string-id`. - Buckets are named
+ * using string names of the form: `projects/{project}/buckets/{bucket}` For globally unique
+ * buckets, `_` may be substituted for the project. - Objects are uniquely identified by their name
+ * along with the name of the bucket they belong to, as separate strings in this API. For example:
+ *
+ * <p>ReadObjectRequest { bucket: 'projects/_/buckets/my-bucket' object: 'my-object' } Note that
+ * object names can contain `/` characters, which are treated as any other character (no special
+ * directory semantics).
  *
  * <p>This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
@@ -190,7 +204,7 @@ public class StorageClient implements BackgroundResource {
    * that method an `WriteObjectSpec.` They should then attach the returned `upload_id` to the first
    * message of each following call to `Create`. If there is an error or the connection is broken
    * during the resumable `Create()`, the client should check the status of the `Create()` by
-   * calling `QueryWriteStatus()` and continue writing from the returned `committed_size`. This may
+   * calling `QueryWriteStatus()` and continue writing from the returned `persisted_size`. This may
    * be less than the amount of data the client previously sent.
    *
    * <p>The service will not view the object as complete until the client has sent a
@@ -294,7 +308,7 @@ public class StorageClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Determines the `committed_size` for an object that is being written, which can then be used as
+   * Determines the `persisted_size` for an object that is being written, which can then be used as
    * the `write_offset` for the next `Write()` call.
    *
    * <p>If the object does not exist (i.e., the object has been deleted, or the first `Write()` has
@@ -303,7 +317,7 @@ public class StorageClient implements BackgroundResource {
    * <p>The client &#42;&#42;may&#42;&#42; call `QueryWriteStatus()` at any time to determine how
    * much data has been processed for this object. This is useful if the client is buffering data
    * and needs to know which data can be safely evicted. For any sequence of `QueryWriteStatus()`
-   * calls for a given object name, the sequence of returned `committed_size` values will be
+   * calls for a given object name, the sequence of returned `persisted_size` values will be
    * non-decreasing.
    *
    * <p>Sample code:
@@ -327,7 +341,7 @@ public class StorageClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Determines the `committed_size` for an object that is being written, which can then be used as
+   * Determines the `persisted_size` for an object that is being written, which can then be used as
    * the `write_offset` for the next `Write()` call.
    *
    * <p>If the object does not exist (i.e., the object has been deleted, or the first `Write()` has
@@ -336,7 +350,7 @@ public class StorageClient implements BackgroundResource {
    * <p>The client &#42;&#42;may&#42;&#42; call `QueryWriteStatus()` at any time to determine how
    * much data has been processed for this object. This is useful if the client is buffering data
    * and needs to know which data can be safely evicted. For any sequence of `QueryWriteStatus()`
-   * calls for a given object name, the sequence of returned `committed_size` values will be
+   * calls for a given object name, the sequence of returned `persisted_size` values will be
    * non-decreasing.
    *
    * <p>Sample code:
@@ -362,7 +376,7 @@ public class StorageClient implements BackgroundResource {
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
   /**
-   * Determines the `committed_size` for an object that is being written, which can then be used as
+   * Determines the `persisted_size` for an object that is being written, which can then be used as
    * the `write_offset` for the next `Write()` call.
    *
    * <p>If the object does not exist (i.e., the object has been deleted, or the first `Write()` has
@@ -371,7 +385,7 @@ public class StorageClient implements BackgroundResource {
    * <p>The client &#42;&#42;may&#42;&#42; call `QueryWriteStatus()` at any time to determine how
    * much data has been processed for this object. This is useful if the client is buffering data
    * and needs to know which data can be safely evicted. For any sequence of `QueryWriteStatus()`
-   * calls for a given object name, the sequence of returned `committed_size` values will be
+   * calls for a given object name, the sequence of returned `persisted_size` values will be
    * non-decreasing.
    *
    * <p>Sample code:

--- a/test/integration/goldens/storage/com/google/storage/v2/package-info.java
+++ b/test/integration/goldens/storage/com/google/storage/v2/package-info.java
@@ -19,7 +19,21 @@
  *
  * <p>======================= StorageClient =======================
  *
- * <p>Service Description: Manages Google Cloud Storage resources.
+ * <p>Service Description: ## API Overview and Naming Syntax
+ *
+ * <p>The GCS gRPC API allows applications to read and write data through the abstractions of
+ * buckets and objects. For a description of these abstractions please see
+ * https://cloud.google.com/storage/docs.
+ *
+ * <p>Resources are named as follows: - Projects are referred to as they are defined by the Resource
+ * Manager API, using strings like `projects/123456` or `projects/my-string-id`. - Buckets are named
+ * using string names of the form: `projects/{project}/buckets/{bucket}` For globally unique
+ * buckets, `_` may be substituted for the project. - Objects are uniquely identified by their name
+ * along with the name of the bucket they belong to, as separate strings in this API. For example:
+ *
+ * <p>ReadObjectRequest { bucket: 'projects/_/buckets/my-bucket' object: 'my-object' } Note that
+ * object names can contain `/` characters, which are treated as any other character (no special
+ * directory semantics).
  *
  * <p>Sample for StorageClient:
  *


### PR DESCRIPTION
This is an implementation of the go/actools-dynamic-routing-proposal
which provides a way in an API description to specify a limited per-RPC
projection from RPC’s input message to a routing header.

NOTE: This is work-in-progress and not meant for review yet.