### PR TITLE
fix: pre-commit script addlicense tool installation command and add same for buildifier

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,7 +48,29 @@ function header_check_preparation {
       if [ $? -ne 0 ];
       then
         echo_status "addlicense tool is not yet installed, downloading it now."
-        go get -u github.com/google/addlicense
+        go install github.com/google/addlicense@latest
+      fi
+  fi
+}
+
+function buildifier_preparation {
+  echo_status "Setting up tool to fix Bazel format"
+  export GOPATH=$(go env GOPATH)
+  if [ $? -ne 0 ];
+  then
+      echo_status "Please install Go first, instructions can be found here: https://golang.org/doc/install."
+  else
+      export ENV_PATH=$(echo $PATH)
+      if [[ $ENV_PATH != *$GOPATH* ]];
+      then
+        echo_status "GOPATH is not in the system path, adding it now."
+        export PATH=$GOPATH/bin:$PATH
+      fi
+      which addlicense
+      if [ $? -ne 0 ];
+      then
+        echo_status "buildifier tool is not yet installed, downloading it now."
+        go install github.com/bazelbuild/buildtools/buildifier@latest
       fi
   fi
 }
@@ -123,6 +145,7 @@ fi
 # Check and fix Bazel format.
 if [ $NUM_BAZEL_FILES_CHANGED -gt 0 ]
 then
+  buildifier_preparation
   for FILE in $(find ./ -name BUILD.bazel)
   do
     buildifier --lint=fix $FILE


### PR DESCRIPTION
- `go get -u` command used to install `addlicense` tool in L51 is [deprecated](https://go.dev/doc/go-get-install-deprecation#overview) since Go 1.17. Replace it with `go install`.
- Add similar function to install `buildifier` if not already installed. This is used to fix Bazel format.

These are for development onboard only, tested changes locally:
```
INFO: Running command line: bazel-bin/google_java_format_verification.sh
INFO: Build completed successfully, 3 total actions
   Precommit:    Setting up tool to fix Bazel format 
   Precommit:    buildifier tool is not yet installed, downloading it now. 
   Precommit:    Checking Apache License Header ... 
   Precommit:    Setting up license check environment 
   Precommit:    addlicense tool is not yet installed, downloading it now. 
   Precommit:      SUCCESS.  All checks passed!
[fix-pre-commit 54419ff6] fake commit to test.
```