### PR TITLE
chore: update snippet bot to ignore unit tests

### DIFF
--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -1,2 +1,4 @@
 aggregateChecks: false
 alwaysCreateStatusCheck: false
+ignoreFiles:
+  - src/test/**


### PR DESCRIPTION
Check failing on unit test made up product prefix in generated sample region tags.
[example](https://github.com/googleapis/gapic-generator-java/pull/933/checks?check_run_id=5559995994)