### PR TITLE
chore: clean up build

### DIFF
--- a/PROPERTIES.bzl
+++ b/PROPERTIES.bzl
@@ -14,7 +14,6 @@ PROPERTIES = {
     "maven.com_google_protobuf_protobuf_java": "com.google.protobuf:protobuf-java:3.19.1",
     "maven.io_github_java_diff_utils": "io.github.java-diff-utils:java-diff-utils:4.0",
     "maven.javax_annotation_javax_annotation_api": "javax.annotation:javax.annotation-api:1.3.2",
-    "maven.javax_validation_javax_validation_api": "javax.validation:validation-api:2.0.1.Final",
 
     # Gapic YAML parsing for batching settings.
     "maven.org_yaml_snakeyaml": "org.yaml:snakeyaml:1.26",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -66,15 +66,6 @@ def gapic_generator_java_repositories():
     )
 
     _maybe(
-        http_archive,
-        name = "com_google_googleapis_discovery",
-        strip_prefix = "googleapis-discovery-34478e2969042ed837d33684360f1ee3be7d2f74",
-        urls = [
-            "https://github.com/googleapis/googleapis-discovery/archive/34478e2969042ed837d33684360f1ee3be7d2f74.zip",
-        ],
-    )
-
-    _maybe(
         native.bind,
         name = "guava",
         actual = "@com_google_guava_guava//jar",
@@ -84,20 +75,6 @@ def gapic_generator_java_repositories():
         native.bind,
         name = "gson",
         actual = "@com_google_code_gson_gson//jar",
-    )
-
-    _maybe(
-        jvm_maven_import_external,
-        name = "error_prone_annotations_maven",
-        artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
-        server_urls = ["https://repo.maven.apache.org/maven2/", "http://repo1.maven.org/maven2/"],
-        licenses = ["notice", "reciprocal"],
-    )
-
-    _maybe(
-        native.bind,
-        name = "error_prone_annotations",
-        actual = "@error_prone_annotations_maven//jar",
     )
 
     _api_common_java_version = PROPERTIES["version.com_google_api_common_java"]

--- a/src/main/java/com/google/api/generator/engine/ast/BUILD.bazel
+++ b/src/main/java/com/google/api/generator/engine/ast/BUILD.bazel
@@ -14,6 +14,5 @@ java_library(
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
-        "@javax_validation_javax_validation_api//jar",
     ],
 )

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -1,13 +1,10 @@
 load(
-    "@gapic_generator_java//rules_java_gapic:java_gapic.bzl",
+    "//rules_java_gapic:java_gapic.bzl",
     "java_gapic_library",
     "java_gapic_test",
 )
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-load(
-    "@gapic_generator_java//rules_java_gapic:java_gapic_pkg.bzl",
-    "java_gapic_assembly_gradle_pkg",
-)
+load("//rules_java_gapic:java_gapic_pkg.bzl", "java_gapic_assembly_gradle_pkg")
 load("@rules_gapic//:gapic.bzl", "proto_library_with_info")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
@@ -37,7 +34,7 @@ API_GAPIC_TARGETS = {
     # No gRPC service config.
     "library": "@com_google_googleapis//google/example/library/v1:library_java_gapic",
     # REGAPIC test.
-    "compute": "@com_google_googleapis_discovery//google/cloud/compute/v1:compute_small_java_gapic",
+    "compute": "@com_google_googleapis//google/cloud/compute/v1small:compute_small_java_gapic",
 }
 
 [sh_test(

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/AddressesClient.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/AddressesClient.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1;
+package com.google.cloud.compute.v1small;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -27,8 +27,8 @@ import com.google.api.gax.paging.AbstractPagedListResponse;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.stub.AddressesStub;
-import com.google.cloud.compute.v1.stub.AddressesStubSettings;
+import com.google.cloud.compute.v1small.stub.AddressesStub;
+import com.google.cloud.compute.v1small.stub.AddressesStubSettings;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.List;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/AddressesClientTest.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/AddressesClientTest.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1;
+package com.google.cloud.compute.v1small;
+
+import static com.google.cloud.compute.v1small.AddressesClient.AggregatedListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.ListPagedResponse;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
@@ -25,11 +28,16 @@ import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
-import com.google.cloud.compute.v1.Operation.Status;
-import com.google.cloud.compute.v1.stub.HttpJsonRegionOperationsStub;
+import com.google.cloud.compute.v1small.Operation.Status;
+import com.google.cloud.compute.v1small.stub.HttpJsonAddressesStub;
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Generated;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -39,25 +47,24 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 @Generated("by gapic-generator-java")
-public class RegionOperationsClientTest {
+public class AddressesClientTest {
   private static MockHttpService mockService;
-  private static RegionOperationsClient client;
+  private static AddressesClient client;
 
   @BeforeClass
   public static void startStaticServer() throws IOException {
     mockService =
         new MockHttpService(
-            HttpJsonRegionOperationsStub.getMethodDescriptors(),
-            RegionOperationsSettings.getDefaultEndpoint());
-    RegionOperationsSettings settings =
-        RegionOperationsSettings.newBuilder()
+            HttpJsonAddressesStub.getMethodDescriptors(), AddressesSettings.getDefaultEndpoint());
+    AddressesSettings settings =
+        AddressesSettings.newBuilder()
             .setTransportChannelProvider(
-                RegionOperationsSettings.defaultHttpJsonTransportProviderBuilder()
+                AddressesSettings.defaultHttpJsonTransportProviderBuilder()
                     .setHttpTransport(mockService)
                     .build())
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build();
-    client = RegionOperationsClient.create(settings);
+    client = AddressesClient.create(settings);
   }
 
   @AfterClass
@@ -74,41 +81,25 @@ public class RegionOperationsClientTest {
   }
 
   @Test
-  public void getTest() throws Exception {
-    Operation expectedResponse =
-        Operation.newBuilder()
-            .setClientOperationId("clientOperationId-1230366697")
-            .setCreationTimestamp("creationTimestamp-370203401")
-            .setDescription("description-1724546052")
-            .setEndTime("endTime-1607243192")
-            .setError(Error.newBuilder().build())
-            .setHttpErrorMessage("httpErrorMessage1577303431")
-            .setHttpErrorStatusCode(0)
-            .setId(3355)
-            .setInsertTime("insertTime966165798")
-            .setKind("kind3292052")
-            .setName("name3373707")
-            .setOperationType("operationType91999553")
-            .setProgress(-1001078227)
-            .setRegion("region-934795532")
-            .setSelfLink("selfLink1191800166")
-            .setStartTime("startTime-2129294769")
-            .setStatus(Status.DONE)
-            .setStatusMessage("statusMessage-958704715")
-            .setTargetId(-815576439)
-            .setTargetLink("targetLink486368555")
-            .setUser("user3599307")
-            .addAllWarnings(new ArrayList<Warnings>())
-            .setZone("zone3744684")
+  public void aggregatedListTest() throws Exception {
+    AddressesScopedList responsesElement = AddressesScopedList.newBuilder().build();
+    AddressAggregatedList expectedResponse =
+        AddressAggregatedList.newBuilder()
+            .setNextPageToken("")
+            .putAllItems(Collections.singletonMap("items", responsesElement))
             .build();
     mockService.addResponse(expectedResponse);
 
     String project = "project-6911";
-    String region = "region-9622";
-    String operation = "operation-3971";
 
-    Operation actualResponse = client.get(project, region, operation);
-    Assert.assertEquals(expectedResponse, actualResponse);
+    AggregatedListPagedResponse pagedListResponse = client.aggregatedList(project);
+
+    List<Map.Entry<String, AddressesScopedList>> resources =
+        Lists.newArrayList(pagedListResponse.iterateAll());
+
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(
+        expectedResponse.getItemsMap().entrySet().iterator().next(), resources.get(0));
 
     List<String> actualRequests = mockService.getRequestPaths();
     Assert.assertEquals(1, actualRequests.size());
@@ -126,7 +117,7 @@ public class RegionOperationsClientTest {
   }
 
   @Test
-  public void getExceptionTest() throws Exception {
+  public void aggregatedListExceptionTest() throws Exception {
     ApiException exception =
         ApiExceptionFactory.createException(
             new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
@@ -134,9 +125,7 @@ public class RegionOperationsClientTest {
 
     try {
       String project = "project-6911";
-      String region = "region-9622";
-      String operation = "operation-3971";
-      client.get(project, region, operation);
+      client.aggregatedList(project);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.
@@ -144,7 +133,7 @@ public class RegionOperationsClientTest {
   }
 
   @Test
-  public void waitTest() throws Exception {
+  public void deleteTest() throws Exception {
     Operation expectedResponse =
         Operation.newBuilder()
             .setClientOperationId("clientOperationId-1230366697")
@@ -175,9 +164,9 @@ public class RegionOperationsClientTest {
 
     String project = "project-6911";
     String region = "region-9622";
-    String operation = "operation-3971";
+    String address = "address-4954";
 
-    Operation actualResponse = client.wait(project, region, operation);
+    Operation actualResponse = client.deleteAsync(project, region, address).get();
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<String> actualRequests = mockService.getRequestPaths();
@@ -196,7 +185,7 @@ public class RegionOperationsClientTest {
   }
 
   @Test
-  public void waitExceptionTest() throws Exception {
+  public void deleteExceptionTest() throws Exception {
     ApiException exception =
         ApiExceptionFactory.createException(
             new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
@@ -205,8 +194,130 @@ public class RegionOperationsClientTest {
     try {
       String project = "project-6911";
       String region = "region-9622";
-      String operation = "operation-3971";
-      client.wait(project, region, operation);
+      String address = "address-4954";
+      client.deleteAsync(project, region, address).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+    }
+  }
+
+  @Test
+  public void insertTest() throws Exception {
+    Operation expectedResponse =
+        Operation.newBuilder()
+            .setClientOperationId("clientOperationId-1230366697")
+            .setCreationTimestamp("creationTimestamp-370203401")
+            .setDescription("description-1724546052")
+            .setEndTime("endTime-1607243192")
+            .setError(Error.newBuilder().build())
+            .setHttpErrorMessage("httpErrorMessage1577303431")
+            .setHttpErrorStatusCode(0)
+            .setId(3355)
+            .setInsertTime("insertTime966165798")
+            .setKind("kind3292052")
+            .setName("name3373707")
+            .setOperationType("operationType91999553")
+            .setProgress(-1001078227)
+            .setRegion("region-934795532")
+            .setSelfLink("selfLink1191800166")
+            .setStartTime("startTime-2129294769")
+            .setStatus(Status.DONE)
+            .setStatusMessage("statusMessage-958704715")
+            .setTargetId(-815576439)
+            .setTargetLink("targetLink486368555")
+            .setUser("user3599307")
+            .addAllWarnings(new ArrayList<Warnings>())
+            .setZone("zone3744684")
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    String project = "project-6911";
+    String region = "region-9622";
+    Address addressResource = Address.newBuilder().build();
+
+    Operation actualResponse = client.insertAsync(project, region, addressResource).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void insertExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      String project = "project-6911";
+      String region = "region-9622";
+      Address addressResource = Address.newBuilder().build();
+      client.insertAsync(project, region, addressResource).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+    }
+  }
+
+  @Test
+  public void listTest() throws Exception {
+    Address responsesElement = Address.newBuilder().build();
+    AddressList expectedResponse =
+        AddressList.newBuilder()
+            .setNextPageToken("")
+            .addAllItems(Arrays.asList(responsesElement))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    String project = "project-6911";
+    String region = "region-9622";
+    String orderBy = "orderBy-1207110587";
+
+    ListPagedResponse pagedListResponse = client.list(project, region, orderBy);
+
+    List<Address> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getItemsList().get(0), resources.get(0));
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void listExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      String project = "project-6911";
+      String region = "region-9622";
+      String orderBy = "orderBy-1207110587";
+      client.list(project, region, orderBy);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/AddressesSettings.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/AddressesSettings.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1;
+package com.google.cloud.compute.v1small;
 
-import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
-import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.AggregatedListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.ListPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
@@ -32,7 +32,7 @@ import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.cloud.compute.v1.stub.AddressesStubSettings;
+import com.google.cloud.compute.v1small.stub.AddressesStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/RegionOperationsClient.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/RegionOperationsClient.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1;
+package com.google.cloud.compute.v1small;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.stub.RegionOperationsStub;
-import com.google.cloud.compute.v1.stub.RegionOperationsStubSettings;
+import com.google.cloud.compute.v1small.stub.RegionOperationsStub;
+import com.google.cloud.compute.v1small.stub.RegionOperationsStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/RegionOperationsClientTest.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/RegionOperationsClientTest.java
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1;
-
-import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
-import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
+package com.google.cloud.compute.v1small;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
@@ -28,16 +25,11 @@ import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
-import com.google.cloud.compute.v1.Operation.Status;
-import com.google.cloud.compute.v1.stub.HttpJsonAddressesStub;
-import com.google.common.collect.Lists;
+import com.google.cloud.compute.v1small.Operation.Status;
+import com.google.cloud.compute.v1small.stub.HttpJsonRegionOperationsStub;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import javax.annotation.Generated;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -47,24 +39,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 @Generated("by gapic-generator-java")
-public class AddressesClientTest {
+public class RegionOperationsClientTest {
   private static MockHttpService mockService;
-  private static AddressesClient client;
+  private static RegionOperationsClient client;
 
   @BeforeClass
   public static void startStaticServer() throws IOException {
     mockService =
         new MockHttpService(
-            HttpJsonAddressesStub.getMethodDescriptors(), AddressesSettings.getDefaultEndpoint());
-    AddressesSettings settings =
-        AddressesSettings.newBuilder()
+            HttpJsonRegionOperationsStub.getMethodDescriptors(),
+            RegionOperationsSettings.getDefaultEndpoint());
+    RegionOperationsSettings settings =
+        RegionOperationsSettings.newBuilder()
             .setTransportChannelProvider(
-                AddressesSettings.defaultHttpJsonTransportProviderBuilder()
+                RegionOperationsSettings.defaultHttpJsonTransportProviderBuilder()
                     .setHttpTransport(mockService)
                     .build())
             .setCredentialsProvider(NoCredentialsProvider.create())
             .build();
-    client = AddressesClient.create(settings);
+    client = RegionOperationsClient.create(settings);
   }
 
   @AfterClass
@@ -81,25 +74,41 @@ public class AddressesClientTest {
   }
 
   @Test
-  public void aggregatedListTest() throws Exception {
-    AddressesScopedList responsesElement = AddressesScopedList.newBuilder().build();
-    AddressAggregatedList expectedResponse =
-        AddressAggregatedList.newBuilder()
-            .setNextPageToken("")
-            .putAllItems(Collections.singletonMap("items", responsesElement))
+  public void getTest() throws Exception {
+    Operation expectedResponse =
+        Operation.newBuilder()
+            .setClientOperationId("clientOperationId-1230366697")
+            .setCreationTimestamp("creationTimestamp-370203401")
+            .setDescription("description-1724546052")
+            .setEndTime("endTime-1607243192")
+            .setError(Error.newBuilder().build())
+            .setHttpErrorMessage("httpErrorMessage1577303431")
+            .setHttpErrorStatusCode(0)
+            .setId(3355)
+            .setInsertTime("insertTime966165798")
+            .setKind("kind3292052")
+            .setName("name3373707")
+            .setOperationType("operationType91999553")
+            .setProgress(-1001078227)
+            .setRegion("region-934795532")
+            .setSelfLink("selfLink1191800166")
+            .setStartTime("startTime-2129294769")
+            .setStatus(Status.DONE)
+            .setStatusMessage("statusMessage-958704715")
+            .setTargetId(-815576439)
+            .setTargetLink("targetLink486368555")
+            .setUser("user3599307")
+            .addAllWarnings(new ArrayList<Warnings>())
+            .setZone("zone3744684")
             .build();
     mockService.addResponse(expectedResponse);
 
     String project = "project-6911";
+    String region = "region-9622";
+    String operation = "operation-3971";
 
-    AggregatedListPagedResponse pagedListResponse = client.aggregatedList(project);
-
-    List<Map.Entry<String, AddressesScopedList>> resources =
-        Lists.newArrayList(pagedListResponse.iterateAll());
-
-    Assert.assertEquals(1, resources.size());
-    Assert.assertEquals(
-        expectedResponse.getItemsMap().entrySet().iterator().next(), resources.get(0));
+    Operation actualResponse = client.get(project, region, operation);
+    Assert.assertEquals(expectedResponse, actualResponse);
 
     List<String> actualRequests = mockService.getRequestPaths();
     Assert.assertEquals(1, actualRequests.size());
@@ -117,7 +126,7 @@ public class AddressesClientTest {
   }
 
   @Test
-  public void aggregatedListExceptionTest() throws Exception {
+  public void getExceptionTest() throws Exception {
     ApiException exception =
         ApiExceptionFactory.createException(
             new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
@@ -125,7 +134,9 @@ public class AddressesClientTest {
 
     try {
       String project = "project-6911";
-      client.aggregatedList(project);
+      String region = "region-9622";
+      String operation = "operation-3971";
+      client.get(project, region, operation);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.
@@ -133,7 +144,7 @@ public class AddressesClientTest {
   }
 
   @Test
-  public void deleteTest() throws Exception {
+  public void waitTest() throws Exception {
     Operation expectedResponse =
         Operation.newBuilder()
             .setClientOperationId("clientOperationId-1230366697")
@@ -164,9 +175,9 @@ public class AddressesClientTest {
 
     String project = "project-6911";
     String region = "region-9622";
-    String address = "address-4954";
+    String operation = "operation-3971";
 
-    Operation actualResponse = client.deleteAsync(project, region, address).get();
+    Operation actualResponse = client.wait(project, region, operation);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<String> actualRequests = mockService.getRequestPaths();
@@ -185,7 +196,7 @@ public class AddressesClientTest {
   }
 
   @Test
-  public void deleteExceptionTest() throws Exception {
+  public void waitExceptionTest() throws Exception {
     ApiException exception =
         ApiExceptionFactory.createException(
             new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
@@ -194,130 +205,8 @@ public class AddressesClientTest {
     try {
       String project = "project-6911";
       String region = "region-9622";
-      String address = "address-4954";
-      client.deleteAsync(project, region, address).get();
-      Assert.fail("No exception raised");
-    } catch (ExecutionException e) {
-    }
-  }
-
-  @Test
-  public void insertTest() throws Exception {
-    Operation expectedResponse =
-        Operation.newBuilder()
-            .setClientOperationId("clientOperationId-1230366697")
-            .setCreationTimestamp("creationTimestamp-370203401")
-            .setDescription("description-1724546052")
-            .setEndTime("endTime-1607243192")
-            .setError(Error.newBuilder().build())
-            .setHttpErrorMessage("httpErrorMessage1577303431")
-            .setHttpErrorStatusCode(0)
-            .setId(3355)
-            .setInsertTime("insertTime966165798")
-            .setKind("kind3292052")
-            .setName("name3373707")
-            .setOperationType("operationType91999553")
-            .setProgress(-1001078227)
-            .setRegion("region-934795532")
-            .setSelfLink("selfLink1191800166")
-            .setStartTime("startTime-2129294769")
-            .setStatus(Status.DONE)
-            .setStatusMessage("statusMessage-958704715")
-            .setTargetId(-815576439)
-            .setTargetLink("targetLink486368555")
-            .setUser("user3599307")
-            .addAllWarnings(new ArrayList<Warnings>())
-            .setZone("zone3744684")
-            .build();
-    mockService.addResponse(expectedResponse);
-
-    String project = "project-6911";
-    String region = "region-9622";
-    Address addressResource = Address.newBuilder().build();
-
-    Operation actualResponse = client.insertAsync(project, region, addressResource).get();
-    Assert.assertEquals(expectedResponse, actualResponse);
-
-    List<String> actualRequests = mockService.getRequestPaths();
-    Assert.assertEquals(1, actualRequests.size());
-
-    String apiClientHeaderKey =
-        mockService
-            .getRequestHeaders()
-            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
-            .iterator()
-            .next();
-    Assert.assertTrue(
-        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
-            .matcher(apiClientHeaderKey)
-            .matches());
-  }
-
-  @Test
-  public void insertExceptionTest() throws Exception {
-    ApiException exception =
-        ApiExceptionFactory.createException(
-            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
-    mockService.addException(exception);
-
-    try {
-      String project = "project-6911";
-      String region = "region-9622";
-      Address addressResource = Address.newBuilder().build();
-      client.insertAsync(project, region, addressResource).get();
-      Assert.fail("No exception raised");
-    } catch (ExecutionException e) {
-    }
-  }
-
-  @Test
-  public void listTest() throws Exception {
-    Address responsesElement = Address.newBuilder().build();
-    AddressList expectedResponse =
-        AddressList.newBuilder()
-            .setNextPageToken("")
-            .addAllItems(Arrays.asList(responsesElement))
-            .build();
-    mockService.addResponse(expectedResponse);
-
-    String project = "project-6911";
-    String region = "region-9622";
-    String orderBy = "orderBy-1207110587";
-
-    ListPagedResponse pagedListResponse = client.list(project, region, orderBy);
-
-    List<Address> resources = Lists.newArrayList(pagedListResponse.iterateAll());
-
-    Assert.assertEquals(1, resources.size());
-    Assert.assertEquals(expectedResponse.getItemsList().get(0), resources.get(0));
-
-    List<String> actualRequests = mockService.getRequestPaths();
-    Assert.assertEquals(1, actualRequests.size());
-
-    String apiClientHeaderKey =
-        mockService
-            .getRequestHeaders()
-            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
-            .iterator()
-            .next();
-    Assert.assertTrue(
-        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
-            .matcher(apiClientHeaderKey)
-            .matches());
-  }
-
-  @Test
-  public void listExceptionTest() throws Exception {
-    ApiException exception =
-        ApiExceptionFactory.createException(
-            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
-    mockService.addException(exception);
-
-    try {
-      String project = "project-6911";
-      String region = "region-9622";
-      String orderBy = "orderBy-1207110587";
-      client.list(project, region, orderBy);
+      String operation = "operation-3971";
+      client.wait(project, region, operation);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/RegionOperationsSettings.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/RegionOperationsSettings.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1;
+package com.google.cloud.compute.v1small;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
@@ -27,7 +27,7 @@ import com.google.api.gax.rpc.ClientSettings;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.cloud.compute.v1.stub.RegionOperationsStubSettings;
+import com.google.cloud.compute.v1small.stub.RegionOperationsStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/gapic_metadata.json
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/gapic_metadata.json
@@ -2,8 +2,8 @@
   "schema": "1.0",
   "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
   "language": "java",
-  "protoPackage": "google.cloud.compute.v1",
-  "libraryPackage": "com.google.cloud.compute.v1",
+  "protoPackage": "google.cloud.compute.v1small",
+  "libraryPackage": "com.google.cloud.compute.v1small",
   "services": {
     "Addresses": {
       "clients": {

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/package-info.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/package-info.java
@@ -51,6 +51,6 @@
  * }</pre>
  */
 @Generated("by gapic-generator-java")
-package com.google.cloud.compute.v1;
+package com.google.cloud.compute.v1small;
 
 import javax.annotation.Generated;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/AddressesStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/AddressesStub.java
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
-import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
-import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.AggregatedListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.ListPagedResponse;
 
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.AddressAggregatedList;
-import com.google.cloud.compute.v1.AddressList;
-import com.google.cloud.compute.v1.AggregatedListAddressesRequest;
-import com.google.cloud.compute.v1.DeleteAddressRequest;
-import com.google.cloud.compute.v1.InsertAddressRequest;
-import com.google.cloud.compute.v1.ListAddressesRequest;
-import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1small.AddressAggregatedList;
+import com.google.cloud.compute.v1small.AddressList;
+import com.google.cloud.compute.v1small.AggregatedListAddressesRequest;
+import com.google.cloud.compute.v1small.DeleteAddressRequest;
+import com.google.cloud.compute.v1small.InsertAddressRequest;
+import com.google.cloud.compute.v1small.ListAddressesRequest;
+import com.google.cloud.compute.v1small.Operation;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
-import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
-import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.AggregatedListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.ListPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
@@ -45,15 +45,15 @@ import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.Address;
-import com.google.cloud.compute.v1.AddressAggregatedList;
-import com.google.cloud.compute.v1.AddressList;
-import com.google.cloud.compute.v1.AddressesScopedList;
-import com.google.cloud.compute.v1.AggregatedListAddressesRequest;
-import com.google.cloud.compute.v1.DeleteAddressRequest;
-import com.google.cloud.compute.v1.InsertAddressRequest;
-import com.google.cloud.compute.v1.ListAddressesRequest;
-import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1small.Address;
+import com.google.cloud.compute.v1small.AddressAggregatedList;
+import com.google.cloud.compute.v1small.AddressList;
+import com.google.cloud.compute.v1small.AddressesScopedList;
+import com.google.cloud.compute.v1small.AggregatedListAddressesRequest;
+import com.google.cloud.compute.v1small.DeleteAddressRequest;
+import com.google.cloud.compute.v1small.InsertAddressRequest;
+import com.google.cloud.compute.v1small.ListAddressesRequest;
+import com.google.cloud.compute.v1small.Operation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -498,13 +498,13 @@ public class AddressesStubSettings extends StubSettings<AddressesStubSettings> {
           .setPollingAlgorithm(
               OperationTimedPollAlgorithm.create(
                   RetrySettings.newBuilder()
-                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                      .setInitialRetryDelay(Duration.ofMillis(500L))
                       .setRetryDelayMultiplier(1.5)
-                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                      .setMaxRetryDelay(Duration.ofMillis(20000L))
                       .setInitialRpcTimeout(Duration.ZERO)
                       .setRpcTimeoutMultiplier(1.0)
                       .setMaxRpcTimeout(Duration.ZERO)
-                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .setTotalTimeout(Duration.ofMillis(600000L))
                       .build()));
 
       builder
@@ -522,13 +522,13 @@ public class AddressesStubSettings extends StubSettings<AddressesStubSettings> {
           .setPollingAlgorithm(
               OperationTimedPollAlgorithm.create(
                   RetrySettings.newBuilder()
-                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                      .setInitialRetryDelay(Duration.ofMillis(500L))
                       .setRetryDelayMultiplier(1.5)
-                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                      .setMaxRetryDelay(Duration.ofMillis(20000L))
                       .setInitialRpcTimeout(Duration.ZERO)
                       .setRpcTimeoutMultiplier(1.0)
                       .setMaxRpcTimeout(Duration.ZERO)
-                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .setTotalTimeout(Duration.ofMillis(600000L))
                       .build()));
 
       return builder;

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
 import com.google.api.gax.httpjson.HttpJsonOperationSnapshotCallable;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
-import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallSettings;
@@ -31,19 +30,19 @@ import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.longrunning.Operation;
+import com.google.cloud.compute.v1small.Operation;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
- * REST callable factory implementation for the RegionOperations service API.
+ * REST callable factory implementation for the Addresses service API.
  *
  * <p>This class is for advanced usage.
  */
 @Generated("by gapic-generator-java")
 @BetaApi
-public class HttpJsonRegionOperationsCallableFactory
-    implements HttpJsonStubCallableFactory<Operation, OperationsStub> {
+public class HttpJsonAddressesCallableFactory
+    implements HttpJsonStubCallableFactory<Operation, RegionOperationsStub> {
 
   @Override
   public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
@@ -81,7 +80,7 @@ public class HttpJsonRegionOperationsCallableFactory
           HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
           OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
           ClientContext clientContext,
-          OperationsStub operationsStub) {
+          RegionOperationsStub operationsStub) {
     UnaryCallable<RequestT, Operation> innerCallable =
         HttpJsonCallableFactory.createBaseUnaryCallable(
             httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
-import static com.google.cloud.compute.v1.AddressesClient.AggregatedListPagedResponse;
-import static com.google.cloud.compute.v1.AddressesClient.ListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.AggregatedListPagedResponse;
+import static com.google.cloud.compute.v1small.AddressesClient.ListPagedResponse;
 
 import com.google.api.client.http.HttpMethods;
 import com.google.api.core.BetaApi;
@@ -35,14 +35,14 @@ import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.AddressAggregatedList;
-import com.google.cloud.compute.v1.AddressList;
-import com.google.cloud.compute.v1.AggregatedListAddressesRequest;
-import com.google.cloud.compute.v1.DeleteAddressRequest;
-import com.google.cloud.compute.v1.InsertAddressRequest;
-import com.google.cloud.compute.v1.ListAddressesRequest;
-import com.google.cloud.compute.v1.Operation;
-import com.google.cloud.compute.v1.Operation.Status;
+import com.google.cloud.compute.v1small.AddressAggregatedList;
+import com.google.cloud.compute.v1small.AddressList;
+import com.google.cloud.compute.v1small.AggregatedListAddressesRequest;
+import com.google.cloud.compute.v1small.DeleteAddressRequest;
+import com.google.cloud.compute.v1small.InsertAddressRequest;
+import com.google.cloud.compute.v1small.ListAddressesRequest;
+import com.google.cloud.compute.v1small.Operation;
+import com.google.cloud.compute.v1small.Operation.Status;
 import com.google.protobuf.TypeRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -67,7 +67,7 @@ public class HttpJsonAddressesStub extends AddressesStub {
   private static final ApiMethodDescriptor<AggregatedListAddressesRequest, AddressAggregatedList>
       aggregatedListMethodDescriptor =
           ApiMethodDescriptor.<AggregatedListAddressesRequest, AddressAggregatedList>newBuilder()
-              .setFullMethodName("google.cloud.compute.v1.Addresses/AggregatedList")
+              .setFullMethodName("google.cloud.compute.v1small.Addresses/AggregatedList")
               .setHttpMethod(HttpMethods.GET)
               .setType(ApiMethodDescriptor.MethodType.UNARY)
               .setRequestFormatter(
@@ -116,7 +116,7 @@ public class HttpJsonAddressesStub extends AddressesStub {
 
   private static final ApiMethodDescriptor<DeleteAddressRequest, Operation> deleteMethodDescriptor =
       ApiMethodDescriptor.<DeleteAddressRequest, Operation>newBuilder()
-          .setFullMethodName("google.cloud.compute.v1.Addresses/Delete")
+          .setFullMethodName("google.cloud.compute.v1small.Addresses/Delete")
           .setHttpMethod(HttpMethods.DELETE)
           .setType(ApiMethodDescriptor.MethodType.UNARY)
           .setRequestFormatter(
@@ -166,7 +166,7 @@ public class HttpJsonAddressesStub extends AddressesStub {
 
   private static final ApiMethodDescriptor<InsertAddressRequest, Operation> insertMethodDescriptor =
       ApiMethodDescriptor.<InsertAddressRequest, Operation>newBuilder()
-          .setFullMethodName("google.cloud.compute.v1.Addresses/Insert")
+          .setFullMethodName("google.cloud.compute.v1small.Addresses/Insert")
           .setHttpMethod(HttpMethods.POST)
           .setType(ApiMethodDescriptor.MethodType.UNARY)
           .setRequestFormatter(
@@ -218,7 +218,7 @@ public class HttpJsonAddressesStub extends AddressesStub {
 
   private static final ApiMethodDescriptor<ListAddressesRequest, AddressList> listMethodDescriptor =
       ApiMethodDescriptor.<ListAddressesRequest, AddressList>newBuilder()
-          .setFullMethodName("google.cloud.compute.v1.Addresses/List")
+          .setFullMethodName("google.cloud.compute.v1small.Addresses/List")
           .setHttpMethod(HttpMethods.GET)
           .setType(ApiMethodDescriptor.MethodType.UNARY)
           .setRequestFormatter(

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.httpjson.HttpJsonCallSettings;
 import com.google.api.gax.httpjson.HttpJsonCallableFactory;
 import com.google.api.gax.httpjson.HttpJsonOperationSnapshotCallable;
 import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
+import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
 import com.google.api.gax.rpc.BatchingCallSettings;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallSettings;
@@ -30,19 +31,19 @@ import com.google.api.gax.rpc.ServerStreamingCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.Operation;
+import com.google.longrunning.Operation;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
- * REST callable factory implementation for the Addresses service API.
+ * REST callable factory implementation for the RegionOperations service API.
  *
  * <p>This class is for advanced usage.
  */
 @Generated("by gapic-generator-java")
 @BetaApi
-public class HttpJsonAddressesCallableFactory
-    implements HttpJsonStubCallableFactory<Operation, RegionOperationsStub> {
+public class HttpJsonRegionOperationsCallableFactory
+    implements HttpJsonStubCallableFactory<Operation, OperationsStub> {
 
   @Override
   public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
@@ -80,7 +81,7 @@ public class HttpJsonAddressesCallableFactory
           HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
           OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
           ClientContext clientContext,
-          RegionOperationsStub operationsStub) {
+          OperationsStub operationsStub) {
     UnaryCallable<RequestT, Operation> innerCallable =
         HttpJsonCallableFactory.createBaseUnaryCallable(
             httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
 import com.google.api.client.http.HttpMethods;
 import com.google.api.core.BetaApi;
@@ -33,10 +33,10 @@ import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.GetRegionOperationRequest;
-import com.google.cloud.compute.v1.Operation;
-import com.google.cloud.compute.v1.Operation.Status;
-import com.google.cloud.compute.v1.WaitRegionOperationRequest;
+import com.google.cloud.compute.v1small.GetRegionOperationRequest;
+import com.google.cloud.compute.v1small.Operation;
+import com.google.cloud.compute.v1small.Operation.Status;
+import com.google.cloud.compute.v1small.WaitRegionOperationRequest;
 import com.google.protobuf.TypeRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,7 +61,7 @@ public class HttpJsonRegionOperationsStub extends RegionOperationsStub {
   private static final ApiMethodDescriptor<GetRegionOperationRequest, Operation>
       getMethodDescriptor =
           ApiMethodDescriptor.<GetRegionOperationRequest, Operation>newBuilder()
-              .setFullMethodName("google.cloud.compute.v1.RegionOperations/Get")
+              .setFullMethodName("google.cloud.compute.v1small.RegionOperations/Get")
               .setHttpMethod(HttpMethods.GET)
               .setType(ApiMethodDescriptor.MethodType.UNARY)
               .setRequestFormatter(
@@ -116,7 +116,7 @@ public class HttpJsonRegionOperationsStub extends RegionOperationsStub {
   private static final ApiMethodDescriptor<WaitRegionOperationRequest, Operation>
       waitMethodDescriptor =
           ApiMethodDescriptor.<WaitRegionOperationRequest, Operation>newBuilder()
-              .setFullMethodName("google.cloud.compute.v1.RegionOperations/Wait")
+              .setFullMethodName("google.cloud.compute.v1small.RegionOperations/Wait")
               .setHttpMethod(HttpMethods.POST)
               .setType(ApiMethodDescriptor.MethodType.UNARY)
               .setRequestFormatter(

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.LongRunningClient;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.compute.v1.GetRegionOperationRequest;
-import com.google.cloud.compute.v1.Operation;
-import com.google.cloud.compute.v1.WaitRegionOperationRequest;
+import com.google.cloud.compute.v1small.GetRegionOperationRequest;
+import com.google.cloud.compute.v1small.Operation;
+import com.google.cloud.compute.v1small.WaitRegionOperationRequest;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.

--- a/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
+++ b/test/integration/goldens/compute/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.compute.v1.stub;
+package com.google.cloud.compute.v1small.stub;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
@@ -31,9 +31,9 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.cloud.compute.v1.GetRegionOperationRequest;
-import com.google.cloud.compute.v1.Operation;
-import com.google.cloud.compute.v1.WaitRegionOperationRequest;
+import com.google.cloud.compute.v1small.GetRegionOperationRequest;
+import com.google.cloud.compute.v1small.Operation;
+import com.google.cloud.compute.v1small.WaitRegionOperationRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -195,7 +195,8 @@ public class RegionOperationsStubSettings extends StubSettings<RegionOperationsS
           ImmutableSet.copyOf(
               Lists.<StatusCode.Code>newArrayList(
                   StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
-      definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      definitions.put(
+          "no_retry_1_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
     }
 
@@ -215,8 +216,14 @@ public class RegionOperationsStubSettings extends StubSettings<RegionOperationsS
               .setTotalTimeout(Duration.ofMillis(600000L))
               .build();
       definitions.put("retry_policy_0_params", settings);
-      settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
-      definitions.put("no_retry_params", settings);
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRpcTimeout(Duration.ofMillis(600000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(600000L))
+              .setTotalTimeout(Duration.ofMillis(600000L))
+              .build();
+      definitions.put("no_retry_1_params", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
 
@@ -266,8 +273,8 @@ public class RegionOperationsStubSettings extends StubSettings<RegionOperationsS
 
       builder
           .waitSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
-          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_1_params"));
 
       return builder;
     }


### PR DESCRIPTION
googleapis now has compute v1small, so no need to pull in googleapis_discovery.

error_prone is simply unused.

javax.validation is not used anywhere either. `git grep javax.validation` shows nothing.