### PR TITLE
chore: Bump gax-version to 2.12.2. 

### DIFF
--- a/PROPERTIES.bzl
+++ b/PROPERTIES.bzl
@@ -2,7 +2,6 @@ PROPERTIES = {
     "version.com_google_protobuf": "3.19.1",
     # Version of google-java-format is downgraded from 1.8 to 1.7, because 1.8 supports java 11 minimum, while our JRE is java 8.
     "version.google_java_format": "1.7",
-    "version.com_google_api_common_java": "1.9.3",
     "version.io_grpc_java": "1.42.1",
 
     # Common deps.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,7 +33,7 @@ jvm_maven_import_external(
 # which in its turn, prioritizes actual generated clients runtime dependencies
 # over the generator dependencies.
 
-_gax_java_version = "2.11.0"
+_gax_java_version = "2.12.2"
 
 http_archive(
     name = "com_google_api_gax_java",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -77,14 +77,6 @@ def gapic_generator_java_repositories():
         actual = "@com_google_code_gson_gson//jar",
     )
 
-    _api_common_java_version = PROPERTIES["version.com_google_api_common_java"]
-    _maybe(
-        jvm_maven_import_external,
-        name = "com_google_api_api_common",
-        artifact = "com.google.api:api-common:%s" % _api_common_java_version,
-        server_urls = ["https://repo.maven.apache.org/maven2/"],
-    )
-
     # grpc-proto doesn't have releases, so we use hashes instead.
     _io_grpc_proto_prefix = "8e3fec8612bc0708e857950dccadfd5063703e04"  # Nov. 6, 2021.
     _maybe(


### PR DESCRIPTION
Bump gax-version to 2.12.2. Remove unnecessary api-common dependency since it's a transitive dependency of gax.