### PR TITLE
fix: add missing dependencies in Gradle for "self-service" library generation

### DIFF
--- a/rules_java_gapic/resources/gradle/client_grpc.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpc.gradle.tmpl
@@ -10,6 +10,8 @@ dependencies {
   testImplementation 'com.google.api:gax:{{version.gax}}:testlib'
   implementation 'com.google.api:gax-grpc:{{version.gax_grpc}}'
   testImplementation 'com.google.api:gax-grpc:{{version.gax_grpc}}:testlib'
+  implementation 'io.grpc:grpc-protobuf:{{version.io_grpc}}'
+  testImplementation 'io.grpc:grpc-stub:{{version.io_grpc}}'
   testImplementation 'io.grpc:grpc-netty-shaded:{{version.io_grpc}}'
   testImplementation '{{maven.junit_junit}}'
   {{extra_deps}}

--- a/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
@@ -12,6 +12,8 @@ dependencies {
   testImplementation 'com.google.api:gax-grpc:{{version.gax_grpc}}:testlib'
   implementation 'com.google.api:gax-httpjson:{{version.gax_httpjson}}'
   testImplementation 'com.google.api:gax-httpjson:{{version.gax_httpjson}}:testlib'
+  implementation 'io.grpc:grpc-protobuf:{{version.io_grpc}}'
+  testImplementation 'io.grpc:grpc-stub:{{version.io_grpc}}'
   testImplementation 'io.grpc:grpc-netty-shaded:{{version.io_grpc}}'
   testImplementation '{{maven.junit_junit}}'
   {{extra_deps}}

--- a/rules_java_gapic/resources/gradle/proto.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/proto.gradle.tmpl
@@ -7,6 +7,7 @@ javadoc.options.encoding = 'UTF-8'
 
 dependencies {
   implementation 'com.google.protobuf:protobuf-java:{{version.com_google_protobuf}}'
+  implementation '{{maven.com_google_guava_guava}}'
   implementation '{{maven.com_google_api_api_common}}'
   implementation '{{maven.com_google_api_grpc_proto_google_common_protos}}'
   {{extra_deps}}


### PR DESCRIPTION
After #876, turns out these dependencies are required to compile generated libraries.

The reason that these were not required previously is probably the same as https://github.com/googleapis/gax-java/issues/1534. That is, something people realize after they drop the obsolete `compile` or `runtime` "scopes."

This will resolve b/211697397, but there might be more dependencies to add (hopefully not).