### PR TITLE
feat: support Java 9+ compilation of generated libraries

### DIFF
--- a/rules_java_gapic/resources/gradle/client_grpc.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpc.gradle.tmpl
@@ -14,6 +14,11 @@ dependencies {
   testImplementation 'io.grpc:grpc-stub:{{version.io_grpc}}'
   testImplementation 'io.grpc:grpc-netty-shaded:{{version.io_grpc}}'
   testImplementation '{{maven.junit_junit}}'
+
+  // TODO: remove when dropping Java 8 support.
+  // https://github.com/googleapis/gapic-generator-java/issues/888
+  implementation '{{maven.javax_annotation_javax_annotation_api}}'
+
   {{extra_deps}}
 }
 

--- a/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
@@ -16,6 +16,11 @@ dependencies {
   testImplementation 'io.grpc:grpc-stub:{{version.io_grpc}}'
   testImplementation 'io.grpc:grpc-netty-shaded:{{version.io_grpc}}'
   testImplementation '{{maven.junit_junit}}'
+
+  // TODO: remove when dropping Java 8 support.
+  // https://github.com/googleapis/gapic-generator-java/issues/888
+  implementation '{{maven.javax_annotation_javax_annotation_api}}'
+
   {{extra_deps}}
 }
 

--- a/rules_java_gapic/resources/gradle/client_rest.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_rest.gradle.tmpl
@@ -11,6 +11,11 @@ dependencies {
   implementation 'com.google.api:gax-httpjson:{{version.gax_httpjson}}'
   testImplementation 'com.google.api:gax-httpjson:{{version.gax_httpjson}}:testlib'
   testImplementation '{{maven.junit_junit}}'
+
+  // TODO: remove when dropping Java 8 support.
+  // https://github.com/googleapis/gapic-generator-java/issues/888
+  implementation '{{maven.javax_annotation_javax_annotation_api}}'
+
   {{extra_deps}}
 }
 

--- a/rules_java_gapic/resources/gradle/grpc.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/grpc.gradle.tmpl
@@ -8,6 +8,11 @@ javadoc.options.encoding = 'UTF-8'
 dependencies {
   implementation 'io.grpc:grpc-stub:{{version.io_grpc}}'
   implementation 'io.grpc:grpc-protobuf:{{version.io_grpc}}'
+
+  // TODO: remove when dropping Java 8 support.
+  // https://github.com/googleapis/gapic-generator-java/issues/888
+  implementation '{{maven.javax_annotation_javax_annotation_api}}'
+
   {{extra_deps}}
 }
 

--- a/rules_java_gapic/resources/gradle/proto.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/proto.gradle.tmpl
@@ -10,6 +10,11 @@ dependencies {
   implementation '{{maven.com_google_guava_guava}}'
   implementation '{{maven.com_google_api_api_common}}'
   implementation '{{maven.com_google_api_grpc_proto_google_common_protos}}'
+
+  // TODO: remove when dropping Java 8 support.
+  // https://github.com/googleapis/gapic-generator-java/issues/888
+  implementation '{{maven.javax_annotation_javax_annotation_api}}'
+
   {{extra_deps}}
 }
 


### PR DESCRIPTION
Stopgap support for generated libraries. See #888.

Tested this with java-compute and java-retail using Java 11.