### PR TITLE
fix: fix broken Gradle allJars task on generated libs and add tests for it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           mkdir /tmp/java-storage
           tar zxvf bazel-bin/test/integration/google-cloud-storage-v2-java.tar.gz -C /tmp/java-storage
           pushd /tmp/java-storage/google-cloud-storage-v2-java
-          ./gradlew clean build publishToMavenLocal
+          ./gradlew clean build publishToMavenLocal sourcesJar allJars
           popd
 
       - name: Gradle Build Generated Compute Client Library
@@ -62,7 +62,7 @@ jobs:
           bazel --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
           tar zxvf bazel-bin/external/com_google_googleapis/google/cloud/compute/v1small/google-cloud-compute-small-v1-java.tar.gz -C /tmp/java-compute
           pushd /tmp/java-compute/google-cloud-compute-small-v1-java
-          ./gradlew clean build publishToMavenLocal
+          ./gradlew clean build publishToMavenLocal sourcesJar allJars
           popd
 
       - uses: actions/upload-artifact@v2

--- a/rules_java_gapic/resources/gradle/client_grpc.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpc.gradle.tmpl
@@ -40,6 +40,6 @@ clean {
 task allJars(type: Copy) {
   dependsOn test, jar
   into 'all-jars'
-  // Replace with `from configurations.testRuntimeOnly, jar` to include test dependencies
-  from configurations.runtimeOnly, jar
+  // Replace with `from configurations.testRuntimeClasspath, jar` to include test dependencies
+  from configurations.runtimeClasspath, jar
 }

--- a/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_grpcrest.gradle.tmpl
@@ -42,6 +42,6 @@ clean {
 task allJars(type: Copy) {
   dependsOn test, jar
   into 'all-jars'
-  // Replace with `from configurations.testRuntimeOnly, jar` to include test dependencies
-  from configurations.runtimeOnly, jar
+  // Replace with `from configurations.testRuntimeClasspath, jar` to include test dependencies
+  from configurations.runtimeClasspath, jar
 }

--- a/rules_java_gapic/resources/gradle/client_rest.gradle.tmpl
+++ b/rules_java_gapic/resources/gradle/client_rest.gradle.tmpl
@@ -37,6 +37,6 @@ clean {
 task allJars(type: Copy) {
   dependsOn test, jar
   into 'all-jars'
-  // Replace with `from configurations.testRuntimeOnly, jar` to include test dependencies
-  from configurations.runtimeOnly, jar
+  // Replace with `from configurations.testRuntimeClasspath, jar` to include test dependencies
+  from configurations.runtimeClasspath, jar
 }


### PR DESCRIPTION
b/214271851

```
> Resolving dependency configuration 'runtimeOnly' is not allowed as it is defined as 'canBeResolved=false'.
  Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'runtimeOnly' should be resolved.
```

`runtimeOnly` is not resolvable. The point of `allJars` is to get all the runtime dependencies + library itself, so `runtimeClasspath` should do it.