### PR TITLE
fix: Routing annotation was not recognized on parsing protos

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -59,9 +59,9 @@ def gapic_generator_java_repositories():
     _maybe(
         http_archive,
         name = "com_google_googleapis",
-        strip_prefix = "googleapis-0899ba0f4c053a4487ccf0b699df5f850e39a45f",
+        strip_prefix = "googleapis-44d6bef0ca6db8bba3fb324c8186e694bcc4829c",
         urls = [
-            "https://github.com/googleapis/googleapis/archive/0899ba0f4c053a4487ccf0b699df5f850e39a45f.zip",
+            "https://github.com/googleapis/googleapis/archive/44d6bef0ca6db8bba3fb324c8186e694bcc4829c.zip",
         ],
     )
 

--- a/src/main/java/com/google/api/generator/ProtoRegistry.java
+++ b/src/main/java/com/google/api/generator/ProtoRegistry.java
@@ -18,6 +18,7 @@ import com.google.api.AnnotationsProto;
 import com.google.api.ClientProto;
 import com.google.api.FieldBehaviorProto;
 import com.google.api.ResourceProto;
+import com.google.api.RoutingProto;
 import com.google.cloud.ExtendedOperationsProto;
 import com.google.longrunning.OperationsProto;
 import com.google.protobuf.ExtensionRegistry;
@@ -31,5 +32,6 @@ public class ProtoRegistry {
     ResourceProto.registerAllExtensions(extensionRegistry);
     FieldBehaviorProto.registerAllExtensions(extensionRegistry);
     ExtendedOperationsProto.registerAllExtensions(extensionRegistry);
+    RoutingProto.registerAllExtensions(extensionRegistry);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/SubscriberClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/SubscriberClientTest.golden
@@ -88,6 +88,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -147,6 +148,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -206,6 +208,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -265,6 +268,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -324,6 +328,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -373,6 +378,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -422,6 +428,7 @@ public class SubscriberClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .build();
     mockSubscriber.addResponse(expectedResponse);
 
@@ -939,6 +946,10 @@ public class SubscriberClientTest {
     StreamingPullResponse expectedResponse =
         StreamingPullResponse.newBuilder()
             .addAllReceivedMessages(new ArrayList<ReceivedMessage>())
+            .setAcknowlegeConfirmation(
+                StreamingPullResponse.AcknowledgeConfirmation.newBuilder().build())
+            .setModifyAckDeadlineConfirmation(
+                StreamingPullResponse.ModifyAckDeadlineConfirmation.newBuilder().build())
             .setSubscriptionProperties(
                 StreamingPullResponse.SubscriptionProperties.newBuilder().build())
             .build();

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -126,6 +126,15 @@ java_gapic_test(
     runtime_deps = ["@com_google_googleapis//google/iam/credentials/v1:credentials_java_gapic_test"],
 )
 
+# Bigtable API
+java_gapic_test(
+    name = "bigtable_java_gapic_test_suite",
+    test_classes = [
+        "com.google.cloud.bigtable.data.v2.BaseBigtableDataClientTest",
+    ],
+    runtime_deps = ["@com_google_googleapis//google/bigtable/v2:bigtable_java_gapic_test"],
+)
+
 # IAM (for a standalone mixed-in API).
 java_gapic_library(
     name = "iam_java_gapic",

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -32,6 +32,8 @@ API_GAPIC_TARGETS = {
     "library": "@com_google_googleapis//google/example/library/v1:library_java_gapic",
     # REGAPIC test.
     "compute": "@com_google_googleapis//google/cloud/compute/v1small:compute_small_java_gapic",
+    # Routing headers.
+    "bigtable": "@com_google_googleapis//google/bigtable/v2:bigtable_java_gapic",
 }
 
 [filegroup(

--- a/test/integration/goldens/bigtable/com/google/bigtable/v2/TableName.java
+++ b/test/integration/goldens/bigtable/com/google/bigtable/v2/TableName.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.bigtable.v2;
+
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+@Generated("by gapic-generator-java")
+public class TableName implements ResourceName {
+  private static final PathTemplate PROJECT_INSTANCE_TABLE =
+      PathTemplate.createWithoutUrlEncoding(
+          "projects/{project}/instances/{instance}/tables/{table}");
+  private volatile Map<String, String> fieldValuesMap;
+  private final String project;
+  private final String instance;
+  private final String table;
+
+  @Deprecated
+  protected TableName() {
+    project = null;
+    instance = null;
+    table = null;
+  }
+
+  private TableName(Builder builder) {
+    project = Preconditions.checkNotNull(builder.getProject());
+    instance = Preconditions.checkNotNull(builder.getInstance());
+    table = Preconditions.checkNotNull(builder.getTable());
+  }
+
+  public String getProject() {
+    return project;
+  }
+
+  public String getInstance() {
+    return instance;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static TableName of(String project, String instance, String table) {
+    return newBuilder().setProject(project).setInstance(instance).setTable(table).build();
+  }
+
+  public static String format(String project, String instance, String table) {
+    return newBuilder()
+        .setProject(project)
+        .setInstance(instance)
+        .setTable(table)
+        .build()
+        .toString();
+  }
+
+  public static TableName parse(String formattedString) {
+    if (formattedString.isEmpty()) {
+      return null;
+    }
+    Map<String, String> matchMap =
+        PROJECT_INSTANCE_TABLE.validatedMatch(
+            formattedString, "TableName.parse: formattedString not in valid format");
+    return of(matchMap.get("project"), matchMap.get("instance"), matchMap.get("table"));
+  }
+
+  public static List<TableName> parseList(List<String> formattedStrings) {
+    List<TableName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<TableName> values) {
+    List<String> list = new ArrayList<>(values.size());
+    for (TableName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PROJECT_INSTANCE_TABLE.matches(formattedString);
+  }
+
+  @Override
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          if (project != null) {
+            fieldMapBuilder.put("project", project);
+          }
+          if (instance != null) {
+            fieldMapBuilder.put("instance", instance);
+          }
+          if (table != null) {
+            fieldMapBuilder.put("table", table);
+          }
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return PROJECT_INSTANCE_TABLE.instantiate(
+        "project", project, "instance", instance, "table", table);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o != null || getClass() == o.getClass()) {
+      TableName that = ((TableName) o);
+      return Objects.equals(this.project, that.project)
+          && Objects.equals(this.instance, that.instance)
+          && Objects.equals(this.table, that.table);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= Objects.hashCode(project);
+    h *= 1000003;
+    h ^= Objects.hashCode(instance);
+    h *= 1000003;
+    h ^= Objects.hashCode(table);
+    return h;
+  }
+
+  /** Builder for projects/{project}/instances/{instance}/tables/{table}. */
+  public static class Builder {
+    private String project;
+    private String instance;
+    private String table;
+
+    protected Builder() {}
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getInstance() {
+      return instance;
+    }
+
+    public String getTable() {
+      return table;
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setInstance(String instance) {
+      this.instance = instance;
+      return this;
+    }
+
+    public Builder setTable(String table) {
+      this.table = table;
+      return this;
+    }
+
+    private Builder(TableName tableName) {
+      this.project = tableName.project;
+      this.instance = tableName.instance;
+      this.table = tableName.table;
+    }
+
+    public TableName build() {
+      return new TableName(this);
+    }
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
@@ -1,0 +1,997 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.bigtable.v2.TableName;
+import com.google.cloud.bigtable.data.v2.stub.BigtableStub;
+import com.google.cloud.bigtable.data.v2.stub.BigtableStubSettings;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Service Description: Service for reading from and writing to existing Bigtable tables.
+ *
+ * <p>This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+ *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+ *   ByteString rowKey = ByteString.EMPTY;
+ *   List<Mutation> mutations = new ArrayList<>();
+ *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the BaseBigtableDataClient object to clean up resources
+ * such as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of BaseBigtableDataSettings to
+ * create(). For example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * BaseBigtableDataSettings baseBigtableDataSettings =
+ *     BaseBigtableDataSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * BaseBigtableDataClient baseBigtableDataClient =
+ *     BaseBigtableDataClient.create(baseBigtableDataSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * BaseBigtableDataSettings baseBigtableDataSettings =
+ *     BaseBigtableDataSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * BaseBigtableDataClient baseBigtableDataClient =
+ *     BaseBigtableDataClient.create(baseBigtableDataSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ */
+@Generated("by gapic-generator-java")
+public class BaseBigtableDataClient implements BackgroundResource {
+  private final BaseBigtableDataSettings settings;
+  private final BigtableStub stub;
+
+  /** Constructs an instance of BaseBigtableDataClient with default settings. */
+  public static final BaseBigtableDataClient create() throws IOException {
+    return create(BaseBigtableDataSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of BaseBigtableDataClient, using the given settings. The channels are
+   * created based on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final BaseBigtableDataClient create(BaseBigtableDataSettings settings)
+      throws IOException {
+    return new BaseBigtableDataClient(settings);
+  }
+
+  /**
+   * Constructs an instance of BaseBigtableDataClient, using the given stub for making calls. This
+   * is for advanced usage - prefer using create(BaseBigtableDataSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final BaseBigtableDataClient create(BigtableStub stub) {
+    return new BaseBigtableDataClient(stub);
+  }
+
+  /**
+   * Constructs an instance of BaseBigtableDataClient, using the given settings. This is protected
+   * so that it is easy to make a subclass, but otherwise, the static factory methods should be
+   * preferred.
+   */
+  protected BaseBigtableDataClient(BaseBigtableDataSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((BigtableStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected BaseBigtableDataClient(BigtableStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final BaseBigtableDataSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public BigtableStub getStub() {
+    return stub;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Streams back the contents of all requested rows in key order, optionally applying the same
+   * Reader filter to each. Depending on their size, rows and cells may be broken up across multiple
+   * responses, but atomicity of each row will still be preserved. See the ReadRowsResponse
+   * documentation for details.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   ReadRowsRequest request =
+   *       ReadRowsRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRows(RowSet.newBuilder().build())
+   *           .setFilter(RowFilter.newBuilder().build())
+   *           .setRowsLimit(-944199211)
+   *           .build();
+   *   ServerStream<ReadRowsResponse> stream =
+   *       baseBigtableDataClient.readRowsCallable().call(request);
+   *   for (ReadRowsResponse response : stream) {
+   *     // Do something when a response is received.
+   *   }
+   * }
+   * }</pre>
+   */
+  public final ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
+    return stub.readRowsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Returns a sample of row keys in the table. The returned row keys will delimit contiguous
+   * sections of the table of approximately equal size, which can be used to break up the data for
+   * distributed tasks like mapreduces.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   SampleRowKeysRequest request =
+   *       SampleRowKeysRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .build();
+   *   ServerStream<SampleRowKeysResponse> stream =
+   *       baseBigtableDataClient.sampleRowKeysCallable().call(request);
+   *   for (SampleRowKeysResponse response : stream) {
+   *     // Do something when a response is received.
+   *   }
+   * }
+   * }</pre>
+   */
+  public final ServerStreamingCallable<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysCallable() {
+    return stub.sampleRowKeysCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly
+   * changed by `mutation`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<Mutation> mutations = new ArrayList<>();
+   *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the mutation should be
+   *     applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the mutation should be applied.
+   * @param mutations Required. Changes to be atomically applied to the specified row. Entries are
+   *     applied in order, meaning that earlier mutations can be masked by later ones. Must contain
+   *     at least one entry and at most 100000.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MutateRowResponse mutateRow(
+      TableName tableName, ByteString rowKey, List<Mutation> mutations) {
+    MutateRowRequest request =
+        MutateRowRequest.newBuilder()
+            .setTableName(tableName == null ? null : tableName.toString())
+            .setRowKey(rowKey)
+            .addAllMutations(mutations)
+            .build();
+    return mutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly
+   * changed by `mutation`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   String tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<Mutation> mutations = new ArrayList<>();
+   *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the mutation should be
+   *     applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the mutation should be applied.
+   * @param mutations Required. Changes to be atomically applied to the specified row. Entries are
+   *     applied in order, meaning that earlier mutations can be masked by later ones. Must contain
+   *     at least one entry and at most 100000.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MutateRowResponse mutateRow(
+      String tableName, ByteString rowKey, List<Mutation> mutations) {
+    MutateRowRequest request =
+        MutateRowRequest.newBuilder()
+            .setTableName(tableName)
+            .setRowKey(rowKey)
+            .addAllMutations(mutations)
+            .build();
+    return mutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly
+   * changed by `mutation`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<Mutation> mutations = new ArrayList<>();
+   *   String appProfileId = "appProfileId704923523";
+   *   MutateRowResponse response =
+   *       baseBigtableDataClient.mutateRow(tableName, rowKey, mutations, appProfileId);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the mutation should be
+   *     applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the mutation should be applied.
+   * @param mutations Required. Changes to be atomically applied to the specified row. Entries are
+   *     applied in order, meaning that earlier mutations can be masked by later ones. Must contain
+   *     at least one entry and at most 100000.
+   * @param appProfileId This value specifies routing for replication. If not specified, the
+   *     "default" application profile will be used.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MutateRowResponse mutateRow(
+      TableName tableName, ByteString rowKey, List<Mutation> mutations, String appProfileId) {
+    MutateRowRequest request =
+        MutateRowRequest.newBuilder()
+            .setTableName(tableName == null ? null : tableName.toString())
+            .setRowKey(rowKey)
+            .addAllMutations(mutations)
+            .setAppProfileId(appProfileId)
+            .build();
+    return mutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly
+   * changed by `mutation`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   String tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<Mutation> mutations = new ArrayList<>();
+   *   String appProfileId = "appProfileId704923523";
+   *   MutateRowResponse response =
+   *       baseBigtableDataClient.mutateRow(tableName, rowKey, mutations, appProfileId);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the mutation should be
+   *     applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the mutation should be applied.
+   * @param mutations Required. Changes to be atomically applied to the specified row. Entries are
+   *     applied in order, meaning that earlier mutations can be masked by later ones. Must contain
+   *     at least one entry and at most 100000.
+   * @param appProfileId This value specifies routing for replication. If not specified, the
+   *     "default" application profile will be used.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MutateRowResponse mutateRow(
+      String tableName, ByteString rowKey, List<Mutation> mutations, String appProfileId) {
+    MutateRowRequest request =
+        MutateRowRequest.newBuilder()
+            .setTableName(tableName)
+            .setRowKey(rowKey)
+            .addAllMutations(mutations)
+            .setAppProfileId(appProfileId)
+            .build();
+    return mutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly
+   * changed by `mutation`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   MutateRowRequest request =
+   *       MutateRowRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRowKey(ByteString.EMPTY)
+   *           .addAllMutations(new ArrayList<Mutation>())
+   *           .build();
+   *   MutateRowResponse response = baseBigtableDataClient.mutateRow(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final MutateRowResponse mutateRow(MutateRowRequest request) {
+    return mutateRowCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically. Cells already present in the row are left unchanged unless explicitly
+   * changed by `mutation`.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   MutateRowRequest request =
+   *       MutateRowRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRowKey(ByteString.EMPTY)
+   *           .addAllMutations(new ArrayList<Mutation>())
+   *           .build();
+   *   ApiFuture<MutateRowResponse> future =
+   *       baseBigtableDataClient.mutateRowCallable().futureCall(request);
+   *   // Do something.
+   *   MutateRowResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<MutateRowRequest, MutateRowResponse> mutateRowCallable() {
+    return stub.mutateRowCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates multiple rows in a batch. Each individual row is mutated atomically as in MutateRow,
+   * but the entire batch is not executed atomically.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   MutateRowsRequest request =
+   *       MutateRowsRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .addAllEntries(new ArrayList<MutateRowsRequest.Entry>())
+   *           .build();
+   *   ServerStream<MutateRowsResponse> stream =
+   *       baseBigtableDataClient.mutateRowsCallable().call(request);
+   *   for (MutateRowsResponse response : stream) {
+   *     // Do something when a response is received.
+   *   }
+   * }
+   * }</pre>
+   */
+  public final ServerStreamingCallable<MutateRowsRequest, MutateRowsResponse> mutateRowsCallable() {
+    return stub.mutateRowsCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   RowFilter predicateFilter = RowFilter.newBuilder().build();
+   *   List<Mutation> trueMutations = new ArrayList<>();
+   *   List<Mutation> falseMutations = new ArrayList<>();
+   *   CheckAndMutateRowResponse response =
+   *       baseBigtableDataClient.checkAndMutateRow(
+   *           tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the conditional mutation
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the conditional mutation should be applied.
+   * @param predicateFilter The filter to be applied to the contents of the specified row. Depending
+   *     on whether or not any results are yielded, either `true_mutations` or `false_mutations`
+   *     will be executed. If unset, checks that the row contains any values at all.
+   * @param trueMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` yields at least one cell when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `false_mutations` is empty, and at most 100000.
+   * @param falseMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` does not yield any cells when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `true_mutations` is empty, and at most 100000.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckAndMutateRowResponse checkAndMutateRow(
+      TableName tableName,
+      ByteString rowKey,
+      RowFilter predicateFilter,
+      List<Mutation> trueMutations,
+      List<Mutation> falseMutations) {
+    CheckAndMutateRowRequest request =
+        CheckAndMutateRowRequest.newBuilder()
+            .setTableName(tableName == null ? null : tableName.toString())
+            .setRowKey(rowKey)
+            .setPredicateFilter(predicateFilter)
+            .addAllTrueMutations(trueMutations)
+            .addAllFalseMutations(falseMutations)
+            .build();
+    return checkAndMutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   String tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   RowFilter predicateFilter = RowFilter.newBuilder().build();
+   *   List<Mutation> trueMutations = new ArrayList<>();
+   *   List<Mutation> falseMutations = new ArrayList<>();
+   *   CheckAndMutateRowResponse response =
+   *       baseBigtableDataClient.checkAndMutateRow(
+   *           tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the conditional mutation
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the conditional mutation should be applied.
+   * @param predicateFilter The filter to be applied to the contents of the specified row. Depending
+   *     on whether or not any results are yielded, either `true_mutations` or `false_mutations`
+   *     will be executed. If unset, checks that the row contains any values at all.
+   * @param trueMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` yields at least one cell when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `false_mutations` is empty, and at most 100000.
+   * @param falseMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` does not yield any cells when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `true_mutations` is empty, and at most 100000.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckAndMutateRowResponse checkAndMutateRow(
+      String tableName,
+      ByteString rowKey,
+      RowFilter predicateFilter,
+      List<Mutation> trueMutations,
+      List<Mutation> falseMutations) {
+    CheckAndMutateRowRequest request =
+        CheckAndMutateRowRequest.newBuilder()
+            .setTableName(tableName)
+            .setRowKey(rowKey)
+            .setPredicateFilter(predicateFilter)
+            .addAllTrueMutations(trueMutations)
+            .addAllFalseMutations(falseMutations)
+            .build();
+    return checkAndMutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   RowFilter predicateFilter = RowFilter.newBuilder().build();
+   *   List<Mutation> trueMutations = new ArrayList<>();
+   *   List<Mutation> falseMutations = new ArrayList<>();
+   *   String appProfileId = "appProfileId704923523";
+   *   CheckAndMutateRowResponse response =
+   *       baseBigtableDataClient.checkAndMutateRow(
+   *           tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the conditional mutation
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the conditional mutation should be applied.
+   * @param predicateFilter The filter to be applied to the contents of the specified row. Depending
+   *     on whether or not any results are yielded, either `true_mutations` or `false_mutations`
+   *     will be executed. If unset, checks that the row contains any values at all.
+   * @param trueMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` yields at least one cell when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `false_mutations` is empty, and at most 100000.
+   * @param falseMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` does not yield any cells when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `true_mutations` is empty, and at most 100000.
+   * @param appProfileId This value specifies routing for replication. If not specified, the
+   *     "default" application profile will be used.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckAndMutateRowResponse checkAndMutateRow(
+      TableName tableName,
+      ByteString rowKey,
+      RowFilter predicateFilter,
+      List<Mutation> trueMutations,
+      List<Mutation> falseMutations,
+      String appProfileId) {
+    CheckAndMutateRowRequest request =
+        CheckAndMutateRowRequest.newBuilder()
+            .setTableName(tableName == null ? null : tableName.toString())
+            .setRowKey(rowKey)
+            .setPredicateFilter(predicateFilter)
+            .addAllTrueMutations(trueMutations)
+            .addAllFalseMutations(falseMutations)
+            .setAppProfileId(appProfileId)
+            .build();
+    return checkAndMutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   String tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   RowFilter predicateFilter = RowFilter.newBuilder().build();
+   *   List<Mutation> trueMutations = new ArrayList<>();
+   *   List<Mutation> falseMutations = new ArrayList<>();
+   *   String appProfileId = "appProfileId704923523";
+   *   CheckAndMutateRowResponse response =
+   *       baseBigtableDataClient.checkAndMutateRow(
+   *           tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the conditional mutation
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the conditional mutation should be applied.
+   * @param predicateFilter The filter to be applied to the contents of the specified row. Depending
+   *     on whether or not any results are yielded, either `true_mutations` or `false_mutations`
+   *     will be executed. If unset, checks that the row contains any values at all.
+   * @param trueMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` yields at least one cell when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `false_mutations` is empty, and at most 100000.
+   * @param falseMutations Changes to be atomically applied to the specified row if
+   *     `predicate_filter` does not yield any cells when applied to `row_key`. Entries are applied
+   *     in order, meaning that earlier mutations can be masked by later ones. Must contain at least
+   *     one entry if `true_mutations` is empty, and at most 100000.
+   * @param appProfileId This value specifies routing for replication. If not specified, the
+   *     "default" application profile will be used.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckAndMutateRowResponse checkAndMutateRow(
+      String tableName,
+      ByteString rowKey,
+      RowFilter predicateFilter,
+      List<Mutation> trueMutations,
+      List<Mutation> falseMutations,
+      String appProfileId) {
+    CheckAndMutateRowRequest request =
+        CheckAndMutateRowRequest.newBuilder()
+            .setTableName(tableName)
+            .setRowKey(rowKey)
+            .setPredicateFilter(predicateFilter)
+            .addAllTrueMutations(trueMutations)
+            .addAllFalseMutations(falseMutations)
+            .setAppProfileId(appProfileId)
+            .build();
+    return checkAndMutateRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   CheckAndMutateRowRequest request =
+   *       CheckAndMutateRowRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRowKey(ByteString.EMPTY)
+   *           .setPredicateFilter(RowFilter.newBuilder().build())
+   *           .addAllTrueMutations(new ArrayList<Mutation>())
+   *           .addAllFalseMutations(new ArrayList<Mutation>())
+   *           .build();
+   *   CheckAndMutateRowResponse response = baseBigtableDataClient.checkAndMutateRow(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final CheckAndMutateRowResponse checkAndMutateRow(CheckAndMutateRowRequest request) {
+    return checkAndMutateRowCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   CheckAndMutateRowRequest request =
+   *       CheckAndMutateRowRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRowKey(ByteString.EMPTY)
+   *           .setPredicateFilter(RowFilter.newBuilder().build())
+   *           .addAllTrueMutations(new ArrayList<Mutation>())
+   *           .addAllFalseMutations(new ArrayList<Mutation>())
+   *           .build();
+   *   ApiFuture<CheckAndMutateRowResponse> future =
+   *       baseBigtableDataClient.checkAndMutateRowCallable().futureCall(request);
+   *   // Do something.
+   *   CheckAndMutateRowResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowCallable() {
+    return stub.checkAndMutateRowCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Modifies a row atomically on the server. The method reads the latest existing timestamp and
+   * value from the specified columns and writes a new entry based on pre-defined read/modify/write
+   * rules. The new value for the timestamp is the greater of the existing timestamp or the current
+   * server time. The method returns the new contents of all modified cells.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<ReadModifyWriteRule> rules = new ArrayList<>();
+   *   ReadModifyWriteRowResponse response =
+   *       baseBigtableDataClient.readModifyWriteRow(tableName, rowKey, rules);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the read/modify/write rules
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the read/modify/write rules should be
+   *     applied.
+   * @param rules Required. Rules specifying how the specified row's contents are to be transformed
+   *     into writes. Entries are applied in order, meaning that earlier rules will affect the
+   *     results of later ones.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ReadModifyWriteRowResponse readModifyWriteRow(
+      TableName tableName, ByteString rowKey, List<ReadModifyWriteRule> rules) {
+    ReadModifyWriteRowRequest request =
+        ReadModifyWriteRowRequest.newBuilder()
+            .setTableName(tableName == null ? null : tableName.toString())
+            .setRowKey(rowKey)
+            .addAllRules(rules)
+            .build();
+    return readModifyWriteRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Modifies a row atomically on the server. The method reads the latest existing timestamp and
+   * value from the specified columns and writes a new entry based on pre-defined read/modify/write
+   * rules. The new value for the timestamp is the greater of the existing timestamp or the current
+   * server time. The method returns the new contents of all modified cells.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   String tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<ReadModifyWriteRule> rules = new ArrayList<>();
+   *   ReadModifyWriteRowResponse response =
+   *       baseBigtableDataClient.readModifyWriteRow(tableName, rowKey, rules);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the read/modify/write rules
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the read/modify/write rules should be
+   *     applied.
+   * @param rules Required. Rules specifying how the specified row's contents are to be transformed
+   *     into writes. Entries are applied in order, meaning that earlier rules will affect the
+   *     results of later ones.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ReadModifyWriteRowResponse readModifyWriteRow(
+      String tableName, ByteString rowKey, List<ReadModifyWriteRule> rules) {
+    ReadModifyWriteRowRequest request =
+        ReadModifyWriteRowRequest.newBuilder()
+            .setTableName(tableName)
+            .setRowKey(rowKey)
+            .addAllRules(rules)
+            .build();
+    return readModifyWriteRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Modifies a row atomically on the server. The method reads the latest existing timestamp and
+   * value from the specified columns and writes a new entry based on pre-defined read/modify/write
+   * rules. The new value for the timestamp is the greater of the existing timestamp or the current
+   * server time. The method returns the new contents of all modified cells.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<ReadModifyWriteRule> rules = new ArrayList<>();
+   *   String appProfileId = "appProfileId704923523";
+   *   ReadModifyWriteRowResponse response =
+   *       baseBigtableDataClient.readModifyWriteRow(tableName, rowKey, rules, appProfileId);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the read/modify/write rules
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the read/modify/write rules should be
+   *     applied.
+   * @param rules Required. Rules specifying how the specified row's contents are to be transformed
+   *     into writes. Entries are applied in order, meaning that earlier rules will affect the
+   *     results of later ones.
+   * @param appProfileId This value specifies routing for replication. If not specified, the
+   *     "default" application profile will be used.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ReadModifyWriteRowResponse readModifyWriteRow(
+      TableName tableName,
+      ByteString rowKey,
+      List<ReadModifyWriteRule> rules,
+      String appProfileId) {
+    ReadModifyWriteRowRequest request =
+        ReadModifyWriteRowRequest.newBuilder()
+            .setTableName(tableName == null ? null : tableName.toString())
+            .setRowKey(rowKey)
+            .addAllRules(rules)
+            .setAppProfileId(appProfileId)
+            .build();
+    return readModifyWriteRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Modifies a row atomically on the server. The method reads the latest existing timestamp and
+   * value from the specified columns and writes a new entry based on pre-defined read/modify/write
+   * rules. The new value for the timestamp is the greater of the existing timestamp or the current
+   * server time. The method returns the new contents of all modified cells.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   String tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString();
+   *   ByteString rowKey = ByteString.EMPTY;
+   *   List<ReadModifyWriteRule> rules = new ArrayList<>();
+   *   String appProfileId = "appProfileId704923523";
+   *   ReadModifyWriteRowResponse response =
+   *       baseBigtableDataClient.readModifyWriteRow(tableName, rowKey, rules, appProfileId);
+   * }
+   * }</pre>
+   *
+   * @param tableName Required. The unique name of the table to which the read/modify/write rules
+   *     should be applied. Values are of the form
+   *     `projects/&lt;project&gt;/instances/&lt;instance&gt;/tables/&lt;table&gt;`.
+   * @param rowKey Required. The key of the row to which the read/modify/write rules should be
+   *     applied.
+   * @param rules Required. Rules specifying how the specified row's contents are to be transformed
+   *     into writes. Entries are applied in order, meaning that earlier rules will affect the
+   *     results of later ones.
+   * @param appProfileId This value specifies routing for replication. If not specified, the
+   *     "default" application profile will be used.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ReadModifyWriteRowResponse readModifyWriteRow(
+      String tableName, ByteString rowKey, List<ReadModifyWriteRule> rules, String appProfileId) {
+    ReadModifyWriteRowRequest request =
+        ReadModifyWriteRowRequest.newBuilder()
+            .setTableName(tableName)
+            .setRowKey(rowKey)
+            .addAllRules(rules)
+            .setAppProfileId(appProfileId)
+            .build();
+    return readModifyWriteRow(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Modifies a row atomically on the server. The method reads the latest existing timestamp and
+   * value from the specified columns and writes a new entry based on pre-defined read/modify/write
+   * rules. The new value for the timestamp is the greater of the existing timestamp or the current
+   * server time. The method returns the new contents of all modified cells.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   ReadModifyWriteRowRequest request =
+   *       ReadModifyWriteRowRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRowKey(ByteString.EMPTY)
+   *           .addAllRules(new ArrayList<ReadModifyWriteRule>())
+   *           .build();
+   *   ReadModifyWriteRowResponse response = baseBigtableDataClient.readModifyWriteRow(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final ReadModifyWriteRowResponse readModifyWriteRow(ReadModifyWriteRowRequest request) {
+    return readModifyWriteRowCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Modifies a row atomically on the server. The method reads the latest existing timestamp and
+   * value from the specified columns and writes a new entry based on pre-defined read/modify/write
+   * rules. The new value for the timestamp is the greater of the existing timestamp or the current
+   * server time. The method returns the new contents of all modified cells.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+   *   ReadModifyWriteRowRequest request =
+   *       ReadModifyWriteRowRequest.newBuilder()
+   *           .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+   *           .setAppProfileId("appProfileId704923523")
+   *           .setRowKey(ByteString.EMPTY)
+   *           .addAllRules(new ArrayList<ReadModifyWriteRule>())
+   *           .build();
+   *   ApiFuture<ReadModifyWriteRowResponse> future =
+   *       baseBigtableDataClient.readModifyWriteRowCallable().futureCall(request);
+   *   // Do something.
+   *   ReadModifyWriteRowResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowCallable() {
+    return stub.readModifyWriteRowCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/BaseBigtableDataClientTest.java
@@ -1,0 +1,811 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.grpc.testing.MockStreamObserver;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadModifyWriteRule;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.Row;
+import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.RowSet;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.bigtable.v2.TableName;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.ByteString;
+import io.grpc.StatusRuntimeException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Generated;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@Generated("by gapic-generator-java")
+public class BaseBigtableDataClientTest {
+  private static MockBigtable mockBigtable;
+  private static MockServiceHelper mockServiceHelper;
+  private LocalChannelProvider channelProvider;
+  private BaseBigtableDataClient client;
+
+  @BeforeClass
+  public static void startStaticServer() {
+    mockBigtable = new MockBigtable();
+    mockServiceHelper =
+        new MockServiceHelper(
+            UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockBigtable));
+    mockServiceHelper.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    mockServiceHelper.stop();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    mockServiceHelper.reset();
+    channelProvider = mockServiceHelper.createChannelProvider();
+    BaseBigtableDataSettings settings =
+        BaseBigtableDataSettings.newBuilder()
+            .setTransportChannelProvider(channelProvider)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build();
+    client = BaseBigtableDataClient.create(settings);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+  }
+
+  @Test
+  public void readRowsTest() throws Exception {
+    ReadRowsResponse expectedResponse =
+        ReadRowsResponse.newBuilder()
+            .addAllChunks(new ArrayList<ReadRowsResponse.CellChunk>())
+            .setLastScannedRowKey(ByteString.EMPTY)
+            .build();
+    mockBigtable.addResponse(expectedResponse);
+    ReadRowsRequest request =
+        ReadRowsRequest.newBuilder()
+            .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+            .setAppProfileId("appProfileId704923523")
+            .setRows(RowSet.newBuilder().build())
+            .setFilter(RowFilter.newBuilder().build())
+            .setRowsLimit(-944199211)
+            .build();
+
+    MockStreamObserver<ReadRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> callable = client.readRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    List<ReadRowsResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  public void readRowsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+    ReadRowsRequest request =
+        ReadRowsRequest.newBuilder()
+            .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+            .setAppProfileId("appProfileId704923523")
+            .setRows(RowSet.newBuilder().build())
+            .setFilter(RowFilter.newBuilder().build())
+            .setRowsLimit(-944199211)
+            .build();
+
+    MockStreamObserver<ReadRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> callable = client.readRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<ReadRowsResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void sampleRowKeysTest() throws Exception {
+    SampleRowKeysResponse expectedResponse =
+        SampleRowKeysResponse.newBuilder()
+            .setRowKey(ByteString.EMPTY)
+            .setOffsetBytes(889884095)
+            .build();
+    mockBigtable.addResponse(expectedResponse);
+    SampleRowKeysRequest request =
+        SampleRowKeysRequest.newBuilder()
+            .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+            .setAppProfileId("appProfileId704923523")
+            .build();
+
+    MockStreamObserver<SampleRowKeysResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<SampleRowKeysRequest, SampleRowKeysResponse> callable =
+        client.sampleRowKeysCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    List<SampleRowKeysResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  public void sampleRowKeysExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+    SampleRowKeysRequest request =
+        SampleRowKeysRequest.newBuilder()
+            .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+            .setAppProfileId("appProfileId704923523")
+            .build();
+
+    MockStreamObserver<SampleRowKeysResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<SampleRowKeysRequest, SampleRowKeysResponse> callable =
+        client.sampleRowKeysCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<SampleRowKeysResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void mutateRowTest() throws Exception {
+    MutateRowResponse expectedResponse = MutateRowResponse.newBuilder().build();
+    mockBigtable.addResponse(expectedResponse);
+
+    TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    ByteString rowKey = ByteString.EMPTY;
+    List<Mutation> mutations = new ArrayList<>();
+
+    MutateRowResponse actualResponse = client.mutateRow(tableName, rowKey, mutations);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MutateRowRequest actualRequest = ((MutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName.toString(), actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(mutations, actualRequest.getMutationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void mutateRowExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      ByteString rowKey = ByteString.EMPTY;
+      List<Mutation> mutations = new ArrayList<>();
+      client.mutateRow(tableName, rowKey, mutations);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void mutateRowTest2() throws Exception {
+    MutateRowResponse expectedResponse = MutateRowResponse.newBuilder().build();
+    mockBigtable.addResponse(expectedResponse);
+
+    String tableName = "tableName-1988717703";
+    ByteString rowKey = ByteString.EMPTY;
+    List<Mutation> mutations = new ArrayList<>();
+
+    MutateRowResponse actualResponse = client.mutateRow(tableName, rowKey, mutations);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MutateRowRequest actualRequest = ((MutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName, actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(mutations, actualRequest.getMutationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void mutateRowExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      String tableName = "tableName-1988717703";
+      ByteString rowKey = ByteString.EMPTY;
+      List<Mutation> mutations = new ArrayList<>();
+      client.mutateRow(tableName, rowKey, mutations);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void mutateRowTest3() throws Exception {
+    MutateRowResponse expectedResponse = MutateRowResponse.newBuilder().build();
+    mockBigtable.addResponse(expectedResponse);
+
+    TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    ByteString rowKey = ByteString.EMPTY;
+    List<Mutation> mutations = new ArrayList<>();
+    String appProfileId = "appProfileId704923523";
+
+    MutateRowResponse actualResponse = client.mutateRow(tableName, rowKey, mutations, appProfileId);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MutateRowRequest actualRequest = ((MutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName.toString(), actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(mutations, actualRequest.getMutationsList());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void mutateRowExceptionTest3() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      ByteString rowKey = ByteString.EMPTY;
+      List<Mutation> mutations = new ArrayList<>();
+      String appProfileId = "appProfileId704923523";
+      client.mutateRow(tableName, rowKey, mutations, appProfileId);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void mutateRowTest4() throws Exception {
+    MutateRowResponse expectedResponse = MutateRowResponse.newBuilder().build();
+    mockBigtable.addResponse(expectedResponse);
+
+    String tableName = "tableName-1988717703";
+    ByteString rowKey = ByteString.EMPTY;
+    List<Mutation> mutations = new ArrayList<>();
+    String appProfileId = "appProfileId704923523";
+
+    MutateRowResponse actualResponse = client.mutateRow(tableName, rowKey, mutations, appProfileId);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MutateRowRequest actualRequest = ((MutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName, actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(mutations, actualRequest.getMutationsList());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void mutateRowExceptionTest4() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      String tableName = "tableName-1988717703";
+      ByteString rowKey = ByteString.EMPTY;
+      List<Mutation> mutations = new ArrayList<>();
+      String appProfileId = "appProfileId704923523";
+      client.mutateRow(tableName, rowKey, mutations, appProfileId);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void mutateRowsTest() throws Exception {
+    MutateRowsResponse expectedResponse =
+        MutateRowsResponse.newBuilder()
+            .addAllEntries(new ArrayList<MutateRowsResponse.Entry>())
+            .build();
+    mockBigtable.addResponse(expectedResponse);
+    MutateRowsRequest request =
+        MutateRowsRequest.newBuilder()
+            .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+            .setAppProfileId("appProfileId704923523")
+            .addAllEntries(new ArrayList<MutateRowsRequest.Entry>())
+            .build();
+
+    MockStreamObserver<MutateRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<MutateRowsRequest, MutateRowsResponse> callable =
+        client.mutateRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    List<MutateRowsResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  public void mutateRowsExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+    MutateRowsRequest request =
+        MutateRowsRequest.newBuilder()
+            .setTableName(TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]").toString())
+            .setAppProfileId("appProfileId704923523")
+            .addAllEntries(new ArrayList<MutateRowsRequest.Entry>())
+            .build();
+
+    MockStreamObserver<MutateRowsResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<MutateRowsRequest, MutateRowsResponse> callable =
+        client.mutateRowsCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<MutateRowsResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void checkAndMutateRowTest() throws Exception {
+    CheckAndMutateRowResponse expectedResponse =
+        CheckAndMutateRowResponse.newBuilder().setPredicateMatched(true).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    ByteString rowKey = ByteString.EMPTY;
+    RowFilter predicateFilter = RowFilter.newBuilder().build();
+    List<Mutation> trueMutations = new ArrayList<>();
+    List<Mutation> falseMutations = new ArrayList<>();
+
+    CheckAndMutateRowResponse actualResponse =
+        client.checkAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CheckAndMutateRowRequest actualRequest = ((CheckAndMutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName.toString(), actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(predicateFilter, actualRequest.getPredicateFilter());
+    Assert.assertEquals(trueMutations, actualRequest.getTrueMutationsList());
+    Assert.assertEquals(falseMutations, actualRequest.getFalseMutationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void checkAndMutateRowExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      ByteString rowKey = ByteString.EMPTY;
+      RowFilter predicateFilter = RowFilter.newBuilder().build();
+      List<Mutation> trueMutations = new ArrayList<>();
+      List<Mutation> falseMutations = new ArrayList<>();
+      client.checkAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void checkAndMutateRowTest2() throws Exception {
+    CheckAndMutateRowResponse expectedResponse =
+        CheckAndMutateRowResponse.newBuilder().setPredicateMatched(true).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    String tableName = "tableName-1988717703";
+    ByteString rowKey = ByteString.EMPTY;
+    RowFilter predicateFilter = RowFilter.newBuilder().build();
+    List<Mutation> trueMutations = new ArrayList<>();
+    List<Mutation> falseMutations = new ArrayList<>();
+
+    CheckAndMutateRowResponse actualResponse =
+        client.checkAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CheckAndMutateRowRequest actualRequest = ((CheckAndMutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName, actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(predicateFilter, actualRequest.getPredicateFilter());
+    Assert.assertEquals(trueMutations, actualRequest.getTrueMutationsList());
+    Assert.assertEquals(falseMutations, actualRequest.getFalseMutationsList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void checkAndMutateRowExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      String tableName = "tableName-1988717703";
+      ByteString rowKey = ByteString.EMPTY;
+      RowFilter predicateFilter = RowFilter.newBuilder().build();
+      List<Mutation> trueMutations = new ArrayList<>();
+      List<Mutation> falseMutations = new ArrayList<>();
+      client.checkAndMutateRow(tableName, rowKey, predicateFilter, trueMutations, falseMutations);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void checkAndMutateRowTest3() throws Exception {
+    CheckAndMutateRowResponse expectedResponse =
+        CheckAndMutateRowResponse.newBuilder().setPredicateMatched(true).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    ByteString rowKey = ByteString.EMPTY;
+    RowFilter predicateFilter = RowFilter.newBuilder().build();
+    List<Mutation> trueMutations = new ArrayList<>();
+    List<Mutation> falseMutations = new ArrayList<>();
+    String appProfileId = "appProfileId704923523";
+
+    CheckAndMutateRowResponse actualResponse =
+        client.checkAndMutateRow(
+            tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CheckAndMutateRowRequest actualRequest = ((CheckAndMutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName.toString(), actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(predicateFilter, actualRequest.getPredicateFilter());
+    Assert.assertEquals(trueMutations, actualRequest.getTrueMutationsList());
+    Assert.assertEquals(falseMutations, actualRequest.getFalseMutationsList());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void checkAndMutateRowExceptionTest3() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      ByteString rowKey = ByteString.EMPTY;
+      RowFilter predicateFilter = RowFilter.newBuilder().build();
+      List<Mutation> trueMutations = new ArrayList<>();
+      List<Mutation> falseMutations = new ArrayList<>();
+      String appProfileId = "appProfileId704923523";
+      client.checkAndMutateRow(
+          tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void checkAndMutateRowTest4() throws Exception {
+    CheckAndMutateRowResponse expectedResponse =
+        CheckAndMutateRowResponse.newBuilder().setPredicateMatched(true).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    String tableName = "tableName-1988717703";
+    ByteString rowKey = ByteString.EMPTY;
+    RowFilter predicateFilter = RowFilter.newBuilder().build();
+    List<Mutation> trueMutations = new ArrayList<>();
+    List<Mutation> falseMutations = new ArrayList<>();
+    String appProfileId = "appProfileId704923523";
+
+    CheckAndMutateRowResponse actualResponse =
+        client.checkAndMutateRow(
+            tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CheckAndMutateRowRequest actualRequest = ((CheckAndMutateRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName, actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(predicateFilter, actualRequest.getPredicateFilter());
+    Assert.assertEquals(trueMutations, actualRequest.getTrueMutationsList());
+    Assert.assertEquals(falseMutations, actualRequest.getFalseMutationsList());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void checkAndMutateRowExceptionTest4() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      String tableName = "tableName-1988717703";
+      ByteString rowKey = ByteString.EMPTY;
+      RowFilter predicateFilter = RowFilter.newBuilder().build();
+      List<Mutation> trueMutations = new ArrayList<>();
+      List<Mutation> falseMutations = new ArrayList<>();
+      String appProfileId = "appProfileId704923523";
+      client.checkAndMutateRow(
+          tableName, rowKey, predicateFilter, trueMutations, falseMutations, appProfileId);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void readModifyWriteRowTest() throws Exception {
+    ReadModifyWriteRowResponse expectedResponse =
+        ReadModifyWriteRowResponse.newBuilder().setRow(Row.newBuilder().build()).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    ByteString rowKey = ByteString.EMPTY;
+    List<ReadModifyWriteRule> rules = new ArrayList<>();
+
+    ReadModifyWriteRowResponse actualResponse = client.readModifyWriteRow(tableName, rowKey, rules);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ReadModifyWriteRowRequest actualRequest = ((ReadModifyWriteRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName.toString(), actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(rules, actualRequest.getRulesList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void readModifyWriteRowExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      ByteString rowKey = ByteString.EMPTY;
+      List<ReadModifyWriteRule> rules = new ArrayList<>();
+      client.readModifyWriteRow(tableName, rowKey, rules);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void readModifyWriteRowTest2() throws Exception {
+    ReadModifyWriteRowResponse expectedResponse =
+        ReadModifyWriteRowResponse.newBuilder().setRow(Row.newBuilder().build()).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    String tableName = "tableName-1988717703";
+    ByteString rowKey = ByteString.EMPTY;
+    List<ReadModifyWriteRule> rules = new ArrayList<>();
+
+    ReadModifyWriteRowResponse actualResponse = client.readModifyWriteRow(tableName, rowKey, rules);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ReadModifyWriteRowRequest actualRequest = ((ReadModifyWriteRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName, actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(rules, actualRequest.getRulesList());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void readModifyWriteRowExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      String tableName = "tableName-1988717703";
+      ByteString rowKey = ByteString.EMPTY;
+      List<ReadModifyWriteRule> rules = new ArrayList<>();
+      client.readModifyWriteRow(tableName, rowKey, rules);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void readModifyWriteRowTest3() throws Exception {
+    ReadModifyWriteRowResponse expectedResponse =
+        ReadModifyWriteRowResponse.newBuilder().setRow(Row.newBuilder().build()).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+    ByteString rowKey = ByteString.EMPTY;
+    List<ReadModifyWriteRule> rules = new ArrayList<>();
+    String appProfileId = "appProfileId704923523";
+
+    ReadModifyWriteRowResponse actualResponse =
+        client.readModifyWriteRow(tableName, rowKey, rules, appProfileId);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ReadModifyWriteRowRequest actualRequest = ((ReadModifyWriteRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName.toString(), actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(rules, actualRequest.getRulesList());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void readModifyWriteRowExceptionTest3() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+      ByteString rowKey = ByteString.EMPTY;
+      List<ReadModifyWriteRule> rules = new ArrayList<>();
+      String appProfileId = "appProfileId704923523";
+      client.readModifyWriteRow(tableName, rowKey, rules, appProfileId);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void readModifyWriteRowTest4() throws Exception {
+    ReadModifyWriteRowResponse expectedResponse =
+        ReadModifyWriteRowResponse.newBuilder().setRow(Row.newBuilder().build()).build();
+    mockBigtable.addResponse(expectedResponse);
+
+    String tableName = "tableName-1988717703";
+    ByteString rowKey = ByteString.EMPTY;
+    List<ReadModifyWriteRule> rules = new ArrayList<>();
+    String appProfileId = "appProfileId704923523";
+
+    ReadModifyWriteRowResponse actualResponse =
+        client.readModifyWriteRow(tableName, rowKey, rules, appProfileId);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockBigtable.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ReadModifyWriteRowRequest actualRequest = ((ReadModifyWriteRowRequest) actualRequests.get(0));
+
+    Assert.assertEquals(tableName, actualRequest.getTableName());
+    Assert.assertEquals(rowKey, actualRequest.getRowKey());
+    Assert.assertEquals(rules, actualRequest.getRulesList());
+    Assert.assertEquals(appProfileId, actualRequest.getAppProfileId());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void readModifyWriteRowExceptionTest4() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockBigtable.addException(exception);
+
+    try {
+      String tableName = "tableName-1988717703";
+      ByteString rowKey = ByteString.EMPTY;
+      List<ReadModifyWriteRule> rules = new ArrayList<>();
+      String appProfileId = "appProfileId704923523";
+      client.readModifyWriteRow(tableName, rowKey, rules, appProfileId);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.cloud.bigtable.data.v2.stub.BigtableStubSettings;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Settings class to configure an instance of {@link BaseBigtableDataClient}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ *   <li>The default service address (bigtable.googleapis.com) and default port (443) are used.
+ *   <li>Credentials are acquired automatically through Application Default Credentials.
+ *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders. When
+ * build() is called, the tree of builders is called to create the complete settings object.
+ *
+ * <p>For example, to set the total timeout of mutateRow to 30 seconds:
+ *
+ * <pre>{@code
+ * BaseBigtableDataSettings.Builder baseBigtableDataSettingsBuilder =
+ *     BaseBigtableDataSettings.newBuilder();
+ * baseBigtableDataSettingsBuilder
+ *     .mutateRowSettings()
+ *     .setRetrySettings(
+ *         baseBigtableDataSettingsBuilder
+ *             .mutateRowSettings()
+ *             .getRetrySettings()
+ *             .toBuilder()
+ *             .setTotalTimeout(Duration.ofSeconds(30))
+ *             .build());
+ * BaseBigtableDataSettings baseBigtableDataSettings = baseBigtableDataSettingsBuilder.build();
+ * }</pre>
+ */
+@Generated("by gapic-generator-java")
+public class BaseBigtableDataSettings extends ClientSettings<BaseBigtableDataSettings> {
+
+  /** Returns the object with the settings used for calls to readRows. */
+  public ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsSettings() {
+    return ((BigtableStubSettings) getStubSettings()).readRowsSettings();
+  }
+
+  /** Returns the object with the settings used for calls to sampleRowKeys. */
+  public ServerStreamingCallSettings<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysSettings() {
+    return ((BigtableStubSettings) getStubSettings()).sampleRowKeysSettings();
+  }
+
+  /** Returns the object with the settings used for calls to mutateRow. */
+  public UnaryCallSettings<MutateRowRequest, MutateRowResponse> mutateRowSettings() {
+    return ((BigtableStubSettings) getStubSettings()).mutateRowSettings();
+  }
+
+  /** Returns the object with the settings used for calls to mutateRows. */
+  public ServerStreamingCallSettings<MutateRowsRequest, MutateRowsResponse> mutateRowsSettings() {
+    return ((BigtableStubSettings) getStubSettings()).mutateRowsSettings();
+  }
+
+  /** Returns the object with the settings used for calls to checkAndMutateRow. */
+  public UnaryCallSettings<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowSettings() {
+    return ((BigtableStubSettings) getStubSettings()).checkAndMutateRowSettings();
+  }
+
+  /** Returns the object with the settings used for calls to readModifyWriteRow. */
+  public UnaryCallSettings<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowSettings() {
+    return ((BigtableStubSettings) getStubSettings()).readModifyWriteRowSettings();
+  }
+
+  public static final BaseBigtableDataSettings create(BigtableStubSettings stub)
+      throws IOException {
+    return new BaseBigtableDataSettings.Builder(stub.toBuilder()).build();
+  }
+
+  /** Returns a builder for the default ExecutorProvider for this service. */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return BigtableStubSettings.defaultExecutorProviderBuilder();
+  }
+
+  /** Returns the default service endpoint. */
+  public static String getDefaultEndpoint() {
+    return BigtableStubSettings.getDefaultEndpoint();
+  }
+
+  /** Returns the default service scopes. */
+  public static List<String> getDefaultServiceScopes() {
+    return BigtableStubSettings.getDefaultServiceScopes();
+  }
+
+  /** Returns a builder for the default credentials for this service. */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return BigtableStubSettings.defaultCredentialsProviderBuilder();
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return BigtableStubSettings.defaultGrpcTransportProviderBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return BigtableStubSettings.defaultTransportChannelProvider();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return BigtableStubSettings.defaultApiClientHeaderProviderBuilder();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /** Returns a builder containing all the values of this settings class. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected BaseBigtableDataSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+  }
+
+  /** Builder for BaseBigtableDataSettings. */
+  public static class Builder extends ClientSettings.Builder<BaseBigtableDataSettings, Builder> {
+
+    protected Builder() throws IOException {
+      this(((ClientContext) null));
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(BigtableStubSettings.newBuilder(clientContext));
+    }
+
+    protected Builder(BaseBigtableDataSettings settings) {
+      super(settings.getStubSettings().toBuilder());
+    }
+
+    protected Builder(BigtableStubSettings.Builder stubSettings) {
+      super(stubSettings);
+    }
+
+    private static Builder createDefault() {
+      return new Builder(BigtableStubSettings.newBuilder());
+    }
+
+    public BigtableStubSettings.Builder getStubSettingsBuilder() {
+      return ((BigtableStubSettings.Builder) getStubSettings());
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * <p>Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+      super.applyToAllUnaryMethods(
+          getStubSettingsBuilder().unaryMethodSettingsBuilders(), settingsUpdater);
+      return this;
+    }
+
+    /** Returns the builder for the settings used for calls to readRows. */
+    public ServerStreamingCallSettings.Builder<ReadRowsRequest, ReadRowsResponse>
+        readRowsSettings() {
+      return getStubSettingsBuilder().readRowsSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to sampleRowKeys. */
+    public ServerStreamingCallSettings.Builder<SampleRowKeysRequest, SampleRowKeysResponse>
+        sampleRowKeysSettings() {
+      return getStubSettingsBuilder().sampleRowKeysSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to mutateRow. */
+    public UnaryCallSettings.Builder<MutateRowRequest, MutateRowResponse> mutateRowSettings() {
+      return getStubSettingsBuilder().mutateRowSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to mutateRows. */
+    public ServerStreamingCallSettings.Builder<MutateRowsRequest, MutateRowsResponse>
+        mutateRowsSettings() {
+      return getStubSettingsBuilder().mutateRowsSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to checkAndMutateRow. */
+    public UnaryCallSettings.Builder<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+        checkAndMutateRowSettings() {
+      return getStubSettingsBuilder().checkAndMutateRowSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to readModifyWriteRow. */
+    public UnaryCallSettings.Builder<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+        readModifyWriteRowSettings() {
+      return getStubSettingsBuilder().readModifyWriteRowSettings();
+    }
+
+    @Override
+    public BaseBigtableDataSettings build() throws IOException {
+      return new BaseBigtableDataSettings(this);
+    }
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/MockBigtable.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/MockBigtable.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.protobuf.AbstractMessage;
+import io.grpc.ServerServiceDefinition;
+import java.util.List;
+import javax.annotation.Generated;
+
+@BetaApi
+@Generated("by gapic-generator-java")
+public class MockBigtable implements MockGrpcService {
+  private final MockBigtableImpl serviceImpl;
+
+  public MockBigtable() {
+    serviceImpl = new MockBigtableImpl();
+  }
+
+  @Override
+  public List<AbstractMessage> getRequests() {
+    return serviceImpl.getRequests();
+  }
+
+  @Override
+  public void addResponse(AbstractMessage response) {
+    serviceImpl.addResponse(response);
+  }
+
+  @Override
+  public void addException(Exception exception) {
+    serviceImpl.addException(exception);
+  }
+
+  @Override
+  public ServerServiceDefinition getServiceDefinition() {
+    return serviceImpl.bindService();
+  }
+
+  @Override
+  public void reset() {
+    serviceImpl.reset();
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/MockBigtableImpl.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2;
+
+import com.google.api.core.BetaApi;
+import com.google.bigtable.v2.BigtableGrpc.BigtableImplBase;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.protobuf.AbstractMessage;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import javax.annotation.Generated;
+
+@BetaApi
+@Generated("by gapic-generator-java")
+public class MockBigtableImpl extends BigtableImplBase {
+  private List<AbstractMessage> requests;
+  private Queue<Object> responses;
+
+  public MockBigtableImpl() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  public List<AbstractMessage> getRequests() {
+    return requests;
+  }
+
+  public void addResponse(AbstractMessage response) {
+    responses.add(response);
+  }
+
+  public void setResponses(List<AbstractMessage> responses) {
+    this.responses = new LinkedList<Object>(responses);
+  }
+
+  public void addException(Exception exception) {
+    responses.add(exception);
+  }
+
+  public void reset() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  @Override
+  public void readRows(ReadRowsRequest request, StreamObserver<ReadRowsResponse> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof ReadRowsResponse) {
+      requests.add(request);
+      responseObserver.onNext(((ReadRowsResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method ReadRows, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  ReadRowsResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void sampleRowKeys(
+      SampleRowKeysRequest request, StreamObserver<SampleRowKeysResponse> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof SampleRowKeysResponse) {
+      requests.add(request);
+      responseObserver.onNext(((SampleRowKeysResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method SampleRowKeys, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  SampleRowKeysResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void mutateRow(
+      MutateRowRequest request, StreamObserver<MutateRowResponse> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof MutateRowResponse) {
+      requests.add(request);
+      responseObserver.onNext(((MutateRowResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method MutateRow, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  MutateRowResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void mutateRows(
+      MutateRowsRequest request, StreamObserver<MutateRowsResponse> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof MutateRowsResponse) {
+      requests.add(request);
+      responseObserver.onNext(((MutateRowsResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method MutateRows, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  MutateRowsResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void checkAndMutateRow(
+      CheckAndMutateRowRequest request,
+      StreamObserver<CheckAndMutateRowResponse> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof CheckAndMutateRowResponse) {
+      requests.add(request);
+      responseObserver.onNext(((CheckAndMutateRowResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method CheckAndMutateRow, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  CheckAndMutateRowResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void readModifyWriteRow(
+      ReadModifyWriteRowRequest request,
+      StreamObserver<ReadModifyWriteRowResponse> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof ReadModifyWriteRowResponse) {
+      requests.add(request);
+      responseObserver.onNext(((ReadModifyWriteRowResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method ReadModifyWriteRow, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  ReadModifyWriteRowResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/gapic_metadata.json
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/gapic_metadata.json
@@ -1,0 +1,36 @@
+{
+  "schema": "1.0",
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "java",
+  "protoPackage": "google.bigtable.v2",
+  "libraryPackage": "com.google.cloud.bigtable.data.v2",
+  "services": {
+    "Bigtable": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "BaseBigtableDataClient",
+          "rpcs": {
+            "CheckAndMutateRow": {
+              "methods": ["checkAndMutateRow", "checkAndMutateRow", "checkAndMutateRow", "checkAndMutateRow", "checkAndMutateRow", "checkAndMutateRowCallable"]
+            },
+            "MutateRow": {
+              "methods": ["mutateRow", "mutateRow", "mutateRow", "mutateRow", "mutateRow", "mutateRowCallable"]
+            },
+            "MutateRows": {
+              "methods": ["mutateRowsCallable"]
+            },
+            "ReadModifyWriteRow": {
+              "methods": ["readModifyWriteRow", "readModifyWriteRow", "readModifyWriteRow", "readModifyWriteRow", "readModifyWriteRow", "readModifyWriteRowCallable"]
+            },
+            "ReadRows": {
+              "methods": ["readRowsCallable"]
+            },
+            "SampleRowKeys": {
+              "methods": ["sampleRowKeysCallable"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/package-info.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/package-info.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The interfaces provided are listed below, along with usage samples.
+ *
+ * <p>======================= BaseBigtableDataClient =======================
+ *
+ * <p>Service Description: Service for reading from and writing to existing Bigtable tables.
+ *
+ * <p>Sample for BaseBigtableDataClient:
+ *
+ * <pre>{@code
+ * try (BaseBigtableDataClient baseBigtableDataClient = BaseBigtableDataClient.create()) {
+ *   TableName tableName = TableName.of("[PROJECT]", "[INSTANCE]", "[TABLE]");
+ *   ByteString rowKey = ByteString.EMPTY;
+ *   List<Mutation> mutations = new ArrayList<>();
+ *   MutateRowResponse response = baseBigtableDataClient.mutateRow(tableName, rowKey, mutations);
+ * }
+ * }</pre>
+ */
+@Generated("by gapic-generator-java")
+package com.google.cloud.bigtable.data.v2;
+
+import javax.annotation.Generated;

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2.stub;
+
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Base stub class for the Bigtable service API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by gapic-generator-java")
+public abstract class BigtableStub implements BackgroundResource {
+
+  public ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
+    throw new UnsupportedOperationException("Not implemented: readRowsCallable()");
+  }
+
+  public ServerStreamingCallable<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysCallable() {
+    throw new UnsupportedOperationException("Not implemented: sampleRowKeysCallable()");
+  }
+
+  public UnaryCallable<MutateRowRequest, MutateRowResponse> mutateRowCallable() {
+    throw new UnsupportedOperationException("Not implemented: mutateRowCallable()");
+  }
+
+  public ServerStreamingCallable<MutateRowsRequest, MutateRowsResponse> mutateRowsCallable() {
+    throw new UnsupportedOperationException("Not implemented: mutateRowsCallable()");
+  }
+
+  public UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowCallable() {
+    throw new UnsupportedOperationException("Not implemented: checkAndMutateRowCallable()");
+  }
+
+  public UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowCallable() {
+    throw new UnsupportedOperationException("Not implemented: readModifyWriteRowCallable()");
+  }
+
+  @Override
+  public abstract void close();
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2.stub;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Settings class to configure an instance of {@link BigtableStub}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ *   <li>The default service address (bigtable.googleapis.com) and default port (443) are used.
+ *   <li>Credentials are acquired automatically through Application Default Credentials.
+ *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders. When
+ * build() is called, the tree of builders is called to create the complete settings object.
+ *
+ * <p>For example, to set the total timeout of mutateRow to 30 seconds:
+ *
+ * <pre>{@code
+ * BigtableStubSettings.Builder baseBigtableDataSettingsBuilder =
+ *     BigtableStubSettings.newBuilder();
+ * baseBigtableDataSettingsBuilder
+ *     .mutateRowSettings()
+ *     .setRetrySettings(
+ *         baseBigtableDataSettingsBuilder
+ *             .mutateRowSettings()
+ *             .getRetrySettings()
+ *             .toBuilder()
+ *             .setTotalTimeout(Duration.ofSeconds(30))
+ *             .build());
+ * BigtableStubSettings baseBigtableDataSettings = baseBigtableDataSettingsBuilder.build();
+ * }</pre>
+ */
+@Generated("by gapic-generator-java")
+public class BigtableStubSettings extends StubSettings<BigtableStubSettings> {
+  /** The default scopes of the service. */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
+      ImmutableList.<String>builder()
+          .add("https://www.googleapis.com/auth/bigtable.data")
+          .add("https://www.googleapis.com/auth/bigtable.data.readonly")
+          .add("https://www.googleapis.com/auth/cloud-bigtable.data")
+          .add("https://www.googleapis.com/auth/cloud-bigtable.data.readonly")
+          .add("https://www.googleapis.com/auth/cloud-platform")
+          .add("https://www.googleapis.com/auth/cloud-platform.read-only")
+          .build();
+
+  private final ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsSettings;
+  private final ServerStreamingCallSettings<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysSettings;
+  private final UnaryCallSettings<MutateRowRequest, MutateRowResponse> mutateRowSettings;
+  private final ServerStreamingCallSettings<MutateRowsRequest, MutateRowsResponse>
+      mutateRowsSettings;
+  private final UnaryCallSettings<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowSettings;
+  private final UnaryCallSettings<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowSettings;
+
+  /** Returns the object with the settings used for calls to readRows. */
+  public ServerStreamingCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsSettings() {
+    return readRowsSettings;
+  }
+
+  /** Returns the object with the settings used for calls to sampleRowKeys. */
+  public ServerStreamingCallSettings<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysSettings() {
+    return sampleRowKeysSettings;
+  }
+
+  /** Returns the object with the settings used for calls to mutateRow. */
+  public UnaryCallSettings<MutateRowRequest, MutateRowResponse> mutateRowSettings() {
+    return mutateRowSettings;
+  }
+
+  /** Returns the object with the settings used for calls to mutateRows. */
+  public ServerStreamingCallSettings<MutateRowsRequest, MutateRowsResponse> mutateRowsSettings() {
+    return mutateRowsSettings;
+  }
+
+  /** Returns the object with the settings used for calls to checkAndMutateRow. */
+  public UnaryCallSettings<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowSettings() {
+    return checkAndMutateRowSettings;
+  }
+
+  /** Returns the object with the settings used for calls to readModifyWriteRow. */
+  public UnaryCallSettings<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowSettings() {
+    return readModifyWriteRowSettings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public BigtableStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(GrpcTransportChannel.getGrpcTransportName())) {
+      return GrpcBigtableStub.create(this);
+    }
+    throw new UnsupportedOperationException(
+        String.format(
+            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
+  }
+
+  /** Returns a builder for the default ExecutorProvider for this service. */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /** Returns the default service endpoint. */
+  public static String getDefaultEndpoint() {
+    return "bigtable.googleapis.com:443";
+  }
+
+  /** Returns the default mTLS service endpoint. */
+  public static String getDefaultMtlsEndpoint() {
+    return "bigtable.mtls.googleapis.com:443";
+  }
+
+  /** Returns the default service scopes. */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+  /** Returns a builder for the default credentials for this service. */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return InstantiatingGrpcChannelProvider.newBuilder()
+        .setMaxInboundMessageSize(Integer.MAX_VALUE);
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return defaultGrpcTransportProviderBuilder().build();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(BigtableStubSettings.class))
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /** Returns a builder containing all the values of this settings class. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected BigtableStubSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+
+    readRowsSettings = settingsBuilder.readRowsSettings().build();
+    sampleRowKeysSettings = settingsBuilder.sampleRowKeysSettings().build();
+    mutateRowSettings = settingsBuilder.mutateRowSettings().build();
+    mutateRowsSettings = settingsBuilder.mutateRowsSettings().build();
+    checkAndMutateRowSettings = settingsBuilder.checkAndMutateRowSettings().build();
+    readModifyWriteRowSettings = settingsBuilder.readModifyWriteRowSettings().build();
+  }
+
+  /** Builder for BigtableStubSettings. */
+  public static class Builder extends StubSettings.Builder<BigtableStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+    private final ServerStreamingCallSettings.Builder<ReadRowsRequest, ReadRowsResponse>
+        readRowsSettings;
+    private final ServerStreamingCallSettings.Builder<SampleRowKeysRequest, SampleRowKeysResponse>
+        sampleRowKeysSettings;
+    private final UnaryCallSettings.Builder<MutateRowRequest, MutateRowResponse> mutateRowSettings;
+    private final ServerStreamingCallSettings.Builder<MutateRowsRequest, MutateRowsResponse>
+        mutateRowsSettings;
+    private final UnaryCallSettings.Builder<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+        checkAndMutateRowSettings;
+    private final UnaryCallSettings.Builder<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+        readModifyWriteRowSettings;
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
+        RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
+          ImmutableMap.builder();
+      definitions.put(
+          "retry_policy_3_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      definitions.put(
+          "retry_policy_1_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      definitions.put(
+          "retry_policy_4_codes",
+          ImmutableSet.copyOf(
+              Lists.<StatusCode.Code>newArrayList(
+                  StatusCode.Code.UNAVAILABLE, StatusCode.Code.DEADLINE_EXCEEDED)));
+      definitions.put(
+          "retry_policy_2_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      definitions.put(
+          "retry_policy_0_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(10L))
+              .setRetryDelayMultiplier(2.0)
+              .setMaxRetryDelay(Duration.ofMillis(60000L))
+              .setInitialRpcTimeout(Duration.ofMillis(43200000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(43200000L))
+              .setTotalTimeout(Duration.ofMillis(43200000L))
+              .build();
+      definitions.put("retry_policy_3_params", settings);
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(10L))
+              .setRetryDelayMultiplier(2.0)
+              .setMaxRetryDelay(Duration.ofMillis(60000L))
+              .setInitialRpcTimeout(Duration.ofMillis(60000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(60000L))
+              .setTotalTimeout(Duration.ofMillis(60000L))
+              .build();
+      definitions.put("retry_policy_1_params", settings);
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(10L))
+              .setRetryDelayMultiplier(2.0)
+              .setMaxRetryDelay(Duration.ofMillis(60000L))
+              .setInitialRpcTimeout(Duration.ofMillis(60000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(60000L))
+              .setTotalTimeout(Duration.ofMillis(60000L))
+              .build();
+      definitions.put("retry_policy_4_params", settings);
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(10L))
+              .setRetryDelayMultiplier(2.0)
+              .setMaxRetryDelay(Duration.ofMillis(60000L))
+              .setInitialRpcTimeout(Duration.ofMillis(600000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(600000L))
+              .setTotalTimeout(Duration.ofMillis(600000L))
+              .build();
+      definitions.put("retry_policy_2_params", settings);
+      settings =
+          RetrySettings.newBuilder()
+              .setInitialRetryDelay(Duration.ofMillis(10L))
+              .setRetryDelayMultiplier(2.0)
+              .setMaxRetryDelay(Duration.ofMillis(60000L))
+              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setRpcTimeoutMultiplier(1.0)
+              .setMaxRpcTimeout(Duration.ofMillis(20000L))
+              .setTotalTimeout(Duration.ofMillis(20000L))
+              .build();
+      definitions.put("retry_policy_0_params", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
+      this(((ClientContext) null));
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      readRowsSettings = ServerStreamingCallSettings.newBuilder();
+      sampleRowKeysSettings = ServerStreamingCallSettings.newBuilder();
+      mutateRowSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      mutateRowsSettings = ServerStreamingCallSettings.newBuilder();
+      checkAndMutateRowSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      readModifyWriteRowSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              mutateRowSettings, checkAndMutateRowSettings, readModifyWriteRowSettings);
+      initDefaults(this);
+    }
+
+    protected Builder(BigtableStubSettings settings) {
+      super(settings);
+
+      readRowsSettings = settings.readRowsSettings.toBuilder();
+      sampleRowKeysSettings = settings.sampleRowKeysSettings.toBuilder();
+      mutateRowSettings = settings.mutateRowSettings.toBuilder();
+      mutateRowsSettings = settings.mutateRowsSettings.toBuilder();
+      checkAndMutateRowSettings = settings.checkAndMutateRowSettings.toBuilder();
+      readModifyWriteRowSettings = settings.readModifyWriteRowSettings.toBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              mutateRowSettings, checkAndMutateRowSettings, readModifyWriteRowSettings);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder(((ClientContext) null));
+
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setEndpoint(getDefaultEndpoint());
+      builder.setMtlsEndpoint(getDefaultMtlsEndpoint());
+      builder.setSwitchToMtlsEndpointAllowed(true);
+
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+      builder
+          .readRowsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_3_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_3_params"));
+
+      builder
+          .sampleRowKeysSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_1_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_1_params"));
+
+      builder
+          .mutateRowSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_4_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_4_params"));
+
+      builder
+          .mutateRowsSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_2_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_2_params"));
+
+      builder
+          .checkAndMutateRowSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_0_params"));
+
+      builder
+          .readModifyWriteRowSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("retry_policy_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("retry_policy_0_params"));
+
+      return builder;
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * <p>Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
+    }
+
+    /** Returns the builder for the settings used for calls to readRows. */
+    public ServerStreamingCallSettings.Builder<ReadRowsRequest, ReadRowsResponse>
+        readRowsSettings() {
+      return readRowsSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to sampleRowKeys. */
+    public ServerStreamingCallSettings.Builder<SampleRowKeysRequest, SampleRowKeysResponse>
+        sampleRowKeysSettings() {
+      return sampleRowKeysSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to mutateRow. */
+    public UnaryCallSettings.Builder<MutateRowRequest, MutateRowResponse> mutateRowSettings() {
+      return mutateRowSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to mutateRows. */
+    public ServerStreamingCallSettings.Builder<MutateRowsRequest, MutateRowsResponse>
+        mutateRowsSettings() {
+      return mutateRowsSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to checkAndMutateRow. */
+    public UnaryCallSettings.Builder<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+        checkAndMutateRowSettings() {
+      return checkAndMutateRowSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to readModifyWriteRow. */
+    public UnaryCallSettings.Builder<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+        readModifyWriteRowSettings() {
+      return readModifyWriteRowSettings;
+    }
+
+    @Override
+    public BigtableStubSettings build() throws IOException {
+      return new BigtableStubSettings(this);
+    }
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2.stub;
+
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcCallableFactory;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.OperationsStub;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * gRPC callable factory implementation for the Bigtable service API.
+ *
+ * <p>This class is for advanced usage.
+ */
+@Generated("by gapic-generator-java")
+public class GrpcBigtableCallableFactory implements GrpcStubCallableFactory {
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      UnaryCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createUnaryCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, PagedListResponseT>
+      UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          PagedCallSettings<RequestT, ResponseT, PagedListResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createPagedCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      BatchingCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createBatchingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          GrpcCallSettings<RequestT, Operation> grpcCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
+          ClientContext clientContext,
+          OperationsStub operationsStub) {
+    return GrpcCallableFactory.createOperationCallable(
+        grpcCallSettings, callSettings, clientContext, operationsStub);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createBidiStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createServerStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createClientStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+}

--- a/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
+++ b/test/integration/goldens/bigtable/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.data.v2.stub;
+
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.RequestParamsBuilder;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.bigtable.v2.CheckAndMutateRowRequest;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.longrunning.stub.GrpcOperationsStub;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * gRPC stub implementation for the Bigtable service API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by gapic-generator-java")
+public class GrpcBigtableStub extends BigtableStub {
+  private static final MethodDescriptor<ReadRowsRequest, ReadRowsResponse>
+      readRowsMethodDescriptor =
+          MethodDescriptor.<ReadRowsRequest, ReadRowsResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName("google.bigtable.v2.Bigtable/ReadRows")
+              .setRequestMarshaller(ProtoUtils.marshaller(ReadRowsRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(ReadRowsResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysMethodDescriptor =
+          MethodDescriptor.<SampleRowKeysRequest, SampleRowKeysResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName("google.bigtable.v2.Bigtable/SampleRowKeys")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(SampleRowKeysRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(SampleRowKeysResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<MutateRowRequest, MutateRowResponse>
+      mutateRowMethodDescriptor =
+          MethodDescriptor.<MutateRowRequest, MutateRowResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.v2.Bigtable/MutateRow")
+              .setRequestMarshaller(ProtoUtils.marshaller(MutateRowRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(MutateRowResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<MutateRowsRequest, MutateRowsResponse>
+      mutateRowsMethodDescriptor =
+          MethodDescriptor.<MutateRowsRequest, MutateRowsResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName("google.bigtable.v2.Bigtable/MutateRows")
+              .setRequestMarshaller(ProtoUtils.marshaller(MutateRowsRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(MutateRowsResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowMethodDescriptor =
+          MethodDescriptor.<CheckAndMutateRowRequest, CheckAndMutateRowResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.v2.Bigtable/CheckAndMutateRow")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(CheckAndMutateRowRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(CheckAndMutateRowResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowMethodDescriptor =
+          MethodDescriptor.<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.bigtable.v2.Bigtable/ReadModifyWriteRow")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(ReadModifyWriteRowRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(ReadModifyWriteRowResponse.getDefaultInstance()))
+              .build();
+
+  private final ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable;
+  private final ServerStreamingCallable<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysCallable;
+  private final UnaryCallable<MutateRowRequest, MutateRowResponse> mutateRowCallable;
+  private final ServerStreamingCallable<MutateRowsRequest, MutateRowsResponse> mutateRowsCallable;
+  private final UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowCallable;
+  private final UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowCallable;
+
+  private final BackgroundResource backgroundResources;
+  private final GrpcOperationsStub operationsStub;
+  private final GrpcStubCallableFactory callableFactory;
+
+  private static final PathTemplate READ_ROWS_0_PATH_TEMPLATE =
+      PathTemplate.create("{table_name=projects/*/instances/*/tables/*}");
+  private static final PathTemplate READ_ROWS_1_PATH_TEMPLATE =
+      PathTemplate.create("{app_profile_id=**}");
+  private static final PathTemplate SAMPLE_ROW_KEYS_0_PATH_TEMPLATE =
+      PathTemplate.create("{table_name=projects/*/instances/*/tables/*}");
+  private static final PathTemplate SAMPLE_ROW_KEYS_1_PATH_TEMPLATE =
+      PathTemplate.create("{app_profile_id=**}");
+  private static final PathTemplate MUTATE_ROW_0_PATH_TEMPLATE =
+      PathTemplate.create("{table_name=projects/*/instances/*/tables/*}");
+  private static final PathTemplate MUTATE_ROW_1_PATH_TEMPLATE =
+      PathTemplate.create("{app_profile_id=**}");
+  private static final PathTemplate MUTATE_ROWS_0_PATH_TEMPLATE =
+      PathTemplate.create("{table_name=projects/*/instances/*/tables/*}");
+  private static final PathTemplate MUTATE_ROWS_1_PATH_TEMPLATE =
+      PathTemplate.create("{app_profile_id=**}");
+  private static final PathTemplate CHECK_AND_MUTATE_ROW_0_PATH_TEMPLATE =
+      PathTemplate.create("{table_name=projects/*/instances/*/tables/*}");
+  private static final PathTemplate CHECK_AND_MUTATE_ROW_1_PATH_TEMPLATE =
+      PathTemplate.create("{app_profile_id=**}");
+  private static final PathTemplate READ_MODIFY_WRITE_ROW_0_PATH_TEMPLATE =
+      PathTemplate.create("{table_name=projects/*/instances/*/tables/*}");
+  private static final PathTemplate READ_MODIFY_WRITE_ROW_1_PATH_TEMPLATE =
+      PathTemplate.create("{app_profile_id=**}");
+
+  public static final GrpcBigtableStub create(BigtableStubSettings settings) throws IOException {
+    return new GrpcBigtableStub(settings, ClientContext.create(settings));
+  }
+
+  public static final GrpcBigtableStub create(ClientContext clientContext) throws IOException {
+    return new GrpcBigtableStub(BigtableStubSettings.newBuilder().build(), clientContext);
+  }
+
+  public static final GrpcBigtableStub create(
+      ClientContext clientContext, GrpcStubCallableFactory callableFactory) throws IOException {
+    return new GrpcBigtableStub(
+        BigtableStubSettings.newBuilder().build(), clientContext, callableFactory);
+  }
+
+  /**
+   * Constructs an instance of GrpcBigtableStub, using the given settings. This is protected so that
+   * it is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected GrpcBigtableStub(BigtableStubSettings settings, ClientContext clientContext)
+      throws IOException {
+    this(settings, clientContext, new GrpcBigtableCallableFactory());
+  }
+
+  /**
+   * Constructs an instance of GrpcBigtableStub, using the given settings. This is protected so that
+   * it is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected GrpcBigtableStub(
+      BigtableStubSettings settings,
+      ClientContext clientContext,
+      GrpcStubCallableFactory callableFactory)
+      throws IOException {
+    this.callableFactory = callableFactory;
+    this.operationsStub = GrpcOperationsStub.create(clientContext, callableFactory);
+
+    GrpcCallSettings<ReadRowsRequest, ReadRowsResponse> readRowsTransportSettings =
+        GrpcCallSettings.<ReadRowsRequest, ReadRowsResponse>newBuilder()
+            .setMethodDescriptor(readRowsMethodDescriptor)
+            .setParamsExtractor(
+                request -> {
+                  RequestParamsBuilder builder = RequestParamsBuilder.create();
+                  builder.add(request.getTableName(), "table_name", READ_ROWS_0_PATH_TEMPLATE);
+                  builder.add(
+                      request.getAppProfileId(), "app_profile_id", READ_ROWS_1_PATH_TEMPLATE);
+                  return builder.build();
+                })
+            .build();
+    GrpcCallSettings<SampleRowKeysRequest, SampleRowKeysResponse> sampleRowKeysTransportSettings =
+        GrpcCallSettings.<SampleRowKeysRequest, SampleRowKeysResponse>newBuilder()
+            .setMethodDescriptor(sampleRowKeysMethodDescriptor)
+            .setParamsExtractor(
+                request -> {
+                  RequestParamsBuilder builder = RequestParamsBuilder.create();
+                  builder.add(
+                      request.getTableName(), "table_name", SAMPLE_ROW_KEYS_0_PATH_TEMPLATE);
+                  builder.add(
+                      request.getAppProfileId(), "app_profile_id", SAMPLE_ROW_KEYS_1_PATH_TEMPLATE);
+                  return builder.build();
+                })
+            .build();
+    GrpcCallSettings<MutateRowRequest, MutateRowResponse> mutateRowTransportSettings =
+        GrpcCallSettings.<MutateRowRequest, MutateRowResponse>newBuilder()
+            .setMethodDescriptor(mutateRowMethodDescriptor)
+            .setParamsExtractor(
+                request -> {
+                  RequestParamsBuilder builder = RequestParamsBuilder.create();
+                  builder.add(request.getTableName(), "table_name", MUTATE_ROW_0_PATH_TEMPLATE);
+                  builder.add(
+                      request.getAppProfileId(), "app_profile_id", MUTATE_ROW_1_PATH_TEMPLATE);
+                  return builder.build();
+                })
+            .build();
+    GrpcCallSettings<MutateRowsRequest, MutateRowsResponse> mutateRowsTransportSettings =
+        GrpcCallSettings.<MutateRowsRequest, MutateRowsResponse>newBuilder()
+            .setMethodDescriptor(mutateRowsMethodDescriptor)
+            .setParamsExtractor(
+                request -> {
+                  RequestParamsBuilder builder = RequestParamsBuilder.create();
+                  builder.add(request.getTableName(), "table_name", MUTATE_ROWS_0_PATH_TEMPLATE);
+                  builder.add(
+                      request.getAppProfileId(), "app_profile_id", MUTATE_ROWS_1_PATH_TEMPLATE);
+                  return builder.build();
+                })
+            .build();
+    GrpcCallSettings<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+        checkAndMutateRowTransportSettings =
+            GrpcCallSettings.<CheckAndMutateRowRequest, CheckAndMutateRowResponse>newBuilder()
+                .setMethodDescriptor(checkAndMutateRowMethodDescriptor)
+                .setParamsExtractor(
+                    request -> {
+                      RequestParamsBuilder builder = RequestParamsBuilder.create();
+                      builder.add(
+                          request.getTableName(),
+                          "table_name",
+                          CHECK_AND_MUTATE_ROW_0_PATH_TEMPLATE);
+                      builder.add(
+                          request.getAppProfileId(),
+                          "app_profile_id",
+                          CHECK_AND_MUTATE_ROW_1_PATH_TEMPLATE);
+                      return builder.build();
+                    })
+                .build();
+    GrpcCallSettings<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+        readModifyWriteRowTransportSettings =
+            GrpcCallSettings.<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>newBuilder()
+                .setMethodDescriptor(readModifyWriteRowMethodDescriptor)
+                .setParamsExtractor(
+                    request -> {
+                      RequestParamsBuilder builder = RequestParamsBuilder.create();
+                      builder.add(
+                          request.getTableName(),
+                          "table_name",
+                          READ_MODIFY_WRITE_ROW_0_PATH_TEMPLATE);
+                      builder.add(
+                          request.getAppProfileId(),
+                          "app_profile_id",
+                          READ_MODIFY_WRITE_ROW_1_PATH_TEMPLATE);
+                      return builder.build();
+                    })
+                .build();
+
+    this.readRowsCallable =
+        callableFactory.createServerStreamingCallable(
+            readRowsTransportSettings, settings.readRowsSettings(), clientContext);
+    this.sampleRowKeysCallable =
+        callableFactory.createServerStreamingCallable(
+            sampleRowKeysTransportSettings, settings.sampleRowKeysSettings(), clientContext);
+    this.mutateRowCallable =
+        callableFactory.createUnaryCallable(
+            mutateRowTransportSettings, settings.mutateRowSettings(), clientContext);
+    this.mutateRowsCallable =
+        callableFactory.createServerStreamingCallable(
+            mutateRowsTransportSettings, settings.mutateRowsSettings(), clientContext);
+    this.checkAndMutateRowCallable =
+        callableFactory.createUnaryCallable(
+            checkAndMutateRowTransportSettings,
+            settings.checkAndMutateRowSettings(),
+            clientContext);
+    this.readModifyWriteRowCallable =
+        callableFactory.createUnaryCallable(
+            readModifyWriteRowTransportSettings,
+            settings.readModifyWriteRowSettings(),
+            clientContext);
+
+    this.backgroundResources =
+        new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+  }
+
+  public GrpcOperationsStub getOperationsStub() {
+    return operationsStub;
+  }
+
+  @Override
+  public ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> readRowsCallable() {
+    return readRowsCallable;
+  }
+
+  @Override
+  public ServerStreamingCallable<SampleRowKeysRequest, SampleRowKeysResponse>
+      sampleRowKeysCallable() {
+    return sampleRowKeysCallable;
+  }
+
+  @Override
+  public UnaryCallable<MutateRowRequest, MutateRowResponse> mutateRowCallable() {
+    return mutateRowCallable;
+  }
+
+  @Override
+  public ServerStreamingCallable<MutateRowsRequest, MutateRowsResponse> mutateRowsCallable() {
+    return mutateRowsCallable;
+  }
+
+  @Override
+  public UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse>
+      checkAndMutateRowCallable() {
+    return checkAndMutateRowCallable;
+  }
+
+  @Override
+  public UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse>
+      readModifyWriteRowCallable() {
+    return readModifyWriteRowCallable;
+  }
+
+  @Override
+  public final void close() {
+    try {
+      backgroundResources.close();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to close resource", e);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    backgroundResources.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return backgroundResources.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return backgroundResources.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    backgroundResources.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return backgroundResources.awaitTermination(duration, unit);
+  }
+}

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -485,6 +485,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    *           .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
    *           .setRetryPolicy(RetryPolicy.newBuilder().build())
    *           .setDetached(true)
+   *           .setEnableExactlyOnceDelivery(true)
    *           .setTopicMessageRetentionDuration(Duration.newBuilder().build())
    *           .build();
    *   Subscription response = subscriptionAdminClient.createSubscription(request);
@@ -530,6 +531,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    *           .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
    *           .setRetryPolicy(RetryPolicy.newBuilder().build())
    *           .setDetached(true)
+   *           .setEnableExactlyOnceDelivery(true)
    *           .setTopicMessageRetentionDuration(Duration.newBuilder().build())
    *           .build();
    *   ApiFuture<Subscription> future =

--- a/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/test/integration/goldens/pubsub/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -149,6 +149,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -210,6 +211,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -271,6 +273,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -332,6 +335,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -393,6 +397,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -444,6 +449,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -495,6 +501,7 @@ public class SubscriptionAdminClientTest {
             .setDeadLetterPolicy(DeadLetterPolicy.newBuilder().build())
             .setRetryPolicy(RetryPolicy.newBuilder().build())
             .setDetached(true)
+            .setEnableExactlyOnceDelivery(true)
             .setTopicMessageRetentionDuration(Duration.newBuilder().build())
             .build();
     mockSubscriber.addResponse(expectedResponse);
@@ -1015,6 +1022,10 @@ public class SubscriptionAdminClientTest {
     StreamingPullResponse expectedResponse =
         StreamingPullResponse.newBuilder()
             .addAllReceivedMessages(new ArrayList<ReceivedMessage>())
+            .setAcknowlegeConfirmation(
+                StreamingPullResponse.AcknowledgeConfirmation.newBuilder().build())
+            .setModifyAckDeadlineConfirmation(
+                StreamingPullResponse.ModifyAckDeadlineConfirmation.newBuilder().build())
             .setSubscriptionProperties(
                 StreamingPullResponse.SubscriptionProperties.newBuilder().build())
             .build();

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -35,6 +35,7 @@ import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
+import com.google.protobuf.Timestamp;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -461,6 +462,107 @@ public class CloudRedisClient implements BackgroundResource {
    */
   public final UnaryCallable<GetInstanceRequest, Instance> getInstanceCallable() {
     return stub.getInstanceCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the AUTH string for a Redis instance. If AUTH is not enabled for the instance the response
+   * will be empty. This information is not included in the details returned to GetInstance.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   InstanceName name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]");
+   *   InstanceAuthString response = cloudRedisClient.getInstanceAuthString(name);
+   * }
+   * }</pre>
+   *
+   * @param name Required. Redis instance resource name using the form:
+   *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
+   *     refers to a GCP region.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final InstanceAuthString getInstanceAuthString(InstanceName name) {
+    GetInstanceAuthStringRequest request =
+        GetInstanceAuthStringRequest.newBuilder()
+            .setName(name == null ? null : name.toString())
+            .build();
+    return getInstanceAuthString(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the AUTH string for a Redis instance. If AUTH is not enabled for the instance the response
+   * will be empty. This information is not included in the details returned to GetInstance.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   String name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString();
+   *   InstanceAuthString response = cloudRedisClient.getInstanceAuthString(name);
+   * }
+   * }</pre>
+   *
+   * @param name Required. Redis instance resource name using the form:
+   *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
+   *     refers to a GCP region.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final InstanceAuthString getInstanceAuthString(String name) {
+    GetInstanceAuthStringRequest request =
+        GetInstanceAuthStringRequest.newBuilder().setName(name).build();
+    return getInstanceAuthString(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the AUTH string for a Redis instance. If AUTH is not enabled for the instance the response
+   * will be empty. This information is not included in the details returned to GetInstance.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   GetInstanceAuthStringRequest request =
+   *       GetInstanceAuthStringRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .build();
+   *   InstanceAuthString response = cloudRedisClient.getInstanceAuthString(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final InstanceAuthString getInstanceAuthString(GetInstanceAuthStringRequest request) {
+    return getInstanceAuthStringCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Gets the AUTH string for a Redis instance. If AUTH is not enabled for the instance the response
+   * will be empty. This information is not included in the details returned to GetInstance.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   GetInstanceAuthStringRequest request =
+   *       GetInstanceAuthStringRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .build();
+   *   ApiFuture<InstanceAuthString> future =
+   *       cloudRedisClient.getInstanceAuthStringCallable().futureCall(request);
+   *   // Do something.
+   *   InstanceAuthString response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringCallable() {
+    return stub.getInstanceAuthStringCallable();
   }
 
   // AUTO-GENERATED DOCUMENTATION AND METHOD.
@@ -1416,6 +1518,159 @@ public class CloudRedisClient implements BackgroundResource {
    */
   public final UnaryCallable<DeleteInstanceRequest, Operation> deleteInstanceCallable() {
     return stub.deleteInstanceCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Reschedule maintenance for a given instance in a given project and location.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   InstanceName name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]");
+   *   RescheduleMaintenanceRequest.RescheduleType rescheduleType =
+   *       RescheduleMaintenanceRequest.RescheduleType.forNumber(0);
+   *   Timestamp scheduleTime = Timestamp.newBuilder().build();
+   *   Instance response =
+   *       cloudRedisClient.rescheduleMaintenanceAsync(name, rescheduleType, scheduleTime).get();
+   * }
+   * }</pre>
+   *
+   * @param name Required. Redis instance resource name using the form:
+   *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
+   *     refers to a GCP region.
+   * @param rescheduleType Required. If reschedule type is SPECIFIC_TIME, must set up schedule_time
+   *     as well.
+   * @param scheduleTime Optional. Timestamp when the maintenance shall be rescheduled to if
+   *     reschedule_type=SPECIFIC_TIME, in RFC 3339 format, for example `2012-11-15T16:19:00.094Z`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Instance, Any> rescheduleMaintenanceAsync(
+      InstanceName name,
+      RescheduleMaintenanceRequest.RescheduleType rescheduleType,
+      Timestamp scheduleTime) {
+    RescheduleMaintenanceRequest request =
+        RescheduleMaintenanceRequest.newBuilder()
+            .setName(name == null ? null : name.toString())
+            .setRescheduleType(rescheduleType)
+            .setScheduleTime(scheduleTime)
+            .build();
+    return rescheduleMaintenanceAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Reschedule maintenance for a given instance in a given project and location.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   String name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString();
+   *   RescheduleMaintenanceRequest.RescheduleType rescheduleType =
+   *       RescheduleMaintenanceRequest.RescheduleType.forNumber(0);
+   *   Timestamp scheduleTime = Timestamp.newBuilder().build();
+   *   Instance response =
+   *       cloudRedisClient.rescheduleMaintenanceAsync(name, rescheduleType, scheduleTime).get();
+   * }
+   * }</pre>
+   *
+   * @param name Required. Redis instance resource name using the form:
+   *     `projects/{project_id}/locations/{location_id}/instances/{instance_id}` where `location_id`
+   *     refers to a GCP region.
+   * @param rescheduleType Required. If reschedule type is SPECIFIC_TIME, must set up schedule_time
+   *     as well.
+   * @param scheduleTime Optional. Timestamp when the maintenance shall be rescheduled to if
+   *     reschedule_type=SPECIFIC_TIME, in RFC 3339 format, for example `2012-11-15T16:19:00.094Z`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Instance, Any> rescheduleMaintenanceAsync(
+      String name,
+      RescheduleMaintenanceRequest.RescheduleType rescheduleType,
+      Timestamp scheduleTime) {
+    RescheduleMaintenanceRequest request =
+        RescheduleMaintenanceRequest.newBuilder()
+            .setName(name)
+            .setRescheduleType(rescheduleType)
+            .setScheduleTime(scheduleTime)
+            .build();
+    return rescheduleMaintenanceAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Reschedule maintenance for a given instance in a given project and location.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   RescheduleMaintenanceRequest request =
+   *       RescheduleMaintenanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .setScheduleTime(Timestamp.newBuilder().build())
+   *           .build();
+   *   Instance response = cloudRedisClient.rescheduleMaintenanceAsync(request).get();
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Instance, Any> rescheduleMaintenanceAsync(
+      RescheduleMaintenanceRequest request) {
+    return rescheduleMaintenanceOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Reschedule maintenance for a given instance in a given project and location.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   RescheduleMaintenanceRequest request =
+   *       RescheduleMaintenanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .setScheduleTime(Timestamp.newBuilder().build())
+   *           .build();
+   *   OperationFuture<Instance, Any> future =
+   *       cloudRedisClient.rescheduleMaintenanceOperationCallable().futureCall(request);
+   *   // Do something.
+   *   Instance response = future.get();
+   * }
+   * }</pre>
+   */
+  public final OperationCallable<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationCallable() {
+    return stub.rescheduleMaintenanceOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Reschedule maintenance for a given instance in a given project and location.
+   *
+   * <p>Sample code:
+   *
+   * <pre>{@code
+   * try (CloudRedisClient cloudRedisClient = CloudRedisClient.create()) {
+   *   RescheduleMaintenanceRequest request =
+   *       RescheduleMaintenanceRequest.newBuilder()
+   *           .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+   *           .setScheduleTime(Timestamp.newBuilder().build())
+   *           .build();
+   *   ApiFuture<Operation> future =
+   *       cloudRedisClient.rescheduleMaintenanceCallable().futureCall(request);
+   *   // Do something.
+   *   Operation response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<RescheduleMaintenanceRequest, Operation>
+      rescheduleMaintenanceCallable() {
+    return stub.rescheduleMaintenanceCallable();
   }
 
   @Override

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisClientTest.java
@@ -186,6 +186,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -195,10 +196,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     mockCloudRedis.addResponse(expectedResponse);
 
@@ -243,6 +249,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -252,10 +259,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     mockCloudRedis.addResponse(expectedResponse);
 
@@ -290,6 +302,80 @@ public class CloudRedisClientTest {
   }
 
   @Test
+  public void getInstanceAuthStringTest() throws Exception {
+    InstanceAuthString expectedResponse =
+        InstanceAuthString.newBuilder().setAuthString("authString1994738649").build();
+    mockCloudRedis.addResponse(expectedResponse);
+
+    InstanceName name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]");
+
+    InstanceAuthString actualResponse = client.getInstanceAuthString(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockCloudRedis.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetInstanceAuthStringRequest actualRequest =
+        ((GetInstanceAuthStringRequest) actualRequests.get(0));
+
+    Assert.assertEquals(name.toString(), actualRequest.getName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void getInstanceAuthStringExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockCloudRedis.addException(exception);
+
+    try {
+      InstanceName name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]");
+      client.getInstanceAuthString(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void getInstanceAuthStringTest2() throws Exception {
+    InstanceAuthString expectedResponse =
+        InstanceAuthString.newBuilder().setAuthString("authString1994738649").build();
+    mockCloudRedis.addResponse(expectedResponse);
+
+    String name = "name3373707";
+
+    InstanceAuthString actualResponse = client.getInstanceAuthString(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockCloudRedis.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetInstanceAuthStringRequest actualRequest =
+        ((GetInstanceAuthStringRequest) actualRequests.get(0));
+
+    Assert.assertEquals(name, actualRequest.getName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void getInstanceAuthStringExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockCloudRedis.addException(exception);
+
+    try {
+      String name = "name3373707";
+      client.getInstanceAuthString(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
   public void createInstanceTest() throws Exception {
     Instance expectedResponse =
         Instance.newBuilder()
@@ -300,6 +386,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -309,10 +396,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -371,6 +463,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -380,10 +473,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -442,6 +540,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -451,10 +550,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -510,6 +614,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -519,10 +624,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -578,6 +688,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -587,10 +698,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -646,6 +762,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -655,10 +772,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -714,6 +836,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -723,10 +846,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -782,6 +910,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -791,10 +920,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -852,6 +986,7 @@ public class CloudRedisClientTest {
             .setAlternativeLocationId("alternativeLocationId1787141949")
             .setRedisVersion("redisVersion-1972584739")
             .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
             .setHost("host3208616")
             .setPort(3446913)
             .setCurrentLocationId("currentLocationId-1808505335")
@@ -861,10 +996,15 @@ public class CloudRedisClientTest {
             .setMemorySizeGb(34199707)
             .setAuthorizedNetwork("authorizedNetwork1515554835")
             .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
             .setReplicaCount(564075208)
             .addAllNodes(new ArrayList<NodeInfo>())
             .setReadEndpoint("readEndpoint294053195")
             .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
             .build();
     Operation resultOperation =
         Operation.newBuilder()
@@ -987,6 +1127,168 @@ public class CloudRedisClientTest {
     try {
       String name = "name3373707";
       client.deleteInstanceAsync(name).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void rescheduleMaintenanceTest() throws Exception {
+    Instance expectedResponse =
+        Instance.newBuilder()
+            .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+            .setDisplayName("displayName1714148973")
+            .putAllLabels(new HashMap<String, String>())
+            .setLocationId("locationId1541836720")
+            .setAlternativeLocationId("alternativeLocationId1787141949")
+            .setRedisVersion("redisVersion-1972584739")
+            .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
+            .setHost("host3208616")
+            .setPort(3446913)
+            .setCurrentLocationId("currentLocationId-1808505335")
+            .setCreateTime(Timestamp.newBuilder().build())
+            .setStatusMessage("statusMessage-958704715")
+            .putAllRedisConfigs(new HashMap<String, String>())
+            .setMemorySizeGb(34199707)
+            .setAuthorizedNetwork("authorizedNetwork1515554835")
+            .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
+            .build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("rescheduleMaintenanceTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockCloudRedis.addResponse(resultOperation);
+
+    InstanceName name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]");
+    RescheduleMaintenanceRequest.RescheduleType rescheduleType =
+        RescheduleMaintenanceRequest.RescheduleType.forNumber(0);
+    Timestamp scheduleTime = Timestamp.newBuilder().build();
+
+    Instance actualResponse =
+        client.rescheduleMaintenanceAsync(name, rescheduleType, scheduleTime).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockCloudRedis.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    RescheduleMaintenanceRequest actualRequest =
+        ((RescheduleMaintenanceRequest) actualRequests.get(0));
+
+    Assert.assertEquals(name.toString(), actualRequest.getName());
+    Assert.assertEquals(rescheduleType, actualRequest.getRescheduleType());
+    Assert.assertEquals(scheduleTime, actualRequest.getScheduleTime());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void rescheduleMaintenanceExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockCloudRedis.addException(exception);
+
+    try {
+      InstanceName name = InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]");
+      RescheduleMaintenanceRequest.RescheduleType rescheduleType =
+          RescheduleMaintenanceRequest.RescheduleType.forNumber(0);
+      Timestamp scheduleTime = Timestamp.newBuilder().build();
+      client.rescheduleMaintenanceAsync(name, rescheduleType, scheduleTime).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void rescheduleMaintenanceTest2() throws Exception {
+    Instance expectedResponse =
+        Instance.newBuilder()
+            .setName(InstanceName.of("[PROJECT]", "[LOCATION]", "[INSTANCE]").toString())
+            .setDisplayName("displayName1714148973")
+            .putAllLabels(new HashMap<String, String>())
+            .setLocationId("locationId1541836720")
+            .setAlternativeLocationId("alternativeLocationId1787141949")
+            .setRedisVersion("redisVersion-1972584739")
+            .setReservedIpRange("reservedIpRange575015950")
+            .setSecondaryIpRange("secondaryIpRange-1937131454")
+            .setHost("host3208616")
+            .setPort(3446913)
+            .setCurrentLocationId("currentLocationId-1808505335")
+            .setCreateTime(Timestamp.newBuilder().build())
+            .setStatusMessage("statusMessage-958704715")
+            .putAllRedisConfigs(new HashMap<String, String>())
+            .setMemorySizeGb(34199707)
+            .setAuthorizedNetwork("authorizedNetwork1515554835")
+            .setPersistenceIamIdentity("persistenceIamIdentity1464017428")
+            .setAuthEnabled(true)
+            .addAllServerCaCerts(new ArrayList<TlsCertificate>())
+            .setMaintenancePolicy(MaintenancePolicy.newBuilder().build())
+            .setMaintenanceSchedule(MaintenanceSchedule.newBuilder().build())
+            .setReplicaCount(564075208)
+            .addAllNodes(new ArrayList<NodeInfo>())
+            .setReadEndpoint("readEndpoint294053195")
+            .setReadEndpointPort(-1676143102)
+            .setPersistenceConfig(PersistenceConfig.newBuilder().build())
+            .build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("rescheduleMaintenanceTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockCloudRedis.addResponse(resultOperation);
+
+    String name = "name3373707";
+    RescheduleMaintenanceRequest.RescheduleType rescheduleType =
+        RescheduleMaintenanceRequest.RescheduleType.forNumber(0);
+    Timestamp scheduleTime = Timestamp.newBuilder().build();
+
+    Instance actualResponse =
+        client.rescheduleMaintenanceAsync(name, rescheduleType, scheduleTime).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockCloudRedis.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    RescheduleMaintenanceRequest actualRequest =
+        ((RescheduleMaintenanceRequest) actualRequests.get(0));
+
+    Assert.assertEquals(name, actualRequest.getName());
+    Assert.assertEquals(rescheduleType, actualRequest.getRescheduleType());
+    Assert.assertEquals(scheduleTime, actualRequest.getScheduleTime());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void rescheduleMaintenanceExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockCloudRedis.addException(exception);
+
+    try {
+      String name = "name3373707";
+      RescheduleMaintenanceRequest.RescheduleType rescheduleType =
+          RescheduleMaintenanceRequest.RescheduleType.forNumber(0);
+      Timestamp scheduleTime = Timestamp.newBuilder().build();
+      client.rescheduleMaintenanceAsync(name, rescheduleType, scheduleTime).get();
       Assert.fail("No exception raised");
     } catch (ExecutionException e) {
       Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
@@ -85,6 +85,12 @@ public class CloudRedisSettings extends ClientSettings<CloudRedisSettings> {
     return ((CloudRedisStubSettings) getStubSettings()).getInstanceSettings();
   }
 
+  /** Returns the object with the settings used for calls to getInstanceAuthString. */
+  public UnaryCallSettings<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringSettings() {
+    return ((CloudRedisStubSettings) getStubSettings()).getInstanceAuthStringSettings();
+  }
+
   /** Returns the object with the settings used for calls to createInstance. */
   public UnaryCallSettings<CreateInstanceRequest, Operation> createInstanceSettings() {
     return ((CloudRedisStubSettings) getStubSettings()).createInstanceSettings();
@@ -160,6 +166,18 @@ public class CloudRedisSettings extends ClientSettings<CloudRedisSettings> {
   public OperationCallSettings<DeleteInstanceRequest, Empty, Any>
       deleteInstanceOperationSettings() {
     return ((CloudRedisStubSettings) getStubSettings()).deleteInstanceOperationSettings();
+  }
+
+  /** Returns the object with the settings used for calls to rescheduleMaintenance. */
+  public UnaryCallSettings<RescheduleMaintenanceRequest, Operation>
+      rescheduleMaintenanceSettings() {
+    return ((CloudRedisStubSettings) getStubSettings()).rescheduleMaintenanceSettings();
+  }
+
+  /** Returns the object with the settings used for calls to rescheduleMaintenance. */
+  public OperationCallSettings<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationSettings() {
+    return ((CloudRedisStubSettings) getStubSettings()).rescheduleMaintenanceOperationSettings();
   }
 
   public static final CloudRedisSettings create(CloudRedisStubSettings stub) throws IOException {
@@ -270,6 +288,12 @@ public class CloudRedisSettings extends ClientSettings<CloudRedisSettings> {
       return getStubSettingsBuilder().getInstanceSettings();
     }
 
+    /** Returns the builder for the settings used for calls to getInstanceAuthString. */
+    public UnaryCallSettings.Builder<GetInstanceAuthStringRequest, InstanceAuthString>
+        getInstanceAuthStringSettings() {
+      return getStubSettingsBuilder().getInstanceAuthStringSettings();
+    }
+
     /** Returns the builder for the settings used for calls to createInstance. */
     public UnaryCallSettings.Builder<CreateInstanceRequest, Operation> createInstanceSettings() {
       return getStubSettingsBuilder().createInstanceSettings();
@@ -346,6 +370,18 @@ public class CloudRedisSettings extends ClientSettings<CloudRedisSettings> {
     public OperationCallSettings.Builder<DeleteInstanceRequest, Empty, Any>
         deleteInstanceOperationSettings() {
       return getStubSettingsBuilder().deleteInstanceOperationSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to rescheduleMaintenance. */
+    public UnaryCallSettings.Builder<RescheduleMaintenanceRequest, Operation>
+        rescheduleMaintenanceSettings() {
+      return getStubSettingsBuilder().rescheduleMaintenanceSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to rescheduleMaintenance. */
+    public OperationCallSettings.Builder<RescheduleMaintenanceRequest, Instance, Any>
+        rescheduleMaintenanceOperationSettings() {
+      return getStubSettingsBuilder().rescheduleMaintenanceOperationSettings();
     }
 
     @Override

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/MockCloudRedisImpl.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/MockCloudRedisImpl.java
@@ -101,6 +101,27 @@ public class MockCloudRedisImpl extends CloudRedisImplBase {
   }
 
   @Override
+  public void getInstanceAuthString(
+      GetInstanceAuthStringRequest request, StreamObserver<InstanceAuthString> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof InstanceAuthString) {
+      requests.add(request);
+      responseObserver.onNext(((InstanceAuthString) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method GetInstanceAuthString, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  InstanceAuthString.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
   public void createInstance(
       CreateInstanceRequest request, StreamObserver<Operation> responseObserver) {
     Object response = responses.poll();
@@ -241,6 +262,27 @@ public class MockCloudRedisImpl extends CloudRedisImplBase {
           new IllegalArgumentException(
               String.format(
                   "Unrecognized response type %s for method DeleteInstance, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Operation.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void rescheduleMaintenance(
+      RescheduleMaintenanceRequest request, StreamObserver<Operation> responseObserver) {
+    Object response = responses.poll();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext(((Operation) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method RescheduleMaintenance, expected %s or %s",
                   response == null ? "null" : response.getClass().getName(),
                   Operation.class.getName(),
                   Exception.class.getName())));

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/gapic_metadata.json
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/gapic_metadata.json
@@ -25,11 +25,17 @@
             "GetInstance": {
               "methods": ["getInstance", "getInstance", "getInstance", "getInstanceCallable"]
             },
+            "GetInstanceAuthString": {
+              "methods": ["getInstanceAuthString", "getInstanceAuthString", "getInstanceAuthString", "getInstanceAuthStringCallable"]
+            },
             "ImportInstance": {
               "methods": ["importInstanceAsync", "importInstanceAsync", "importInstanceOperationCallable", "importInstanceCallable"]
             },
             "ListInstances": {
               "methods": ["listInstances", "listInstances", "listInstances", "listInstancesPagedCallable", "listInstancesCallable"]
+            },
+            "RescheduleMaintenance": {
+              "methods": ["rescheduleMaintenanceAsync", "rescheduleMaintenanceAsync", "rescheduleMaintenanceAsync", "rescheduleMaintenanceOperationCallable", "rescheduleMaintenanceCallable"]
             },
             "UpdateInstance": {
               "methods": ["updateInstanceAsync", "updateInstanceAsync", "updateInstanceOperationCallable", "updateInstanceCallable"]

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
@@ -26,11 +26,14 @@ import com.google.cloud.redis.v1beta1.CreateInstanceRequest;
 import com.google.cloud.redis.v1beta1.DeleteInstanceRequest;
 import com.google.cloud.redis.v1beta1.ExportInstanceRequest;
 import com.google.cloud.redis.v1beta1.FailoverInstanceRequest;
+import com.google.cloud.redis.v1beta1.GetInstanceAuthStringRequest;
 import com.google.cloud.redis.v1beta1.GetInstanceRequest;
 import com.google.cloud.redis.v1beta1.ImportInstanceRequest;
 import com.google.cloud.redis.v1beta1.Instance;
+import com.google.cloud.redis.v1beta1.InstanceAuthString;
 import com.google.cloud.redis.v1beta1.ListInstancesRequest;
 import com.google.cloud.redis.v1beta1.ListInstancesResponse;
+import com.google.cloud.redis.v1beta1.RescheduleMaintenanceRequest;
 import com.google.cloud.redis.v1beta1.UpdateInstanceRequest;
 import com.google.cloud.redis.v1beta1.UpgradeInstanceRequest;
 import com.google.longrunning.Operation;
@@ -64,6 +67,11 @@ public abstract class CloudRedisStub implements BackgroundResource {
 
   public UnaryCallable<GetInstanceRequest, Instance> getInstanceCallable() {
     throw new UnsupportedOperationException("Not implemented: getInstanceCallable()");
+  }
+
+  public UnaryCallable<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringCallable() {
+    throw new UnsupportedOperationException("Not implemented: getInstanceAuthStringCallable()");
   }
 
   public OperationCallable<CreateInstanceRequest, Instance, Any> createInstanceOperationCallable() {
@@ -122,6 +130,16 @@ public abstract class CloudRedisStub implements BackgroundResource {
 
   public UnaryCallable<DeleteInstanceRequest, Operation> deleteInstanceCallable() {
     throw new UnsupportedOperationException("Not implemented: deleteInstanceCallable()");
+  }
+
+  public OperationCallable<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: rescheduleMaintenanceOperationCallable()");
+  }
+
+  public UnaryCallable<RescheduleMaintenanceRequest, Operation> rescheduleMaintenanceCallable() {
+    throw new UnsupportedOperationException("Not implemented: rescheduleMaintenanceCallable()");
   }
 
   @Override

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -48,11 +48,14 @@ import com.google.cloud.redis.v1beta1.CreateInstanceRequest;
 import com.google.cloud.redis.v1beta1.DeleteInstanceRequest;
 import com.google.cloud.redis.v1beta1.ExportInstanceRequest;
 import com.google.cloud.redis.v1beta1.FailoverInstanceRequest;
+import com.google.cloud.redis.v1beta1.GetInstanceAuthStringRequest;
 import com.google.cloud.redis.v1beta1.GetInstanceRequest;
 import com.google.cloud.redis.v1beta1.ImportInstanceRequest;
 import com.google.cloud.redis.v1beta1.Instance;
+import com.google.cloud.redis.v1beta1.InstanceAuthString;
 import com.google.cloud.redis.v1beta1.ListInstancesRequest;
 import com.google.cloud.redis.v1beta1.ListInstancesResponse;
+import com.google.cloud.redis.v1beta1.RescheduleMaintenanceRequest;
 import com.google.cloud.redis.v1beta1.UpdateInstanceRequest;
 import com.google.cloud.redis.v1beta1.UpgradeInstanceRequest;
 import com.google.common.collect.ImmutableList;
@@ -109,6 +112,8 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
           ListInstancesRequest, ListInstancesResponse, ListInstancesPagedResponse>
       listInstancesSettings;
   private final UnaryCallSettings<GetInstanceRequest, Instance> getInstanceSettings;
+  private final UnaryCallSettings<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringSettings;
   private final UnaryCallSettings<CreateInstanceRequest, Operation> createInstanceSettings;
   private final OperationCallSettings<CreateInstanceRequest, Instance, Any>
       createInstanceOperationSettings;
@@ -130,6 +135,10 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
   private final UnaryCallSettings<DeleteInstanceRequest, Operation> deleteInstanceSettings;
   private final OperationCallSettings<DeleteInstanceRequest, Empty, Any>
       deleteInstanceOperationSettings;
+  private final UnaryCallSettings<RescheduleMaintenanceRequest, Operation>
+      rescheduleMaintenanceSettings;
+  private final OperationCallSettings<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationSettings;
 
   private static final PagedListDescriptor<ListInstancesRequest, ListInstancesResponse, Instance>
       LIST_INSTANCES_PAGE_STR_DESC =
@@ -193,6 +202,12 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
   /** Returns the object with the settings used for calls to getInstance. */
   public UnaryCallSettings<GetInstanceRequest, Instance> getInstanceSettings() {
     return getInstanceSettings;
+  }
+
+  /** Returns the object with the settings used for calls to getInstanceAuthString. */
+  public UnaryCallSettings<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringSettings() {
+    return getInstanceAuthStringSettings;
   }
 
   /** Returns the object with the settings used for calls to createInstance. */
@@ -270,6 +285,18 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
   public OperationCallSettings<DeleteInstanceRequest, Empty, Any>
       deleteInstanceOperationSettings() {
     return deleteInstanceOperationSettings;
+  }
+
+  /** Returns the object with the settings used for calls to rescheduleMaintenance. */
+  public UnaryCallSettings<RescheduleMaintenanceRequest, Operation>
+      rescheduleMaintenanceSettings() {
+    return rescheduleMaintenanceSettings;
+  }
+
+  /** Returns the object with the settings used for calls to rescheduleMaintenance. */
+  public OperationCallSettings<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationSettings() {
+    return rescheduleMaintenanceOperationSettings;
   }
 
   @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
@@ -350,6 +377,7 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
 
     listInstancesSettings = settingsBuilder.listInstancesSettings().build();
     getInstanceSettings = settingsBuilder.getInstanceSettings().build();
+    getInstanceAuthStringSettings = settingsBuilder.getInstanceAuthStringSettings().build();
     createInstanceSettings = settingsBuilder.createInstanceSettings().build();
     createInstanceOperationSettings = settingsBuilder.createInstanceOperationSettings().build();
     updateInstanceSettings = settingsBuilder.updateInstanceSettings().build();
@@ -364,6 +392,9 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
     failoverInstanceOperationSettings = settingsBuilder.failoverInstanceOperationSettings().build();
     deleteInstanceSettings = settingsBuilder.deleteInstanceSettings().build();
     deleteInstanceOperationSettings = settingsBuilder.deleteInstanceOperationSettings().build();
+    rescheduleMaintenanceSettings = settingsBuilder.rescheduleMaintenanceSettings().build();
+    rescheduleMaintenanceOperationSettings =
+        settingsBuilder.rescheduleMaintenanceOperationSettings().build();
   }
 
   /** Builder for CloudRedisStubSettings. */
@@ -373,6 +404,8 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
             ListInstancesRequest, ListInstancesResponse, ListInstancesPagedResponse>
         listInstancesSettings;
     private final UnaryCallSettings.Builder<GetInstanceRequest, Instance> getInstanceSettings;
+    private final UnaryCallSettings.Builder<GetInstanceAuthStringRequest, InstanceAuthString>
+        getInstanceAuthStringSettings;
     private final UnaryCallSettings.Builder<CreateInstanceRequest, Operation>
         createInstanceSettings;
     private final OperationCallSettings.Builder<CreateInstanceRequest, Instance, Any>
@@ -401,6 +434,10 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
         deleteInstanceSettings;
     private final OperationCallSettings.Builder<DeleteInstanceRequest, Empty, Any>
         deleteInstanceOperationSettings;
+    private final UnaryCallSettings.Builder<RescheduleMaintenanceRequest, Operation>
+        rescheduleMaintenanceSettings;
+    private final OperationCallSettings.Builder<RescheduleMaintenanceRequest, Instance, Any>
+        rescheduleMaintenanceOperationSettings;
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
         RETRYABLE_CODE_DEFINITIONS;
 
@@ -409,6 +446,7 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
           ImmutableMap.builder();
       definitions.put(
           "no_retry_0_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
     }
 
@@ -425,6 +463,8 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
               .setTotalTimeout(Duration.ofMillis(600000L))
               .build();
       definitions.put("no_retry_0_params", settings);
+      settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
+      definitions.put("no_retry_params", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
 
@@ -437,6 +477,7 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
 
       listInstancesSettings = PagedCallSettings.newBuilder(LIST_INSTANCES_PAGE_STR_FACT);
       getInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      getInstanceAuthStringSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       createInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       createInstanceOperationSettings = OperationCallSettings.newBuilder();
       updateInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
@@ -451,18 +492,22 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
       failoverInstanceOperationSettings = OperationCallSettings.newBuilder();
       deleteInstanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       deleteInstanceOperationSettings = OperationCallSettings.newBuilder();
+      rescheduleMaintenanceSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      rescheduleMaintenanceOperationSettings = OperationCallSettings.newBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               listInstancesSettings,
               getInstanceSettings,
+              getInstanceAuthStringSettings,
               createInstanceSettings,
               updateInstanceSettings,
               upgradeInstanceSettings,
               importInstanceSettings,
               exportInstanceSettings,
               failoverInstanceSettings,
-              deleteInstanceSettings);
+              deleteInstanceSettings,
+              rescheduleMaintenanceSettings);
       initDefaults(this);
     }
 
@@ -471,6 +516,7 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
 
       listInstancesSettings = settings.listInstancesSettings.toBuilder();
       getInstanceSettings = settings.getInstanceSettings.toBuilder();
+      getInstanceAuthStringSettings = settings.getInstanceAuthStringSettings.toBuilder();
       createInstanceSettings = settings.createInstanceSettings.toBuilder();
       createInstanceOperationSettings = settings.createInstanceOperationSettings.toBuilder();
       updateInstanceSettings = settings.updateInstanceSettings.toBuilder();
@@ -485,18 +531,23 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
       failoverInstanceOperationSettings = settings.failoverInstanceOperationSettings.toBuilder();
       deleteInstanceSettings = settings.deleteInstanceSettings.toBuilder();
       deleteInstanceOperationSettings = settings.deleteInstanceOperationSettings.toBuilder();
+      rescheduleMaintenanceSettings = settings.rescheduleMaintenanceSettings.toBuilder();
+      rescheduleMaintenanceOperationSettings =
+          settings.rescheduleMaintenanceOperationSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
               listInstancesSettings,
               getInstanceSettings,
+              getInstanceAuthStringSettings,
               createInstanceSettings,
               updateInstanceSettings,
               upgradeInstanceSettings,
               importInstanceSettings,
               exportInstanceSettings,
               failoverInstanceSettings,
-              deleteInstanceSettings);
+              deleteInstanceSettings,
+              rescheduleMaintenanceSettings);
     }
 
     private static Builder createDefault() {
@@ -520,6 +571,11 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
 
       builder
           .getInstanceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
+      builder
+          .getInstanceAuthStringSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
 
@@ -557,6 +613,11 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
           .deleteInstanceSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_0_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_0_params"));
+
+      builder
+          .rescheduleMaintenanceSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
       builder
           .createInstanceOperationSettings()
@@ -719,6 +780,29 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
                       .setTotalTimeout(Duration.ofMillis(1200000L))
                       .build()));
 
+      builder
+          .rescheduleMaintenanceOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings
+                  .<RescheduleMaintenanceRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"))
+                  .build())
+          .setResponseTransformer(
+              ProtoOperationTransformers.ResponseTransformer.create(Instance.class))
+          .setMetadataTransformer(ProtoOperationTransformers.MetadataTransformer.create(Any.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                      .setRetryDelayMultiplier(1.5)
+                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                      .setInitialRpcTimeout(Duration.ZERO)
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeout(Duration.ZERO)
+                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .build()));
+
       return builder;
     }
 
@@ -747,6 +831,12 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
     /** Returns the builder for the settings used for calls to getInstance. */
     public UnaryCallSettings.Builder<GetInstanceRequest, Instance> getInstanceSettings() {
       return getInstanceSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to getInstanceAuthString. */
+    public UnaryCallSettings.Builder<GetInstanceAuthStringRequest, InstanceAuthString>
+        getInstanceAuthStringSettings() {
+      return getInstanceAuthStringSettings;
     }
 
     /** Returns the builder for the settings used for calls to createInstance. */
@@ -839,6 +929,20 @@ public class CloudRedisStubSettings extends StubSettings<CloudRedisStubSettings>
     public OperationCallSettings.Builder<DeleteInstanceRequest, Empty, Any>
         deleteInstanceOperationSettings() {
       return deleteInstanceOperationSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to rescheduleMaintenance. */
+    public UnaryCallSettings.Builder<RescheduleMaintenanceRequest, Operation>
+        rescheduleMaintenanceSettings() {
+      return rescheduleMaintenanceSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to rescheduleMaintenance. */
+    @BetaApi(
+        "The surface for use by generated code is not stable yet and may change in the future.")
+    public OperationCallSettings.Builder<RescheduleMaintenanceRequest, Instance, Any>
+        rescheduleMaintenanceOperationSettings() {
+      return rescheduleMaintenanceOperationSettings;
     }
 
     @Override

--- a/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
+++ b/test/integration/goldens/redis/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
@@ -30,11 +30,14 @@ import com.google.cloud.redis.v1beta1.CreateInstanceRequest;
 import com.google.cloud.redis.v1beta1.DeleteInstanceRequest;
 import com.google.cloud.redis.v1beta1.ExportInstanceRequest;
 import com.google.cloud.redis.v1beta1.FailoverInstanceRequest;
+import com.google.cloud.redis.v1beta1.GetInstanceAuthStringRequest;
 import com.google.cloud.redis.v1beta1.GetInstanceRequest;
 import com.google.cloud.redis.v1beta1.ImportInstanceRequest;
 import com.google.cloud.redis.v1beta1.Instance;
+import com.google.cloud.redis.v1beta1.InstanceAuthString;
 import com.google.cloud.redis.v1beta1.ListInstancesRequest;
 import com.google.cloud.redis.v1beta1.ListInstancesResponse;
+import com.google.cloud.redis.v1beta1.RescheduleMaintenanceRequest;
 import com.google.cloud.redis.v1beta1.UpdateInstanceRequest;
 import com.google.cloud.redis.v1beta1.UpgradeInstanceRequest;
 import com.google.common.collect.ImmutableMap;
@@ -76,6 +79,16 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
           .setRequestMarshaller(ProtoUtils.marshaller(GetInstanceRequest.getDefaultInstance()))
           .setResponseMarshaller(ProtoUtils.marshaller(Instance.getDefaultInstance()))
           .build();
+
+  private static final MethodDescriptor<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringMethodDescriptor =
+          MethodDescriptor.<GetInstanceAuthStringRequest, InstanceAuthString>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.cloud.redis.v1beta1.CloudRedis/GetInstanceAuthString")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(GetInstanceAuthStringRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(InstanceAuthString.getDefaultInstance()))
+              .build();
 
   private static final MethodDescriptor<CreateInstanceRequest, Operation>
       createInstanceMethodDescriptor =
@@ -147,10 +160,22 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
               .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
               .build();
 
+  private static final MethodDescriptor<RescheduleMaintenanceRequest, Operation>
+      rescheduleMaintenanceMethodDescriptor =
+          MethodDescriptor.<RescheduleMaintenanceRequest, Operation>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.cloud.redis.v1beta1.CloudRedis/RescheduleMaintenance")
+              .setRequestMarshaller(
+                  ProtoUtils.marshaller(RescheduleMaintenanceRequest.getDefaultInstance()))
+              .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+              .build();
+
   private final UnaryCallable<ListInstancesRequest, ListInstancesResponse> listInstancesCallable;
   private final UnaryCallable<ListInstancesRequest, ListInstancesPagedResponse>
       listInstancesPagedCallable;
   private final UnaryCallable<GetInstanceRequest, Instance> getInstanceCallable;
+  private final UnaryCallable<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringCallable;
   private final UnaryCallable<CreateInstanceRequest, Operation> createInstanceCallable;
   private final OperationCallable<CreateInstanceRequest, Instance, Any>
       createInstanceOperationCallable;
@@ -172,6 +197,10 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
   private final UnaryCallable<DeleteInstanceRequest, Operation> deleteInstanceCallable;
   private final OperationCallable<DeleteInstanceRequest, Empty, Any>
       deleteInstanceOperationCallable;
+  private final UnaryCallable<RescheduleMaintenanceRequest, Operation>
+      rescheduleMaintenanceCallable;
+  private final OperationCallable<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationCallable;
 
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
@@ -235,6 +264,17 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
                   return params.build();
                 })
             .build();
+    GrpcCallSettings<GetInstanceAuthStringRequest, InstanceAuthString>
+        getInstanceAuthStringTransportSettings =
+            GrpcCallSettings.<GetInstanceAuthStringRequest, InstanceAuthString>newBuilder()
+                .setMethodDescriptor(getInstanceAuthStringMethodDescriptor)
+                .setParamsExtractor(
+                    request -> {
+                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                      params.put("name", String.valueOf(request.getName()));
+                      return params.build();
+                    })
+                .build();
     GrpcCallSettings<CreateInstanceRequest, Operation> createInstanceTransportSettings =
         GrpcCallSettings.<CreateInstanceRequest, Operation>newBuilder()
             .setMethodDescriptor(createInstanceMethodDescriptor)
@@ -305,6 +345,17 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
                   return params.build();
                 })
             .build();
+    GrpcCallSettings<RescheduleMaintenanceRequest, Operation>
+        rescheduleMaintenanceTransportSettings =
+            GrpcCallSettings.<RescheduleMaintenanceRequest, Operation>newBuilder()
+                .setMethodDescriptor(rescheduleMaintenanceMethodDescriptor)
+                .setParamsExtractor(
+                    request -> {
+                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                      params.put("name", String.valueOf(request.getName()));
+                      return params.build();
+                    })
+                .build();
 
     this.listInstancesCallable =
         callableFactory.createUnaryCallable(
@@ -315,6 +366,11 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
     this.getInstanceCallable =
         callableFactory.createUnaryCallable(
             getInstanceTransportSettings, settings.getInstanceSettings(), clientContext);
+    this.getInstanceAuthStringCallable =
+        callableFactory.createUnaryCallable(
+            getInstanceAuthStringTransportSettings,
+            settings.getInstanceAuthStringSettings(),
+            clientContext);
     this.createInstanceCallable =
         callableFactory.createUnaryCallable(
             createInstanceTransportSettings, settings.createInstanceSettings(), clientContext);
@@ -378,6 +434,17 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
             settings.deleteInstanceOperationSettings(),
             clientContext,
             operationsStub);
+    this.rescheduleMaintenanceCallable =
+        callableFactory.createUnaryCallable(
+            rescheduleMaintenanceTransportSettings,
+            settings.rescheduleMaintenanceSettings(),
+            clientContext);
+    this.rescheduleMaintenanceOperationCallable =
+        callableFactory.createOperationCallable(
+            rescheduleMaintenanceTransportSettings,
+            settings.rescheduleMaintenanceOperationSettings(),
+            clientContext,
+            operationsStub);
 
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -401,6 +468,12 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
   @Override
   public UnaryCallable<GetInstanceRequest, Instance> getInstanceCallable() {
     return getInstanceCallable;
+  }
+
+  @Override
+  public UnaryCallable<GetInstanceAuthStringRequest, InstanceAuthString>
+      getInstanceAuthStringCallable() {
+    return getInstanceAuthStringCallable;
   }
 
   @Override
@@ -473,6 +546,17 @@ public class GrpcCloudRedisStub extends CloudRedisStub {
   @Override
   public OperationCallable<DeleteInstanceRequest, Empty, Any> deleteInstanceOperationCallable() {
     return deleteInstanceOperationCallable;
+  }
+
+  @Override
+  public UnaryCallable<RescheduleMaintenanceRequest, Operation> rescheduleMaintenanceCallable() {
+    return rescheduleMaintenanceCallable;
+  }
+
+  @Override
+  public OperationCallable<RescheduleMaintenanceRequest, Instance, Any>
+      rescheduleMaintenanceOperationCallable() {
+    return rescheduleMaintenanceOperationCallable;
   }
 
   @Override

--- a/test/integration/goldens/storage/com/google/storage/v2/StorageClient.java
+++ b/test/integration/goldens/storage/com/google/storage/v2/StorageClient.java
@@ -375,9 +375,9 @@ public class StorageClient implements BackgroundResource {
    * @param parent Required. The project to which this bucket will belong.
    * @param bucket Required. Properties of the new bucket being inserted. The project and name of
    *     the bucket are specified in this request, not in the bucket resource.
-   * @param bucketId The ID to use for this bucket, which will become the final component of the
-   *     bucket's resource name. For example, the value `foo` might result in a bucket with the name
-   *     `projects/123456/buckets/foo`.
+   * @param bucketId Required. The ID to use for this bucket, which will become the final component
+   *     of the bucket's resource name. For example, the value `foo` might result in a bucket with
+   *     the name `projects/123456/buckets/foo`.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Bucket createBucket(ProjectName parent, Bucket bucket, String bucketId) {
@@ -408,9 +408,9 @@ public class StorageClient implements BackgroundResource {
    * @param parent Required. The project to which this bucket will belong.
    * @param bucket Required. Properties of the new bucket being inserted. The project and name of
    *     the bucket are specified in this request, not in the bucket resource.
-   * @param bucketId The ID to use for this bucket, which will become the final component of the
-   *     bucket's resource name. For example, the value `foo` might result in a bucket with the name
-   *     `projects/123456/buckets/foo`.
+   * @param bucketId Required. The ID to use for this bucket, which will become the final component
+   *     of the bucket's resource name. For example, the value `foo` might result in a bucket with
+   *     the name `projects/123456/buckets/foo`.
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
   public final Bucket createBucket(String parent, Bucket bucket, String bucketId) {
@@ -2228,8 +2228,12 @@ public class StorageClient implements BackgroundResource {
    * try (StorageClient storageClient = StorageClient.create()) {
    *   RewriteObjectRequest request =
    *       RewriteObjectRequest.newBuilder()
+   *           .setDestinationName("destinationName-1762755655")
+   *           .setDestinationBucket(BucketName.of("[PROJECT]", "[BUCKET]").toString())
+   *           .setDestinationKmsKey(
+   *               CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+   *                   .toString())
    *           .setDestination(Object.newBuilder().build())
-   *           .setRewriteMask(FieldMask.newBuilder().build())
    *           .setSourceBucket("sourceBucket841604581")
    *           .setSourceObject("sourceObject1196439354")
    *           .setSourceGeneration(1232209852)
@@ -2271,8 +2275,12 @@ public class StorageClient implements BackgroundResource {
    * try (StorageClient storageClient = StorageClient.create()) {
    *   RewriteObjectRequest request =
    *       RewriteObjectRequest.newBuilder()
+   *           .setDestinationName("destinationName-1762755655")
+   *           .setDestinationBucket(BucketName.of("[PROJECT]", "[BUCKET]").toString())
+   *           .setDestinationKmsKey(
+   *               CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+   *                   .toString())
    *           .setDestination(Object.newBuilder().build())
-   *           .setRewriteMask(FieldMask.newBuilder().build())
    *           .setSourceBucket("sourceBucket841604581")
    *           .setSourceObject("sourceObject1196439354")
    *           .setSourceGeneration(1232209852)

--- a/test/integration/goldens/storage/com/google/storage/v2/StorageClientTest.java
+++ b/test/integration/goldens/storage/com/google/storage/v2/StorageClientTest.java
@@ -1328,7 +1328,7 @@ public class StorageClientTest {
             .putAllMetadata(new HashMap<String, String>())
             .setEventBasedHold(true)
             .setOwner(Owner.newBuilder().build())
-            .setCustomerEncryption(Object.CustomerEncryption.newBuilder().build())
+            .setCustomerEncryption(CustomerEncryption.newBuilder().build())
             .setCustomTime(Timestamp.newBuilder().build())
             .build();
     mockStorage.addResponse(expectedResponse);
@@ -1504,7 +1504,7 @@ public class StorageClientTest {
             .putAllMetadata(new HashMap<String, String>())
             .setEventBasedHold(true)
             .setOwner(Owner.newBuilder().build())
-            .setCustomerEncryption(Object.CustomerEncryption.newBuilder().build())
+            .setCustomerEncryption(CustomerEncryption.newBuilder().build())
             .setCustomTime(Timestamp.newBuilder().build())
             .build();
     mockStorage.addResponse(expectedResponse);
@@ -1572,7 +1572,7 @@ public class StorageClientTest {
             .putAllMetadata(new HashMap<String, String>())
             .setEventBasedHold(true)
             .setOwner(Owner.newBuilder().build())
-            .setCustomerEncryption(Object.CustomerEncryption.newBuilder().build())
+            .setCustomerEncryption(CustomerEncryption.newBuilder().build())
             .setCustomTime(Timestamp.newBuilder().build())
             .build();
     mockStorage.addResponse(expectedResponse);
@@ -1716,7 +1716,7 @@ public class StorageClientTest {
             .putAllMetadata(new HashMap<String, String>())
             .setEventBasedHold(true)
             .setOwner(Owner.newBuilder().build())
-            .setCustomerEncryption(Object.CustomerEncryption.newBuilder().build())
+            .setCustomerEncryption(CustomerEncryption.newBuilder().build())
             .setCustomTime(Timestamp.newBuilder().build())
             .build();
     mockStorage.addResponse(expectedResponse);
@@ -1916,8 +1916,12 @@ public class StorageClientTest {
 
     RewriteObjectRequest request =
         RewriteObjectRequest.newBuilder()
+            .setDestinationName("destinationName-1762755655")
+            .setDestinationBucket(BucketName.of("[PROJECT]", "[BUCKET]").toString())
+            .setDestinationKmsKey(
+                CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+                    .toString())
             .setDestination(Object.newBuilder().build())
-            .setRewriteMask(FieldMask.newBuilder().build())
             .setSourceBucket("sourceBucket841604581")
             .setSourceObject("sourceObject1196439354")
             .setSourceGeneration(1232209852)
@@ -1946,8 +1950,10 @@ public class StorageClientTest {
     Assert.assertEquals(1, actualRequests.size());
     RewriteObjectRequest actualRequest = ((RewriteObjectRequest) actualRequests.get(0));
 
+    Assert.assertEquals(request.getDestinationName(), actualRequest.getDestinationName());
+    Assert.assertEquals(request.getDestinationBucket(), actualRequest.getDestinationBucket());
+    Assert.assertEquals(request.getDestinationKmsKey(), actualRequest.getDestinationKmsKey());
     Assert.assertEquals(request.getDestination(), actualRequest.getDestination());
-    Assert.assertEquals(request.getRewriteMask(), actualRequest.getRewriteMask());
     Assert.assertEquals(request.getSourceBucket(), actualRequest.getSourceBucket());
     Assert.assertEquals(request.getSourceObject(), actualRequest.getSourceObject());
     Assert.assertEquals(request.getSourceGeneration(), actualRequest.getSourceGeneration());
@@ -1996,8 +2002,12 @@ public class StorageClientTest {
     try {
       RewriteObjectRequest request =
           RewriteObjectRequest.newBuilder()
+              .setDestinationName("destinationName-1762755655")
+              .setDestinationBucket(BucketName.of("[PROJECT]", "[BUCKET]").toString())
+              .setDestinationKmsKey(
+                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+                      .toString())
               .setDestination(Object.newBuilder().build())
-              .setRewriteMask(FieldMask.newBuilder().build())
               .setSourceBucket("sourceBucket841604581")
               .setSourceObject("sourceObject1196439354")
               .setSourceGeneration(1232209852)


### PR DESCRIPTION
Routing annotation was not recognized on parsing protos, this is due to RoutingProto's extensions are not registered. This also indicate that we are missing integration tests for the new routing annotation, hence added bigtable to integration tests as well.