### PR TITLE
fix: expose extra dependencies transitively to library users

### DIFF
--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -166,7 +166,7 @@ def _java_gapic_build_configs_pkg_impl(ctx):
 
     substitutions = dict(ctx.attr.static_substitutions)
     substitutions["{{extra_deps}}"] = _construct_extra_deps({
-        "implementation": ctx.attr.deps,
+        "api": ctx.attr.deps,
         "testImplementation": ctx.attr.test_deps,
     }, substitutions)
 


### PR DESCRIPTION
This is about "self-service" generated libraries.

We [changed the dependency "scope"](https://github.com/googleapis/gapic-generator-java/pull/876/files#diff-66f068746d573fb515dcebc976e0d2eabf10a609e61ff20fa07d888d88702c23R169) from the obsolete `compile` to `implementation` when we upgraded Gradle, which prevents affecting dependencies from transitively exposed to library users. We did the same to gax a while ago and a report like [this](https://github.com/googleapis/gax-java/issues/1534#issuecomment-944785857) ensued. Likewise, today I got a report where a library user cannot access auto-generated proto stub classes in their Java code.

This PR changes the scope back to what `compile` meant in old Gradle versions. The behavior after the change should be that of the old versions.

I've tacked down which dependencies are being affected and used in practice. I think the best course of action is to go back to the original behavior for safely, even though this could be over-provisioning.