### PR TITLE
fix: setups for manually runs single JUnit test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -209,6 +209,7 @@ GOLDEN_UPDATING_UNIT_TESTS = [
     args = [test_class],
     runtime_deps = [
         ":gapic_generator_java",
+        ":gapic_generator_java_test",
     ] + MAIN_DEPS + TEST_DEPS,
     data = glob([
         "src/test/java/**/*.golden",


### PR DESCRIPTION
This seems to be added setup in #936, but later accidentally deleted?

Verified test runs with command `bazel run //:update_com_google_api_generator_engine_JavaCodeGeneratorTest`