### PR TITLE
chore: add test_suite for unit tests and fix minor build issues

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -96,7 +96,7 @@ fi
 if [ $NUM_JAVA_FILES_CHANGED -gt 0 ] || [ $NUM_UNIT_GOLDEN_FILES_CHANGED -gt 0 ]
 then
   echo_status "Checking unit tests..."
-  bazel --batch test units --disk_cache="$BAZEL_CACHE_DIR"
+  bazel --batch test //:units --disk_cache="$BAZEL_CACHE_DIR"
   TEST_STATUS=$?
   if [ $TEST_STATUS != 0 ]
   then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -96,7 +96,7 @@ fi
 if [ $NUM_JAVA_FILES_CHANGED -gt 0 ] || [ $NUM_UNIT_GOLDEN_FILES_CHANGED -gt 0 ]
 then
   echo_status "Checking unit tests..."
-  bazel --batch test $(bazel query //... | grep ^//:unit_) --disk_cache="$BAZEL_CACHE_DIR"
+  bazel --batch test units --disk_cache="$BAZEL_CACHE_DIR"
   TEST_STATUS=$?
   if [ $TEST_STATUS != 0 ]
   then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "The old one will disappear after 7 days."
 
       - name: Unit Tests
-        run: bazel --batch test $(bazel query //... | grep ^//:unit_) --noshow_progress --test_output=errors
+        run: bazel --batch test units --noshow_progress --test_output=errors
 
       - name: Integration Tests
         run: bazel --batch test //test/integration/...
@@ -87,7 +87,7 @@ jobs:
 
       - name: Generate Code Coverage Report
         # Run only test targets, and not golden_update targets.
-        run: bazel coverage $(bazel query //... | grep ^//:unit_) --combined_report=lcov
+        run: bazel coverage units --combined_report=lcov
 
       - name: Upload Code Coverage Report
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "The old one will disappear after 7 days."
 
       - name: Unit Tests
-        run: bazel --batch test units --noshow_progress --test_output=errors
+        run: bazel --batch test //:units --noshow_progress --test_output=errors
 
       - name: Integration Tests
         run: bazel --batch test //test/integration/...
@@ -87,7 +87,7 @@ jobs:
 
       - name: Generate Code Coverage Report
         # Run only test targets, and not golden_update targets.
-        run: bazel coverage units --combined_report=lcov
+        run: bazel coverage //:units --combined_report=lcov
 
       - name: Upload Code Coverage Report
         uses: codecov/codecov-action@v2

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,7 +112,7 @@ java_binary(
 java_binary(
     name = "protoc-gen-code_generator_request_dumper",
     main_class = "com.google.api.generator.debug.CodeGeneratorRequestDumper",
-    runtime_deps = MAIN_DEPS_DEBUG_RUNTIME_ONLY,
+    runtime_deps = [":protoc-gen-java_gapic"] + MAIN_DEPS_DEBUG_RUNTIME_ONLY,
 )
 
 # A binary similar to protoc-gen-java_gapic but reads the CodeGeneratorRequest
@@ -125,7 +125,7 @@ java_binary(
 java_binary(
     name = "code_generator_request_file_to_gapic_main",
     main_class = "com.google.api.generator.debug.CodeGeneratorRequestFileToGapicMain",
-    runtime_deps = MAIN_DEPS_DEBUG_RUNTIME_ONLY,
+    runtime_deps = [":protoc-gen-java_gapic"] + MAIN_DEPS_DEBUG_RUNTIME_ONLY,
 )
 
 # another test resource
@@ -150,7 +150,10 @@ genrule(
         "src/test/java/**/*.golden",
         "src/test/resources/**",
     ]),
+    tags = ["small"],
 ) for file in glob(["src/test/java/**/*Test.java"])]
+
+test_suite(name = "units", tags = ["small"])
 
 # Tests that generate and save unit golden (.golden) files.
 GOLDEN_UPDATING_UNIT_TESTS = [

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,7 @@
     # that includes "java_gapic".
     java_gapic_library(
         name = "showcase_java_gapic",
-        srcs = ["//:showcase_proto_with_info"],
+        srcs = [":showcase_proto_with_info"],
         grpc_service_config = "showcase_grpc_service_config.json",
         test_deps = [
             ":showcase_java_grpc",
@@ -110,7 +110,7 @@
 -   Run all unit tests.
 
     ```sh
-    bazel test $(bazel query //... | grep ^//:unit_)
+    bazel test units
     ```
 
 -   Run a single unit test like `JavaCodeGeneratorTest.java`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,7 +110,7 @@
 -   Run all unit tests.
 
     ```sh
-    bazel test units
+    bazel test //:units
     ```
 
 -   Run a single unit test like `JavaCodeGeneratorTest.java`


### PR DESCRIPTION
Adds `test_suite(name = "units", ...)`, so now we can just do `bazel test units` to run all tests.

Also, in #919, I missed the project itself from the debug generator runtime classpath. This is fixed.