### PR TITLE
feat: Add add autogenerated javadoc sample for selecting REST transport over gRPC

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -55,6 +55,8 @@ public class ServiceClientCommentComposer {
       "To customize credentials:";
   private static final String SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING =
       "To customize the endpoint:";
+  private static final String SERVICE_DESCRIPTION_TRANSPORT_SUMMARY_STRING =
+      "To use %s transport (instead of %s) for sending an receiving requests over the wire:";
 
   private static final String SERVICE_DESCRIPTION_SAMPLE_REFERENCE_STRING =
       "Please refer to the GitHub repository's samples for more quickstart code snippets.";
@@ -112,7 +114,10 @@ public class ServiceClientCommentComposer {
       Service service,
       String classMethodSampleCode,
       String credentialsSampleCode,
-      String endpointSampleCode) {
+      String endpointSampleCode,
+      String transportStample,
+      String primaryTransport,
+      String secondaryTransport) {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
     if (service.hasDescription()) {
       classHeaderJavadocBuilder =
@@ -146,6 +151,12 @@ public class ServiceClientCommentComposer {
     classHeaderJavadocBuilder.addSampleCode(credentialsSampleCode);
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
     classHeaderJavadocBuilder.addSampleCode(endpointSampleCode);
+    if (transportStample != null) {
+      classHeaderJavadocBuilder.addParagraph(
+          String.format(
+              SERVICE_DESCRIPTION_TRANSPORT_SUMMARY_STRING, secondaryTransport, primaryTransport));
+      classHeaderJavadocBuilder.addSampleCode(transportStample);
+    }
 
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_SAMPLE_REFERENCE_STRING);
 

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -115,7 +115,7 @@ public class ServiceClientCommentComposer {
       String classMethodSampleCode,
       String credentialsSampleCode,
       String endpointSampleCode,
-      String transportStample,
+      String transportSampleCode,
       String primaryTransport,
       String secondaryTransport) {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
@@ -151,11 +151,11 @@ public class ServiceClientCommentComposer {
     classHeaderJavadocBuilder.addSampleCode(credentialsSampleCode);
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_ENDPOINT_SUMMARY_STRING);
     classHeaderJavadocBuilder.addSampleCode(endpointSampleCode);
-    if (transportStample != null) {
+    if (transportSampleCode != null) {
       classHeaderJavadocBuilder.addParagraph(
           String.format(
               SERVICE_DESCRIPTION_TRANSPORT_SUMMARY_STRING, secondaryTransport, primaryTransport));
-      classHeaderJavadocBuilder.addSampleCode(transportStample);
+      classHeaderJavadocBuilder.addSampleCode(transportSampleCode);
     }
 
     classHeaderJavadocBuilder.addParagraph(SERVICE_DESCRIPTION_SAMPLE_REFERENCE_STRING);

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
@@ -188,7 +188,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
     return Arrays.asList(typeStore.get("BackgroundResource"));
   }
 
-  private static List<CommentStatement> createClassHeaderComments(
+  protected List<CommentStatement> createClassHeaderComments(
       Service service,
       TypeStore typeStore,
       Map<String, ResourceName> resourceNames,
@@ -208,7 +208,10 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
         service,
         SampleCodeWriter.writeInlineSample(classMethodSampleCode.body()),
         SampleCodeWriter.writeInlineSample(credentialsSampleCode.body()),
-        SampleCodeWriter.writeInlineSample(endpointSampleCode.body()));
+        SampleCodeWriter.writeInlineSample(endpointSampleCode.body()),
+        null,
+        null,
+        null);
   }
 
   private List<MethodDefinition> createClassMethods(

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcRestTestProtoLoader.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcRestTestProtoLoader.java
@@ -54,7 +54,7 @@ public class GrpcRestTestProtoLoader extends TestProtoLoader {
     FileDescriptor echoFileDescriptor = EchoGrpcrest.getDescriptor();
 
     ServiceDescriptor echoServiceDescriptor = echoFileDescriptor.getServices().get(0);
-    assertEquals(echoServiceDescriptor.getName(), "Echo");
+    assertEquals("Echo", echoServiceDescriptor.getName());
 
     Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
     Map<String, Message> operationMessageTypes =

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcRestTestProtoLoader.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcRestTestProtoLoader.java
@@ -1,0 +1,84 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.generator.gapic.composer.common.TestProtoLoader;
+import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.gapic.model.GapicServiceConfig;
+import com.google.api.generator.gapic.model.Message;
+import com.google.api.generator.gapic.model.ResourceName;
+import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.model.Transport;
+import com.google.api.generator.gapic.protoparser.Parser;
+import com.google.api.generator.gapic.protoparser.ServiceConfigParser;
+import com.google.longrunning.OperationsProto;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
+import com.google.showcase.grpcrest.v1beta1.EchoGrpcrest;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class GrpcRestTestProtoLoader extends TestProtoLoader {
+  private static final GrpcRestTestProtoLoader INSTANCE = new GrpcRestTestProtoLoader();
+
+  protected GrpcRestTestProtoLoader() {
+    super(Transport.GRPC_REST, "src/test/resources/");
+  }
+
+  public static GrpcRestTestProtoLoader instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public GapicContext parseShowcaseEcho() {
+    FileDescriptor echoFileDescriptor = EchoGrpcrest.getDescriptor();
+
+    ServiceDescriptor echoServiceDescriptor = echoFileDescriptor.getServices().get(0);
+    assertEquals(echoServiceDescriptor.getName(), "Echo");
+
+    Map<String, Message> messageTypes = Parser.parseMessages(echoFileDescriptor);
+    Map<String, Message> operationMessageTypes =
+        Parser.parseMessages(OperationsProto.getDescriptor());
+    messageTypes.putAll(operationMessageTypes);
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(echoFileDescriptor);
+    Set<ResourceName> outputResourceNames = new HashSet<>();
+    List<Service> services =
+        Parser.parseService(
+            echoFileDescriptor, messageTypes, resourceNames, Optional.empty(), outputResourceNames);
+
+    String jsonFilename = "showcase_grpc_service_config.json";
+    Path jsonPath = Paths.get(getTestFilesDirectory(), jsonFilename);
+    Optional<GapicServiceConfig> configOpt = ServiceConfigParser.parse(jsonPath.toString());
+    assertTrue(configOpt.isPresent());
+    GapicServiceConfig config = configOpt.get();
+
+    return GapicContext.builder()
+        .setMessages(messageTypes)
+        .setResourceNames(resourceNames)
+        .setServices(services)
+        .setServiceConfig(config)
+        .setHelperResourceNames(outputResourceNames)
+        .setTransport(getTransport())
+        .build();
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceCallableFactoryClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceCallableFactoryClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.grpc.GrpcServiceCallableFactoryClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
@@ -24,19 +25,19 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class GrpcServiceCallableFactoryClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+        GrpcServiceCallableFactoryClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
+    Utils.saveCodegenToFile(this.getClass(), "GrpcEchoCallableFactory.golden", visitor.write());
     Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+        Paths.get(Utils.getGoldenDir(this.getClass()), "GrpcEchoCallableFactory.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/GrpcServiceStubClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.grpc.GrpcServiceStubClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
@@ -24,19 +25,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class GrpcServiceStubClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
-    GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+    GapicClass clazz = GrpcServiceStubClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+    Utils.saveCodegenToFile(this.getClass(), "GrpcEchoStub.golden", visitor.write());
+    Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), "GrpcEchoStub.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceCallableFactoryClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceCallableFactoryClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.rest.HttpJsonServiceCallableFactoryClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
@@ -24,19 +25,19 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class HttpJsonServiceCallableFactoryClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+        HttpJsonServiceCallableFactoryClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
+    Utils.saveCodegenToFile(this.getClass(), "HttpJsonEchoCallableFactory.golden", visitor.write());
     Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+        Paths.get(Utils.getGoldenDir(this.getClass()), "HttpJsonEchoCallableFactory.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import static com.google.api.generator.test.framework.Assert.assertCodeEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
-import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.framework.Utils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class HttpJsonServiceClientTestClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+        HttpJsonServiceClientTestClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
+    Utils.saveCodegenToFile(this.getClass(), "EchoClientHttpJsonTest.golden", visitor.write());
     Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
-    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+        Paths.get(Utils.getGoldenDir(this.getClass()), "EchoClientHttpJsonTest.golden");
+    assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceStubClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
 import com.google.api.generator.gapic.model.GapicClass;
@@ -24,19 +24,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class HttpJsonServiceStubClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+        HttpJsonServiceStubClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+    Utils.saveCodegenToFile(this.getClass(), "HttpJsonEchoStub.golden", visitor.write());
+    Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), "HttpJsonEchoStub.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
 import com.google.api.generator.gapic.model.GapicClass;
@@ -24,19 +24,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class ServiceClientClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
-    GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+    GapicClass clazz = ServiceClientClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+    Utils.saveCodegenToFile(this.getClass(), "EchoClient.golden", visitor.write());
+    Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), "EchoClient.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientTestClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientTestClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
+
+import static com.google.api.generator.test.framework.Assert.assertCodeEquals;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
+import com.google.api.generator.gapic.composer.grpc.ServiceClientTestClassComposer;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Service;
-import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.framework.Utils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class ServiceClientTestClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+        ServiceClientTestClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
-    Assert.assertCodeEquals(goldenFilePath, visitor.write());
+    Utils.saveCodegenToFile(this.getClass(), "EchoClientTest.golden", visitor.write());
+    Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), "EchoClientTest.golden");
+    assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceSettingsClassComposerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.api.generator.gapic.composer.rest;
+package com.google.api.generator.gapic.composer.grpcrest;
 
 import com.google.api.generator.engine.writer.JavaWriterVisitor;
 import com.google.api.generator.gapic.model.GapicClass;
@@ -24,19 +24,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ServiceStubSettingsClassComposerTest {
+public class ServiceSettingsClassComposerTest {
   @Test
   public void generateServiceClasses() {
-    GapicContext context = RestTestProtoLoader.instance().parseCompliance();
+    GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
-    GapicClass clazz =
-        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
+    GapicClass clazz = ServiceSettingsClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);
-    Utils.saveCodegenToFile(this.getClass(), "ComplianceStubSettings.golden", visitor.write());
-    Path goldenFilePath =
-        Paths.get(Utils.getGoldenDir(this.getClass()), "ComplianceStubSettings.golden");
+    Utils.saveCodegenToFile(this.getClass(), "EchoSettings.golden", visitor.write());
+    Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), "EchoSettings.golden");
     Assert.assertCodeEquals(goldenFilePath, visitor.write());
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -1,0 +1,992 @@
+package com.google.showcase.grpcrest.v1beta1;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.httpjson.longrunning.OperationsClient;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.paging.AbstractFixedSizeCollection;
+import com.google.api.gax.paging.AbstractPage;
+import com.google.api.gax.paging.AbstractPagedListResponse;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import com.google.rpc.Status;
+import com.google.showcase.grpcrest.v1beta1.stub.EchoStub;
+import com.google.showcase.grpcrest.v1beta1.stub.EchoStubSettings;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * This class provides the ability to make remote calls to the backing service through method calls
+ * that map to API methods. Sample code to get started:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated for illustrative purposes only.
+ * // It may require modifications to work in your environment.
+ * try (EchoClient echoClient = EchoClient.create()) {
+ *   EchoResponse response = echoClient.echo();
+ * }
+ * }</pre>
+ *
+ * <p>Note: close() needs to be called on the EchoClient object to clean up resources such as
+ * threads. In the example above, try-with-resources is used, which automatically calls close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's
+ * methods:
+ *
+ * <ol>
+ *   <li>A "flattened" method. With this type of method, the fields of the request type have been
+ *       converted into function parameters. It may be the case that not all fields are available as
+ *       parameters, and not every API method will have a flattened method entry point.
+ *   <li>A "request object" method. This type of method only takes one parameter, a request object,
+ *       which must be constructed before the call. Not every API method will have a request object
+ *       method.
+ *   <li>A "callable" method. This type of method takes no parameters and returns an immutable API
+ *       callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist with
+ * these names, this class includes a format method for each type of name, and additionally a parse
+ * method to extract the individual identifiers contained within names that are returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of EchoSettings to create(). For
+ * example:
+ *
+ * <p>To customize credentials:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated for illustrative purposes only.
+ * // It may require modifications to work in your environment.
+ * EchoSettings echoSettings =
+ *     EchoSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * }</pre>
+ *
+ * <p>To customize the endpoint:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated for illustrative purposes only.
+ * // It may require modifications to work in your environment.
+ * EchoSettings echoSettings = EchoSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * }</pre>
+ *
+ * <p>To use REST (HTTP1.1/JSON) transport (instead of gRPC) for sending an receiving requests over
+ * the wire:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated for illustrative purposes only.
+ * // It may require modifications to work in your environment.
+ * EchoSettings echoSettings =
+ *     EchoSettings.newBuilder()
+ *         .setTransportChannelProvider(
+ *             EchoSettings.defaultHttpJsonTransportProviderBuilder().build())
+ *         .build();
+ * EchoClient echoClient = EchoClient.create(echoSettings);
+ * }</pre>
+ *
+ * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+public class EchoClient implements BackgroundResource {
+  private final EchoSettings settings;
+  private final EchoStub stub;
+  private final OperationsClient httpJsonOperationsClient;
+  private final com.google.longrunning.OperationsClient operationsClient;
+
+  /** Constructs an instance of EchoClient with default settings. */
+  public static final EchoClient create() throws IOException {
+    return create(EchoSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of EchoClient, using the given settings. The channels are created based
+   * on the settings passed in, or defaults for any settings that are not set.
+   */
+  public static final EchoClient create(EchoSettings settings) throws IOException {
+    return new EchoClient(settings);
+  }
+
+  /**
+   * Constructs an instance of EchoClient, using the given stub for making calls. This is for
+   * advanced usage - prefer using create(EchoSettings).
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final EchoClient create(EchoStub stub) {
+    return new EchoClient(stub);
+  }
+
+  /**
+   * Constructs an instance of EchoClient, using the given settings. This is protected so that it is
+   * easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected EchoClient(EchoSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((EchoStubSettings) settings.getStubSettings()).createStub();
+    this.operationsClient =
+        com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
+    this.httpJsonOperationsClient = OperationsClient.create(this.stub.getHttpJsonOperationsStub());
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected EchoClient(EchoStub stub) {
+    this.settings = null;
+    this.stub = stub;
+    this.operationsClient =
+        com.google.longrunning.OperationsClient.create(this.stub.getOperationsStub());
+    this.httpJsonOperationsClient = OperationsClient.create(this.stub.getHttpJsonOperationsStub());
+  }
+
+  public final EchoSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public EchoStub getStub() {
+    return stub;
+  }
+
+  /**
+   * Returns the OperationsClient that can be used to query the status of a long-running operation
+   * returned by another API method call.
+   */
+  public final com.google.longrunning.OperationsClient getOperationsClient() {
+    return operationsClient;
+  }
+
+  /**
+   * Returns the OperationsClient that can be used to query the status of a long-running operation
+   * returned by another API method call.
+   */
+  public final OperationsClient getHttpJsonOperationsClient() {
+    return httpJsonOperationsClient;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoResponse response = echoClient.echo();
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo() {
+    EchoRequest request = EchoRequest.newBuilder().build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   ResourceName parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+   *   EchoResponse response = echoClient.echo(parent);
+   * }
+   * }</pre>
+   *
+   * @param parent
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(ResourceName parent) {
+    EchoRequest request =
+        EchoRequest.newBuilder().setParent(parent == null ? null : parent.toString()).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   Status error = Status.newBuilder().build();
+   *   EchoResponse response = echoClient.echo(error);
+   * }
+   * }</pre>
+   *
+   * @param error
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(Status error) {
+    EchoRequest request = EchoRequest.newBuilder().setError(error).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   FoobarName name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+   *   EchoResponse response = echoClient.echo(name);
+   * }
+   * }</pre>
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(FoobarName name) {
+    EchoRequest request =
+        EchoRequest.newBuilder().setName(name == null ? null : name.toString()).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   String content = "content951530617";
+   *   EchoResponse response = echoClient.echo(content);
+   * }
+   * }</pre>
+   *
+   * @param content
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(String content) {
+    EchoRequest request = EchoRequest.newBuilder().setContent(content).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   String name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString();
+   *   EchoResponse response = echoClient.echo(name);
+   * }
+   * }</pre>
+   *
+   * @param name
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(String name) {
+    EchoRequest request = EchoRequest.newBuilder().setName(name).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   String parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString();
+   *   EchoResponse response = echoClient.echo(parent);
+   * }
+   * }</pre>
+   *
+   * @param parent
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(String parent) {
+    EchoRequest request = EchoRequest.newBuilder().setParent(parent).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   String content = "content951530617";
+   *   Severity severity = Severity.forNumber(0);
+   *   EchoResponse response = echoClient.echo(content, severity);
+   * }
+   * }</pre>
+   *
+   * @param content
+   * @param severity
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(String content, Severity severity) {
+    EchoRequest request =
+        EchoRequest.newBuilder().setContent(content).setSeverity(severity).build();
+    return echo(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFoobar(Foobar.newBuilder().build())
+   *           .build();
+   *   EchoResponse response = echoClient.echo(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse echo(EchoRequest request) {
+    return echoCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFoobar(Foobar.newBuilder().build())
+   *           .build();
+   *   ApiFuture<EchoResponse> future = echoClient.echoCallable().futureCall(request);
+   *   // Do something.
+   *   EchoResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<EchoRequest, EchoResponse> echoCallable() {
+    return stub.echoCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   ExpandRequest request =
+   *       ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
+   *   ServerStream<EchoResponse> stream = echoClient.expandCallable().call(request);
+   *   for (EchoResponse response : stream) {
+   *     // Do something when a response is received.
+   *   }
+   * }
+   * }</pre>
+   */
+  public final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable() {
+    return stub.expandCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (EchoResponse element : echoClient.pagedExpand(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final PagedExpandPagedResponse pagedExpand(PagedExpandRequest request) {
+    return pagedExpandPagedCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   ApiFuture<EchoResponse> future = echoClient.pagedExpandPagedCallable().futureCall(request);
+   *   // Do something.
+   *   for (EchoResponse element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<PagedExpandRequest, PagedExpandPagedResponse>
+      pagedExpandPagedCallable() {
+    return stub.pagedExpandPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   while (true) {
+   *     PagedExpandResponse response = echoClient.pagedExpandCallable().call(request);
+   *     for (EchoResponse element : response.getResponsesList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable() {
+    return stub.pagedExpandCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   for (EchoResponse element : echoClient.simplePagedExpand().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final SimplePagedExpandPagedResponse simplePagedExpand() {
+    PagedExpandRequest request = PagedExpandRequest.newBuilder().build();
+    return simplePagedExpand(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   for (EchoResponse element : echoClient.simplePagedExpand(request).iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final SimplePagedExpandPagedResponse simplePagedExpand(PagedExpandRequest request) {
+    return simplePagedExpandPagedCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   ApiFuture<EchoResponse> future =
+   *       echoClient.simplePagedExpandPagedCallable().futureCall(request);
+   *   // Do something.
+   *   for (EchoResponse element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<PagedExpandRequest, SimplePagedExpandPagedResponse>
+      simplePagedExpandPagedCallable() {
+    return stub.simplePagedExpandPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   PagedExpandRequest request =
+   *       PagedExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .setPageSize(883849137)
+   *           .setPageToken("pageToken873572522")
+   *           .build();
+   *   while (true) {
+   *     PagedExpandResponse response = echoClient.simplePagedExpandCallable().call(request);
+   *     for (EchoResponse element : response.getResponsesList()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<PagedExpandRequest, PagedExpandResponse> simplePagedExpandCallable() {
+    return stub.simplePagedExpandCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   Duration ttl = Duration.newBuilder().build();
+   *   WaitResponse response = echoClient.waitAsync(ttl).get();
+   * }
+   * }</pre>
+   *
+   * @param ttl
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<WaitResponse, WaitMetadata> waitAsync(Duration ttl) {
+    WaitRequest request = WaitRequest.newBuilder().setTtl(ttl).build();
+    return waitAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   Timestamp endTime = Timestamp.newBuilder().build();
+   *   WaitResponse response = echoClient.waitAsync(endTime).get();
+   * }
+   * }</pre>
+   *
+   * @param endTime
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<WaitResponse, WaitMetadata> waitAsync(Timestamp endTime) {
+    WaitRequest request = WaitRequest.newBuilder().setEndTime(endTime).build();
+    return waitAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   WaitRequest request = WaitRequest.newBuilder().build();
+   *   WaitResponse response = echoClient.waitAsync(request).get();
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<WaitResponse, WaitMetadata> waitAsync(WaitRequest request) {
+    return waitOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   WaitRequest request = WaitRequest.newBuilder().build();
+   *   OperationFuture<WaitResponse, WaitMetadata> future =
+   *       echoClient.waitOperationCallable().futureCall(request);
+   *   // Do something.
+   *   WaitResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final OperationCallable<WaitRequest, WaitResponse, WaitMetadata> waitOperationCallable() {
+    return stub.waitOperationCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   WaitRequest request = WaitRequest.newBuilder().build();
+   *   ApiFuture<Operation> future = echoClient.waitCallable().futureCall(request);
+   *   // Do something.
+   *   Operation response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<WaitRequest, Operation> waitCallable() {
+    return stub.waitCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   BlockRequest request = BlockRequest.newBuilder().build();
+   *   BlockResponse response = echoClient.block(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final BlockResponse block(BlockRequest request) {
+    return blockCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   BlockRequest request = BlockRequest.newBuilder().build();
+   *   ApiFuture<BlockResponse> future = echoClient.blockCallable().futureCall(request);
+   *   // Do something.
+   *   BlockResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<BlockRequest, BlockResponse> blockCallable() {
+    return stub.blockCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFoobar(Foobar.newBuilder().build())
+   *           .build();
+   *   Object response = echoClient.collideName(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Object collideName(EchoRequest request) {
+    return collideNameCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFoobar(Foobar.newBuilder().build())
+   *           .build();
+   *   ApiFuture<Object> future = echoClient.collideNameCallable().futureCall(request);
+   *   // Do something.
+   *   Object response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<EchoRequest, Object> collideNameCallable() {
+    return stub.collideNameCallable();
+  }
+
+  @Override
+  public final void close() {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+
+  public static class PagedExpandPagedResponse
+      extends AbstractPagedListResponse<
+          PagedExpandRequest,
+          PagedExpandResponse,
+          EchoResponse,
+          PagedExpandPage,
+          PagedExpandFixedSizeCollection> {
+
+    public static ApiFuture<PagedExpandPagedResponse> createAsync(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        ApiFuture<PagedExpandResponse> futureResponse) {
+      ApiFuture<PagedExpandPage> futurePage =
+          PagedExpandPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage, input -> new PagedExpandPagedResponse(input), MoreExecutors.directExecutor());
+    }
+
+    private PagedExpandPagedResponse(PagedExpandPage page) {
+      super(page, PagedExpandFixedSizeCollection.createEmptyCollection());
+    }
+  }
+
+  public static class PagedExpandPage
+      extends AbstractPage<PagedExpandRequest, PagedExpandResponse, EchoResponse, PagedExpandPage> {
+
+    private PagedExpandPage(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        PagedExpandResponse response) {
+      super(context, response);
+    }
+
+    private static PagedExpandPage createEmptyPage() {
+      return new PagedExpandPage(null, null);
+    }
+
+    @Override
+    protected PagedExpandPage createPage(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        PagedExpandResponse response) {
+      return new PagedExpandPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<PagedExpandPage> createPageAsync(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        ApiFuture<PagedExpandResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+  }
+
+  public static class PagedExpandFixedSizeCollection
+      extends AbstractFixedSizeCollection<
+          PagedExpandRequest,
+          PagedExpandResponse,
+          EchoResponse,
+          PagedExpandPage,
+          PagedExpandFixedSizeCollection> {
+
+    private PagedExpandFixedSizeCollection(List<PagedExpandPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static PagedExpandFixedSizeCollection createEmptyCollection() {
+      return new PagedExpandFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected PagedExpandFixedSizeCollection createCollection(
+        List<PagedExpandPage> pages, int collectionSize) {
+      return new PagedExpandFixedSizeCollection(pages, collectionSize);
+    }
+  }
+
+  public static class SimplePagedExpandPagedResponse
+      extends AbstractPagedListResponse<
+          PagedExpandRequest,
+          PagedExpandResponse,
+          EchoResponse,
+          SimplePagedExpandPage,
+          SimplePagedExpandFixedSizeCollection> {
+
+    public static ApiFuture<SimplePagedExpandPagedResponse> createAsync(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        ApiFuture<PagedExpandResponse> futureResponse) {
+      ApiFuture<SimplePagedExpandPage> futurePage =
+          SimplePagedExpandPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          input -> new SimplePagedExpandPagedResponse(input),
+          MoreExecutors.directExecutor());
+    }
+
+    private SimplePagedExpandPagedResponse(SimplePagedExpandPage page) {
+      super(page, SimplePagedExpandFixedSizeCollection.createEmptyCollection());
+    }
+  }
+
+  public static class SimplePagedExpandPage
+      extends AbstractPage<
+          PagedExpandRequest, PagedExpandResponse, EchoResponse, SimplePagedExpandPage> {
+
+    private SimplePagedExpandPage(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        PagedExpandResponse response) {
+      super(context, response);
+    }
+
+    private static SimplePagedExpandPage createEmptyPage() {
+      return new SimplePagedExpandPage(null, null);
+    }
+
+    @Override
+    protected SimplePagedExpandPage createPage(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        PagedExpandResponse response) {
+      return new SimplePagedExpandPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<SimplePagedExpandPage> createPageAsync(
+        PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> context,
+        ApiFuture<PagedExpandResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+  }
+
+  public static class SimplePagedExpandFixedSizeCollection
+      extends AbstractFixedSizeCollection<
+          PagedExpandRequest,
+          PagedExpandResponse,
+          EchoResponse,
+          SimplePagedExpandPage,
+          SimplePagedExpandFixedSizeCollection> {
+
+    private SimplePagedExpandFixedSizeCollection(
+        List<SimplePagedExpandPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static SimplePagedExpandFixedSizeCollection createEmptyCollection() {
+      return new SimplePagedExpandFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected SimplePagedExpandFixedSizeCollection createCollection(
+        List<SimplePagedExpandPage> pages, int collectionSize) {
+      return new SimplePagedExpandFixedSizeCollection(pages, collectionSize);
+    }
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientHttpJsonTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientHttpJsonTest.golden
@@ -1,0 +1,747 @@
+package com.google.showcase.grpcrest.v1beta1;
+
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.PagedExpandPagedResponse;
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
+import com.google.api.gax.httpjson.testing.MockHttpService;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.testing.FakeStatusCode;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.collect.Lists;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import com.google.rpc.Status;
+import com.google.showcase.grpcrest.v1beta1.stub.HttpJsonEchoStub;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Generated;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@Generated("by gapic-generator-java")
+public class EchoClientHttpJsonTest {
+  private static MockHttpService mockService;
+  private static EchoClient client;
+
+  @BeforeClass
+  public static void startStaticServer() throws IOException {
+    mockService =
+        new MockHttpService(
+            HttpJsonEchoStub.getMethodDescriptors(), EchoSettings.getDefaultEndpoint());
+    EchoSettings settings =
+        EchoSettings.newHttpJsonBuilder()
+            .setTransportChannelProvider(
+                EchoSettings.defaultHttpJsonTransportProviderBuilder()
+                    .setHttpTransport(mockService)
+                    .build())
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build();
+    client = EchoClient.create(settings);
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    client.close();
+  }
+
+  @Before
+  public void setUp() {}
+
+  @After
+  public void tearDown() throws Exception {
+    mockService.reset();
+  }
+
+  @Test
+  public void echoTest() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    EchoResponse actualResponse = client.echo();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      EchoRequest request =
+          EchoRequest.newBuilder()
+              .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setSeverity(Severity.forNumber(0))
+              .setFoobar(Foobar.newBuilder().build())
+              .build();
+      client.echo(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest2() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    ResourceName parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+
+    EchoResponse actualResponse = client.echo(parent);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest2() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      ResourceName parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+      client.echo(parent);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest3() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    Status error = Status.newBuilder().build();
+
+    EchoResponse actualResponse = client.echo(error);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest3() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      Status error = Status.newBuilder().build();
+      client.echo(error);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest4() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    FoobarName name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+
+    EchoResponse actualResponse = client.echo(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest4() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      FoobarName name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+      client.echo(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest5() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    String content = "content951530617";
+
+    EchoResponse actualResponse = client.echo(content);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest5() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      String content = "content951530617";
+      client.echo(content);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest6() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    String name = "name3373707";
+
+    EchoResponse actualResponse = client.echo(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest6() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      String name = "name3373707";
+      client.echo(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest7() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    String parent = "parent-995424086";
+
+    EchoResponse actualResponse = client.echo(parent);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest7() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      String parent = "parent-995424086";
+      client.echo(parent);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest8() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    String content = "content951530617";
+    Severity severity = Severity.forNumber(0);
+
+    EchoResponse actualResponse = client.echo(content, severity);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void echoExceptionTest8() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      String content = "content951530617";
+      Severity severity = Severity.forNumber(0);
+      client.echo(content, severity);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void expandTest() throws Exception {}
+
+  @Test
+  public void expandExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+  }
+
+  @Test
+  public void pagedExpandTest() throws Exception {
+    EchoResponse responsesElement = EchoResponse.newBuilder().build();
+    PagedExpandResponse expectedResponse =
+        PagedExpandResponse.newBuilder()
+            .setNextPageToken("")
+            .addAllResponses(Arrays.asList(responsesElement))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    PagedExpandRequest request =
+        PagedExpandRequest.newBuilder()
+            .setContent("content951530617")
+            .setPageSize(883849137)
+            .setPageToken("pageToken873572522")
+            .build();
+
+    PagedExpandPagedResponse pagedListResponse = client.pagedExpand(request);
+
+    List<EchoResponse> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getResponsesList().get(0), resources.get(0));
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void pagedExpandExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      PagedExpandRequest request =
+          PagedExpandRequest.newBuilder()
+              .setContent("content951530617")
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .build();
+      client.pagedExpand(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void simplePagedExpandTest() throws Exception {
+    EchoResponse responsesElement = EchoResponse.newBuilder().build();
+    PagedExpandResponse expectedResponse =
+        PagedExpandResponse.newBuilder()
+            .setNextPageToken("")
+            .addAllResponses(Arrays.asList(responsesElement))
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    SimplePagedExpandPagedResponse pagedListResponse = client.simplePagedExpand();
+
+    List<EchoResponse> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getResponsesList().get(0), resources.get(0));
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void simplePagedExpandExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      PagedExpandRequest request =
+          PagedExpandRequest.newBuilder()
+              .setContent("content951530617")
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .build();
+      client.simplePagedExpand(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void waitTest() throws Exception {
+    WaitResponse expectedResponse =
+        WaitResponse.newBuilder().setContent("content951530617").build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("waitTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockService.addResponse(resultOperation);
+
+    Duration ttl = Duration.newBuilder().build();
+
+    WaitResponse actualResponse = client.waitAsync(ttl).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void waitExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      Duration ttl = Duration.newBuilder().build();
+      client.waitAsync(ttl).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+    }
+  }
+
+  @Test
+  public void waitTest2() throws Exception {
+    WaitResponse expectedResponse =
+        WaitResponse.newBuilder().setContent("content951530617").build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("waitTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockService.addResponse(resultOperation);
+
+    Timestamp endTime = Timestamp.newBuilder().build();
+
+    WaitResponse actualResponse = client.waitAsync(endTime).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void waitExceptionTest2() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      Timestamp endTime = Timestamp.newBuilder().build();
+      client.waitAsync(endTime).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+    }
+  }
+
+  @Test
+  public void blockTest() throws Exception {
+    BlockResponse expectedResponse =
+        BlockResponse.newBuilder().setContent("content951530617").build();
+    mockService.addResponse(expectedResponse);
+
+    BlockRequest request = BlockRequest.newBuilder().build();
+
+    BlockResponse actualResponse = client.block(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void blockExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      BlockRequest request = BlockRequest.newBuilder().build();
+      client.block(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void collideNameTest() throws Exception {
+    Object expectedResponse = Object.newBuilder().setContent("content951530617").build();
+    mockService.addResponse(expectedResponse);
+
+    EchoRequest request =
+        EchoRequest.newBuilder()
+            .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
+            .setFoobar(Foobar.newBuilder().build())
+            .build();
+
+    Object actualResponse = client.collideName(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void collideNameExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      EchoRequest request =
+          EchoRequest.newBuilder()
+              .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setSeverity(Severity.forNumber(0))
+              .setFoobar(Foobar.newBuilder().build())
+              .build();
+      client.collideName(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
@@ -1,0 +1,716 @@
+package com.google.showcase.grpcrest.v1beta1;
+
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.PagedExpandPagedResponse;
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.api.gax.grpc.testing.MockGrpcService;
+import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.grpc.testing.MockStreamObserver;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.collect.Lists;
+import com.google.longrunning.Operation;
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Any;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import com.google.rpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Generated;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@Generated("by gapic-generator-java")
+public class EchoClientTest {
+  private static MockEcho mockEcho;
+  private static MockServiceHelper mockServiceHelper;
+  private LocalChannelProvider channelProvider;
+  private EchoClient client;
+
+  @BeforeClass
+  public static void startStaticServer() {
+    mockEcho = new MockEcho();
+    mockServiceHelper =
+        new MockServiceHelper(
+            UUID.randomUUID().toString(), Arrays.<MockGrpcService>asList(mockEcho));
+    mockServiceHelper.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    mockServiceHelper.stop();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    mockServiceHelper.reset();
+    channelProvider = mockServiceHelper.createChannelProvider();
+    EchoSettings settings =
+        EchoSettings.newBuilder()
+            .setTransportChannelProvider(channelProvider)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build();
+    client = EchoClient.create(settings);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+  }
+
+  @Test
+  public void echoTest() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    EchoResponse actualResponse = client.echo();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      EchoRequest request =
+          EchoRequest.newBuilder()
+              .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setSeverity(Severity.forNumber(0))
+              .setFoobar(Foobar.newBuilder().build())
+              .build();
+      client.echo(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest2() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    ResourceName parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+
+    EchoResponse actualResponse = client.echo(parent);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(parent.toString(), actualRequest.getParent());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      ResourceName parent = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+      client.echo(parent);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest3() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    Status error = Status.newBuilder().build();
+
+    EchoResponse actualResponse = client.echo(error);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(error, actualRequest.getError());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest3() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      Status error = Status.newBuilder().build();
+      client.echo(error);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest4() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    FoobarName name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+
+    EchoResponse actualResponse = client.echo(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(name.toString(), actualRequest.getName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest4() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      FoobarName name = FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]");
+      client.echo(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest5() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    String content = "content951530617";
+
+    EchoResponse actualResponse = client.echo(content);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(content, actualRequest.getContent());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest5() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      String content = "content951530617";
+      client.echo(content);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest6() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    String name = "name3373707";
+
+    EchoResponse actualResponse = client.echo(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(name, actualRequest.getName());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest6() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      String name = "name3373707";
+      client.echo(name);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest7() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    String parent = "parent-995424086";
+
+    EchoResponse actualResponse = client.echo(parent);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(parent, actualRequest.getParent());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest7() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      String parent = "parent-995424086";
+      client.echo(parent);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void echoTest8() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    String content = "content951530617";
+    Severity severity = Severity.forNumber(0);
+
+    EchoResponse actualResponse = client.echo(content, severity);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(content, actualRequest.getContent());
+    Assert.assertEquals(severity, actualRequest.getSeverity());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void echoExceptionTest8() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      String content = "content951530617";
+      Severity severity = Severity.forNumber(0);
+      client.echo(content, severity);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void expandTest() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+    ExpandRequest request =
+        ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
+
+    MockStreamObserver<EchoResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ExpandRequest, EchoResponse> callable = client.expandCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    List<EchoResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  public void expandExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+    ExpandRequest request =
+        ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
+
+    MockStreamObserver<EchoResponse> responseObserver = new MockStreamObserver<>();
+
+    ServerStreamingCallable<ExpandRequest, EchoResponse> callable = client.expandCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    try {
+      List<EchoResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void pagedExpandTest() throws Exception {
+    EchoResponse responsesElement = EchoResponse.newBuilder().build();
+    PagedExpandResponse expectedResponse =
+        PagedExpandResponse.newBuilder()
+            .setNextPageToken("")
+            .addAllResponses(Arrays.asList(responsesElement))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    PagedExpandRequest request =
+        PagedExpandRequest.newBuilder()
+            .setContent("content951530617")
+            .setPageSize(883849137)
+            .setPageToken("pageToken873572522")
+            .build();
+
+    PagedExpandPagedResponse pagedListResponse = client.pagedExpand(request);
+
+    List<EchoResponse> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getResponsesList().get(0), resources.get(0));
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    PagedExpandRequest actualRequest = ((PagedExpandRequest) actualRequests.get(0));
+
+    Assert.assertEquals(request.getContent(), actualRequest.getContent());
+    Assert.assertEquals(request.getPageSize(), actualRequest.getPageSize());
+    Assert.assertEquals(request.getPageToken(), actualRequest.getPageToken());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void pagedExpandExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      PagedExpandRequest request =
+          PagedExpandRequest.newBuilder()
+              .setContent("content951530617")
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .build();
+      client.pagedExpand(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void simplePagedExpandTest() throws Exception {
+    EchoResponse responsesElement = EchoResponse.newBuilder().build();
+    PagedExpandResponse expectedResponse =
+        PagedExpandResponse.newBuilder()
+            .setNextPageToken("")
+            .addAllResponses(Arrays.asList(responsesElement))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    SimplePagedExpandPagedResponse pagedListResponse = client.simplePagedExpand();
+
+    List<EchoResponse> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+
+    Assert.assertEquals(1, resources.size());
+    Assert.assertEquals(expectedResponse.getResponsesList().get(0), resources.get(0));
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    PagedExpandRequest actualRequest = ((PagedExpandRequest) actualRequests.get(0));
+
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void simplePagedExpandExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      PagedExpandRequest request =
+          PagedExpandRequest.newBuilder()
+              .setContent("content951530617")
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .build();
+      client.simplePagedExpand(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void waitTest() throws Exception {
+    WaitResponse expectedResponse =
+        WaitResponse.newBuilder().setContent("content951530617").build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("waitTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockEcho.addResponse(resultOperation);
+
+    Duration ttl = Duration.newBuilder().build();
+
+    WaitResponse actualResponse = client.waitAsync(ttl).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    WaitRequest actualRequest = ((WaitRequest) actualRequests.get(0));
+
+    Assert.assertEquals(ttl, actualRequest.getTtl());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void waitExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      Duration ttl = Duration.newBuilder().build();
+      client.waitAsync(ttl).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void waitTest2() throws Exception {
+    WaitResponse expectedResponse =
+        WaitResponse.newBuilder().setContent("content951530617").build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("waitTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockEcho.addResponse(resultOperation);
+
+    Timestamp endTime = Timestamp.newBuilder().build();
+
+    WaitResponse actualResponse = client.waitAsync(endTime).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    WaitRequest actualRequest = ((WaitRequest) actualRequests.get(0));
+
+    Assert.assertEquals(endTime, actualRequest.getEndTime());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void waitExceptionTest2() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      Timestamp endTime = Timestamp.newBuilder().build();
+      client.waitAsync(endTime).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(InvalidArgumentException.class, e.getCause().getClass());
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
+    }
+  }
+
+  @Test
+  public void blockTest() throws Exception {
+    BlockResponse expectedResponse =
+        BlockResponse.newBuilder().setContent("content951530617").build();
+    mockEcho.addResponse(expectedResponse);
+
+    BlockRequest request = BlockRequest.newBuilder().build();
+
+    BlockResponse actualResponse = client.block(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    BlockRequest actualRequest = ((BlockRequest) actualRequests.get(0));
+
+    Assert.assertEquals(request.getResponseDelay(), actualRequest.getResponseDelay());
+    Assert.assertEquals(request.getError(), actualRequest.getError());
+    Assert.assertEquals(request.getSuccess(), actualRequest.getSuccess());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void blockExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      BlockRequest request = BlockRequest.newBuilder().build();
+      client.block(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void collideNameTest() throws Exception {
+    Object expectedResponse = Object.newBuilder().setContent("content951530617").build();
+    mockEcho.addResponse(expectedResponse);
+
+    EchoRequest request =
+        EchoRequest.newBuilder()
+            .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
+            .setFoobar(Foobar.newBuilder().build())
+            .build();
+
+    Object actualResponse = client.collideName(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(request.getName(), actualRequest.getName());
+    Assert.assertEquals(request.getParent(), actualRequest.getParent());
+    Assert.assertEquals(request.getContent(), actualRequest.getContent());
+    Assert.assertEquals(request.getError(), actualRequest.getError());
+    Assert.assertEquals(request.getSeverity(), actualRequest.getSeverity());
+    Assert.assertEquals(request.getFoobar(), actualRequest.getFoobar());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void collideNameExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      EchoRequest request =
+          EchoRequest.newBuilder()
+              .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setSeverity(Severity.forNumber(0))
+              .setFoobar(Foobar.newBuilder().build())
+              .build();
+      client.collideName(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
@@ -1,0 +1,267 @@
+package com.google.showcase.grpcrest.v1beta1;
+
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.PagedExpandPagedResponse;
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.longrunning.Operation;
+import com.google.showcase.grpcrest.v1beta1.stub.EchoStubSettings;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * Settings class to configure an instance of {@link EchoClient}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ *   <li>The default service address (localhost) and default port (7469) are used.
+ *   <li>Credentials are acquired automatically through Application Default Credentials.
+ *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders. When
+ * build() is called, the tree of builders is called to create the complete settings object.
+ *
+ * <p>For example, to set the total timeout of echo to 30 seconds:
+ *
+ * <pre>{@code
+ * // This snippet has been automatically generated for illustrative purposes only.
+ * // It may require modifications to work in your environment.
+ * EchoSettings.Builder echoSettingsBuilder = EchoSettings.newBuilder();
+ * echoSettingsBuilder
+ *     .echoSettings()
+ *     .setRetrySettings(
+ *         echoSettingsBuilder
+ *             .echoSettings()
+ *             .getRetrySettings()
+ *             .toBuilder()
+ *             .setTotalTimeout(Duration.ofSeconds(30))
+ *             .build());
+ * EchoSettings echoSettings = echoSettingsBuilder.build();
+ * }</pre>
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+public class EchoSettings extends ClientSettings<EchoSettings> {
+
+  /** Returns the object with the settings used for calls to echo. */
+  public UnaryCallSettings<EchoRequest, EchoResponse> echoSettings() {
+    return ((EchoStubSettings) getStubSettings()).echoSettings();
+  }
+
+  /** Returns the object with the settings used for calls to expand. */
+  public ServerStreamingCallSettings<ExpandRequest, EchoResponse> expandSettings() {
+    return ((EchoStubSettings) getStubSettings()).expandSettings();
+  }
+
+  /** Returns the object with the settings used for calls to pagedExpand. */
+  public PagedCallSettings<PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+      pagedExpandSettings() {
+    return ((EchoStubSettings) getStubSettings()).pagedExpandSettings();
+  }
+
+  /** Returns the object with the settings used for calls to simplePagedExpand. */
+  public PagedCallSettings<PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+      simplePagedExpandSettings() {
+    return ((EchoStubSettings) getStubSettings()).simplePagedExpandSettings();
+  }
+
+  /** Returns the object with the settings used for calls to wait. */
+  public UnaryCallSettings<WaitRequest, Operation> waitSettings() {
+    return ((EchoStubSettings) getStubSettings()).waitSettings();
+  }
+
+  /** Returns the object with the settings used for calls to wait. */
+  public OperationCallSettings<WaitRequest, WaitResponse, WaitMetadata> waitOperationSettings() {
+    return ((EchoStubSettings) getStubSettings()).waitOperationSettings();
+  }
+
+  /** Returns the object with the settings used for calls to block. */
+  public UnaryCallSettings<BlockRequest, BlockResponse> blockSettings() {
+    return ((EchoStubSettings) getStubSettings()).blockSettings();
+  }
+
+  /** Returns the object with the settings used for calls to collideName. */
+  public UnaryCallSettings<EchoRequest, Object> collideNameSettings() {
+    return ((EchoStubSettings) getStubSettings()).collideNameSettings();
+  }
+
+  public static final EchoSettings create(EchoStubSettings stub) throws IOException {
+    return new EchoSettings.Builder(stub.toBuilder()).build();
+  }
+
+  /** Returns a builder for the default ExecutorProvider for this service. */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return EchoStubSettings.defaultExecutorProviderBuilder();
+  }
+
+  /** Returns the default service endpoint. */
+  public static String getDefaultEndpoint() {
+    return EchoStubSettings.getDefaultEndpoint();
+  }
+
+  /** Returns the default service scopes. */
+  public static List<String> getDefaultServiceScopes() {
+    return EchoStubSettings.getDefaultServiceScopes();
+  }
+
+  /** Returns a builder for the default credentials for this service. */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return EchoStubSettings.defaultCredentialsProviderBuilder();
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return EchoStubSettings.defaultGrpcTransportProviderBuilder();
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingHttpJsonChannelProvider.Builder
+      defaultHttpJsonTransportProviderBuilder() {
+    return EchoStubSettings.defaultHttpJsonTransportProviderBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return EchoStubSettings.defaultTransportChannelProvider();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return EchoStubSettings.defaultApiClientHeaderProviderBuilder();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newHttpJsonBuilder() {
+    return Builder.createHttpJsonDefault();
+  }
+
+  /** Returns a new builder for this class. */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /** Returns a builder containing all the values of this settings class. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected EchoSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+  }
+
+  /** Builder for EchoSettings. */
+  public static class Builder extends ClientSettings.Builder<EchoSettings, Builder> {
+
+    protected Builder() throws IOException {
+      this(((ClientContext) null));
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(EchoStubSettings.newBuilder(clientContext));
+    }
+
+    protected Builder(EchoSettings settings) {
+      super(settings.getStubSettings().toBuilder());
+    }
+
+    protected Builder(EchoStubSettings.Builder stubSettings) {
+      super(stubSettings);
+    }
+
+    private static Builder createDefault() {
+      return new Builder(EchoStubSettings.newBuilder());
+    }
+
+    private static Builder createHttpJsonDefault() {
+      return new Builder(EchoStubSettings.newHttpJsonBuilder());
+    }
+
+    public EchoStubSettings.Builder getStubSettingsBuilder() {
+      return ((EchoStubSettings.Builder) getStubSettings());
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * <p>Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(
+        ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
+      super.applyToAllUnaryMethods(
+          getStubSettingsBuilder().unaryMethodSettingsBuilders(), settingsUpdater);
+      return this;
+    }
+
+    /** Returns the builder for the settings used for calls to echo. */
+    public UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoSettings() {
+      return getStubSettingsBuilder().echoSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to expand. */
+    public ServerStreamingCallSettings.Builder<ExpandRequest, EchoResponse> expandSettings() {
+      return getStubSettingsBuilder().expandSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to pagedExpand. */
+    public PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+        pagedExpandSettings() {
+      return getStubSettingsBuilder().pagedExpandSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to simplePagedExpand. */
+    public PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+        simplePagedExpandSettings() {
+      return getStubSettingsBuilder().simplePagedExpandSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to wait. */
+    public UnaryCallSettings.Builder<WaitRequest, Operation> waitSettings() {
+      return getStubSettingsBuilder().waitSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to wait. */
+    public OperationCallSettings.Builder<WaitRequest, WaitResponse, WaitMetadata>
+        waitOperationSettings() {
+      return getStubSettingsBuilder().waitOperationSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to block. */
+    public UnaryCallSettings.Builder<BlockRequest, BlockResponse> blockSettings() {
+      return getStubSettingsBuilder().blockSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to collideName. */
+    public UnaryCallSettings.Builder<EchoRequest, Object> collideNameSettings() {
+      return getStubSettingsBuilder().collideNameSettings();
+    }
+
+    @Override
+    public EchoSettings build() throws IOException {
+      return new EchoSettings(this);
+    }
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoCallableFactory.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoCallableFactory.golden
@@ -1,0 +1,99 @@
+package com.google.showcase.grpcrest.v1beta1.stub;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcCallableFactory;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.OperationsStub;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * gRPC callable factory implementation for the Echo service API.
+ *
+ * <p>This class is for advanced usage.
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+public class GrpcEchoCallableFactory implements GrpcStubCallableFactory {
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      UnaryCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createUnaryCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, PagedListResponseT>
+      UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          PagedCallSettings<RequestT, ResponseT, PagedListResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createPagedCallable(grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+      GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+      BatchingCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return GrpcCallableFactory.createBatchingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          GrpcCallSettings<RequestT, Operation> grpcCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
+          ClientContext clientContext,
+          OperationsStub operationsStub) {
+    return GrpcCallableFactory.createOperationCallable(
+        grpcCallSettings, callSettings, clientContext, operationsStub);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      BidiStreamingCallable<RequestT, ResponseT> createBidiStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createBidiStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createServerStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ClientStreamingCallable<RequestT, ResponseT> createClientStreamingCallable(
+          GrpcCallSettings<RequestT, ResponseT> grpcCallSettings,
+          StreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return GrpcCallableFactory.createClientStreamingCallable(
+        grpcCallSettings, callSettings, clientContext);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
@@ -1,0 +1,312 @@
+package com.google.showcase.grpcrest.v1beta1.stub;
+
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.PagedExpandPagedResponse;
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.grpc.GrpcCallSettings;
+import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
+import com.google.longrunning.stub.GrpcOperationsStub;
+import com.google.showcase.grpcrest.v1beta1.BlockRequest;
+import com.google.showcase.grpcrest.v1beta1.BlockResponse;
+import com.google.showcase.grpcrest.v1beta1.EchoRequest;
+import com.google.showcase.grpcrest.v1beta1.EchoResponse;
+import com.google.showcase.grpcrest.v1beta1.ExpandRequest;
+import com.google.showcase.grpcrest.v1beta1.Object;
+import com.google.showcase.grpcrest.v1beta1.PagedExpandRequest;
+import com.google.showcase.grpcrest.v1beta1.PagedExpandResponse;
+import com.google.showcase.grpcrest.v1beta1.WaitMetadata;
+import com.google.showcase.grpcrest.v1beta1.WaitRequest;
+import com.google.showcase.grpcrest.v1beta1.WaitResponse;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * gRPC stub implementation for the Echo service API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+public class GrpcEchoStub extends EchoStub {
+  private static final MethodDescriptor<EchoRequest, EchoResponse> echoMethodDescriptor =
+      MethodDescriptor.<EchoRequest, EchoResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Echo")
+          .setRequestMarshaller(ProtoUtils.marshaller(EchoRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(EchoResponse.getDefaultInstance()))
+          .build();
+
+  private static final MethodDescriptor<ExpandRequest, EchoResponse> expandMethodDescriptor =
+      MethodDescriptor.<ExpandRequest, EchoResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Expand")
+          .setRequestMarshaller(ProtoUtils.marshaller(ExpandRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(EchoResponse.getDefaultInstance()))
+          .build();
+
+  private static final MethodDescriptor<PagedExpandRequest, PagedExpandResponse>
+      pagedExpandMethodDescriptor =
+          MethodDescriptor.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/PagedExpand")
+              .setRequestMarshaller(ProtoUtils.marshaller(PagedExpandRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(PagedExpandResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<PagedExpandRequest, PagedExpandResponse>
+      simplePagedExpandMethodDescriptor =
+          MethodDescriptor.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/SimplePagedExpand")
+              .setRequestMarshaller(ProtoUtils.marshaller(PagedExpandRequest.getDefaultInstance()))
+              .setResponseMarshaller(
+                  ProtoUtils.marshaller(PagedExpandResponse.getDefaultInstance()))
+              .build();
+
+  private static final MethodDescriptor<WaitRequest, Operation> waitMethodDescriptor =
+      MethodDescriptor.<WaitRequest, Operation>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Wait")
+          .setRequestMarshaller(ProtoUtils.marshaller(WaitRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Operation.getDefaultInstance()))
+          .build();
+
+  private static final MethodDescriptor<BlockRequest, BlockResponse> blockMethodDescriptor =
+      MethodDescriptor.<BlockRequest, BlockResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Block")
+          .setRequestMarshaller(ProtoUtils.marshaller(BlockRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(BlockResponse.getDefaultInstance()))
+          .build();
+
+  private static final MethodDescriptor<EchoRequest, Object> collideNameMethodDescriptor =
+      MethodDescriptor.<EchoRequest, Object>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/CollideName")
+          .setRequestMarshaller(ProtoUtils.marshaller(EchoRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Object.getDefaultInstance()))
+          .build();
+
+  private final UnaryCallable<EchoRequest, EchoResponse> echoCallable;
+  private final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable;
+  private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable;
+  private final UnaryCallable<PagedExpandRequest, PagedExpandPagedResponse>
+      pagedExpandPagedCallable;
+  private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> simplePagedExpandCallable;
+  private final UnaryCallable<PagedExpandRequest, SimplePagedExpandPagedResponse>
+      simplePagedExpandPagedCallable;
+  private final UnaryCallable<WaitRequest, Operation> waitCallable;
+  private final OperationCallable<WaitRequest, WaitResponse, WaitMetadata> waitOperationCallable;
+  private final UnaryCallable<BlockRequest, BlockResponse> blockCallable;
+  private final UnaryCallable<EchoRequest, Object> collideNameCallable;
+
+  private final BackgroundResource backgroundResources;
+  private final GrpcOperationsStub operationsStub;
+  private final GrpcStubCallableFactory callableFactory;
+
+  public static final GrpcEchoStub create(EchoStubSettings settings) throws IOException {
+    return new GrpcEchoStub(settings, ClientContext.create(settings));
+  }
+
+  public static final GrpcEchoStub create(ClientContext clientContext) throws IOException {
+    return new GrpcEchoStub(EchoStubSettings.newBuilder().build(), clientContext);
+  }
+
+  public static final GrpcEchoStub create(
+      ClientContext clientContext, GrpcStubCallableFactory callableFactory) throws IOException {
+    return new GrpcEchoStub(EchoStubSettings.newBuilder().build(), clientContext, callableFactory);
+  }
+
+  /**
+   * Constructs an instance of GrpcEchoStub, using the given settings. This is protected so that it
+   * is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected GrpcEchoStub(EchoStubSettings settings, ClientContext clientContext)
+      throws IOException {
+    this(settings, clientContext, new GrpcEchoCallableFactory());
+  }
+
+  /**
+   * Constructs an instance of GrpcEchoStub, using the given settings. This is protected so that it
+   * is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected GrpcEchoStub(
+      EchoStubSettings settings,
+      ClientContext clientContext,
+      GrpcStubCallableFactory callableFactory)
+      throws IOException {
+    this.callableFactory = callableFactory;
+    this.operationsStub = GrpcOperationsStub.create(clientContext, callableFactory);
+
+    GrpcCallSettings<EchoRequest, EchoResponse> echoTransportSettings =
+        GrpcCallSettings.<EchoRequest, EchoResponse>newBuilder()
+            .setMethodDescriptor(echoMethodDescriptor)
+            .build();
+    GrpcCallSettings<ExpandRequest, EchoResponse> expandTransportSettings =
+        GrpcCallSettings.<ExpandRequest, EchoResponse>newBuilder()
+            .setMethodDescriptor(expandMethodDescriptor)
+            .build();
+    GrpcCallSettings<PagedExpandRequest, PagedExpandResponse> pagedExpandTransportSettings =
+        GrpcCallSettings.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+            .setMethodDescriptor(pagedExpandMethodDescriptor)
+            .build();
+    GrpcCallSettings<PagedExpandRequest, PagedExpandResponse> simplePagedExpandTransportSettings =
+        GrpcCallSettings.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+            .setMethodDescriptor(simplePagedExpandMethodDescriptor)
+            .build();
+    GrpcCallSettings<WaitRequest, Operation> waitTransportSettings =
+        GrpcCallSettings.<WaitRequest, Operation>newBuilder()
+            .setMethodDescriptor(waitMethodDescriptor)
+            .build();
+    GrpcCallSettings<BlockRequest, BlockResponse> blockTransportSettings =
+        GrpcCallSettings.<BlockRequest, BlockResponse>newBuilder()
+            .setMethodDescriptor(blockMethodDescriptor)
+            .build();
+    GrpcCallSettings<EchoRequest, Object> collideNameTransportSettings =
+        GrpcCallSettings.<EchoRequest, Object>newBuilder()
+            .setMethodDescriptor(collideNameMethodDescriptor)
+            .build();
+
+    this.echoCallable =
+        callableFactory.createUnaryCallable(
+            echoTransportSettings, settings.echoSettings(), clientContext);
+    this.expandCallable =
+        callableFactory.createServerStreamingCallable(
+            expandTransportSettings, settings.expandSettings(), clientContext);
+    this.pagedExpandCallable =
+        callableFactory.createUnaryCallable(
+            pagedExpandTransportSettings, settings.pagedExpandSettings(), clientContext);
+    this.pagedExpandPagedCallable =
+        callableFactory.createPagedCallable(
+            pagedExpandTransportSettings, settings.pagedExpandSettings(), clientContext);
+    this.simplePagedExpandCallable =
+        callableFactory.createUnaryCallable(
+            simplePagedExpandTransportSettings,
+            settings.simplePagedExpandSettings(),
+            clientContext);
+    this.simplePagedExpandPagedCallable =
+        callableFactory.createPagedCallable(
+            simplePagedExpandTransportSettings,
+            settings.simplePagedExpandSettings(),
+            clientContext);
+    this.waitCallable =
+        callableFactory.createUnaryCallable(
+            waitTransportSettings, settings.waitSettings(), clientContext);
+    this.waitOperationCallable =
+        callableFactory.createOperationCallable(
+            waitTransportSettings, settings.waitOperationSettings(), clientContext, operationsStub);
+    this.blockCallable =
+        callableFactory.createUnaryCallable(
+            blockTransportSettings, settings.blockSettings(), clientContext);
+    this.collideNameCallable =
+        callableFactory.createUnaryCallable(
+            collideNameTransportSettings, settings.collideNameSettings(), clientContext);
+
+    this.backgroundResources =
+        new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+  }
+
+  public GrpcOperationsStub getOperationsStub() {
+    return operationsStub;
+  }
+
+  @Override
+  public UnaryCallable<EchoRequest, EchoResponse> echoCallable() {
+    return echoCallable;
+  }
+
+  @Override
+  public ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable() {
+    return expandCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable() {
+    return pagedExpandCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, PagedExpandPagedResponse> pagedExpandPagedCallable() {
+    return pagedExpandPagedCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, PagedExpandResponse> simplePagedExpandCallable() {
+    return simplePagedExpandCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, SimplePagedExpandPagedResponse>
+      simplePagedExpandPagedCallable() {
+    return simplePagedExpandPagedCallable;
+  }
+
+  @Override
+  public UnaryCallable<WaitRequest, Operation> waitCallable() {
+    return waitCallable;
+  }
+
+  @Override
+  public OperationCallable<WaitRequest, WaitResponse, WaitMetadata> waitOperationCallable() {
+    return waitOperationCallable;
+  }
+
+  @Override
+  public UnaryCallable<BlockRequest, BlockResponse> blockCallable() {
+    return blockCallable;
+  }
+
+  @Override
+  public UnaryCallable<EchoRequest, Object> collideNameCallable() {
+    return collideNameCallable;
+  }
+
+  @Override
+  public final void close() {
+    try {
+      backgroundResources.close();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to close resource", e);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    backgroundResources.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return backgroundResources.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return backgroundResources.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    backgroundResources.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return backgroundResources.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoCallableFactory.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoCallableFactory.golden
@@ -1,0 +1,89 @@
+package com.google.showcase.grpcrest.v1beta1.stub;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonCallableFactory;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshotCallable;
+import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
+import com.google.api.gax.httpjson.longrunning.stub.OperationsStub;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * REST callable factory implementation for the Echo service API.
+ *
+ * <p>This class is for advanced usage.
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+public class HttpJsonEchoCallableFactory
+    implements HttpJsonStubCallableFactory<Operation, OperationsStub> {
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+      UnaryCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return HttpJsonCallableFactory.createUnaryCallable(
+        httpJsonCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, PagedListResponseT>
+      UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
+          HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+          PagedCallSettings<RequestT, ResponseT, PagedListResponseT> callSettings,
+          ClientContext clientContext) {
+    return HttpJsonCallableFactory.createPagedCallable(
+        httpJsonCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+      HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+      BatchingCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return HttpJsonCallableFactory.createBatchingCallable(
+        httpJsonCallSettings, callSettings, clientContext);
+  }
+
+  @BetaApi(
+      "The surface for long-running operations is not stable yet and may change in the future.")
+  @Override
+  public <RequestT, ResponseT, MetadataT>
+      OperationCallable<RequestT, ResponseT, MetadataT> createOperationCallable(
+          HttpJsonCallSettings<RequestT, Operation> httpJsonCallSettings,
+          OperationCallSettings<RequestT, ResponseT, MetadataT> callSettings,
+          ClientContext clientContext,
+          OperationsStub operationsStub) {
+    UnaryCallable<RequestT, Operation> innerCallable =
+        HttpJsonCallableFactory.createBaseUnaryCallable(
+            httpJsonCallSettings, callSettings.getInitialCallSettings(), clientContext);
+    HttpJsonOperationSnapshotCallable<RequestT, Operation> initialCallable =
+        new HttpJsonOperationSnapshotCallable<RequestT, Operation>(
+            innerCallable,
+            httpJsonCallSettings.getMethodDescriptor().getOperationSnapshotFactory());
+    return HttpJsonCallableFactory.createOperationCallable(
+        callSettings, clientContext, operationsStub.longRunningClient(), initialCallable);
+  }
+
+  @Override
+  public <RequestT, ResponseT>
+      ServerStreamingCallable<RequestT, ResponseT> createServerStreamingCallable(
+          HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+          ServerStreamingCallSettings<RequestT, ResponseT> callSettings,
+          ClientContext clientContext) {
+    return HttpJsonCallableFactory.createServerStreamingCallable(
+        httpJsonCallSettings, callSettings, clientContext);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -1,0 +1,524 @@
+package com.google.showcase.grpcrest.v1beta1.stub;
+
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.PagedExpandPagedResponse;
+import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonOperationSnapshot;
+import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
+import com.google.api.gax.httpjson.ProtoMessageRequestFormatter;
+import com.google.api.gax.httpjson.ProtoMessageResponseParser;
+import com.google.api.gax.httpjson.ProtoRestSerializer;
+import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.longrunning.Operation;
+import com.google.protobuf.TypeRegistry;
+import com.google.showcase.grpcrest.v1beta1.BlockRequest;
+import com.google.showcase.grpcrest.v1beta1.BlockResponse;
+import com.google.showcase.grpcrest.v1beta1.EchoRequest;
+import com.google.showcase.grpcrest.v1beta1.EchoResponse;
+import com.google.showcase.grpcrest.v1beta1.ExpandRequest;
+import com.google.showcase.grpcrest.v1beta1.Object;
+import com.google.showcase.grpcrest.v1beta1.PagedExpandRequest;
+import com.google.showcase.grpcrest.v1beta1.PagedExpandResponse;
+import com.google.showcase.grpcrest.v1beta1.WaitMetadata;
+import com.google.showcase.grpcrest.v1beta1.WaitRequest;
+import com.google.showcase.grpcrest.v1beta1.WaitResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS.
+/**
+ * REST stub implementation for the Echo service API.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@BetaApi
+@Generated("by gapic-generator-java")
+@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+public class HttpJsonEchoStub extends EchoStub {
+  private static final TypeRegistry typeRegistry =
+      TypeRegistry.newBuilder()
+          .add(WaitResponse.getDescriptor())
+          .add(WaitMetadata.getDescriptor())
+          .build();
+
+  private static final ApiMethodDescriptor<EchoRequest, EchoResponse> echoMethodDescriptor =
+      ApiMethodDescriptor.<EchoRequest, EchoResponse>newBuilder()
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Echo")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              ProtoMessageRequestFormatter.<EchoRequest>newBuilder()
+                  .setPath(
+                      "/v1beta1/echo:echo",
+                      request -> {
+                        Map<String, String> fields = new HashMap<>();
+                        ProtoRestSerializer<EchoRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setQueryParamsExtractor(
+                      request -> {
+                        Map<String, List<String>> fields = new HashMap<>();
+                        ProtoRestSerializer<EchoRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setRequestBodyExtractor(
+                      request ->
+                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                  .build())
+          .setResponseParser(
+              ProtoMessageResponseParser.<EchoResponse>newBuilder()
+                  .setDefaultInstance(EchoResponse.getDefaultInstance())
+                  .setDefaultTypeRegistry(typeRegistry)
+                  .build())
+          .build();
+
+  private static final ApiMethodDescriptor<ExpandRequest, EchoResponse> expandMethodDescriptor =
+      ApiMethodDescriptor.<ExpandRequest, EchoResponse>newBuilder()
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Expand")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.SERVER_STREAMING)
+          .setRequestFormatter(
+              ProtoMessageRequestFormatter.<ExpandRequest>newBuilder()
+                  .setPath(
+                      "/v1beta1/echo:expand",
+                      request -> {
+                        Map<String, String> fields = new HashMap<>();
+                        ProtoRestSerializer<ExpandRequest> serializer =
+                            ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setQueryParamsExtractor(
+                      request -> {
+                        Map<String, List<String>> fields = new HashMap<>();
+                        ProtoRestSerializer<ExpandRequest> serializer =
+                            ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setRequestBodyExtractor(
+                      request ->
+                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                  .build())
+          .setResponseParser(
+              ProtoMessageResponseParser.<EchoResponse>newBuilder()
+                  .setDefaultInstance(EchoResponse.getDefaultInstance())
+                  .setDefaultTypeRegistry(typeRegistry)
+                  .build())
+          .build();
+
+  private static final ApiMethodDescriptor<PagedExpandRequest, PagedExpandResponse>
+      pagedExpandMethodDescriptor =
+          ApiMethodDescriptor.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+              .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/PagedExpand")
+              .setHttpMethod(HttpMethods.POST)
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<PagedExpandRequest>newBuilder()
+                      .setPath(
+                          "/v1beta1/echo:pagedExpand",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<PagedExpandRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<PagedExpandRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(
+                          request ->
+                              ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
+                      .setDefaultInstance(PagedExpandResponse.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .build();
+
+  private static final ApiMethodDescriptor<PagedExpandRequest, PagedExpandResponse>
+      simplePagedExpandMethodDescriptor =
+          ApiMethodDescriptor.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+              .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/SimplePagedExpand")
+              .setHttpMethod(HttpMethods.POST)
+              .setType(ApiMethodDescriptor.MethodType.UNARY)
+              .setRequestFormatter(
+                  ProtoMessageRequestFormatter.<PagedExpandRequest>newBuilder()
+                      .setPath(
+                          "/v1beta1/echo:pagedExpand",
+                          request -> {
+                            Map<String, String> fields = new HashMap<>();
+                            ProtoRestSerializer<PagedExpandRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setQueryParamsExtractor(
+                          request -> {
+                            Map<String, List<String>> fields = new HashMap<>();
+                            ProtoRestSerializer<PagedExpandRequest> serializer =
+                                ProtoRestSerializer.create();
+                            return fields;
+                          })
+                      .setRequestBodyExtractor(
+                          request ->
+                              ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                      .build())
+              .setResponseParser(
+                  ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
+                      .setDefaultInstance(PagedExpandResponse.getDefaultInstance())
+                      .setDefaultTypeRegistry(typeRegistry)
+                      .build())
+              .build();
+
+  private static final ApiMethodDescriptor<WaitRequest, Operation> waitMethodDescriptor =
+      ApiMethodDescriptor.<WaitRequest, Operation>newBuilder()
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Wait")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              ProtoMessageRequestFormatter.<WaitRequest>newBuilder()
+                  .setPath(
+                      "/v1beta1/echo:wait",
+                      request -> {
+                        Map<String, String> fields = new HashMap<>();
+                        ProtoRestSerializer<WaitRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setQueryParamsExtractor(
+                      request -> {
+                        Map<String, List<String>> fields = new HashMap<>();
+                        ProtoRestSerializer<WaitRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setRequestBodyExtractor(
+                      request ->
+                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                  .build())
+          .setResponseParser(
+              ProtoMessageResponseParser.<Operation>newBuilder()
+                  .setDefaultInstance(Operation.getDefaultInstance())
+                  .setDefaultTypeRegistry(typeRegistry)
+                  .build())
+          .setOperationSnapshotFactory(
+              (WaitRequest request, Operation response) ->
+                  HttpJsonOperationSnapshot.create(response))
+          .build();
+
+  private static final ApiMethodDescriptor<BlockRequest, BlockResponse> blockMethodDescriptor =
+      ApiMethodDescriptor.<BlockRequest, BlockResponse>newBuilder()
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Block")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              ProtoMessageRequestFormatter.<BlockRequest>newBuilder()
+                  .setPath(
+                      "/v1beta1/echo:block",
+                      request -> {
+                        Map<String, String> fields = new HashMap<>();
+                        ProtoRestSerializer<BlockRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setQueryParamsExtractor(
+                      request -> {
+                        Map<String, List<String>> fields = new HashMap<>();
+                        ProtoRestSerializer<BlockRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setRequestBodyExtractor(
+                      request ->
+                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                  .build())
+          .setResponseParser(
+              ProtoMessageResponseParser.<BlockResponse>newBuilder()
+                  .setDefaultInstance(BlockResponse.getDefaultInstance())
+                  .setDefaultTypeRegistry(typeRegistry)
+                  .build())
+          .build();
+
+  private static final ApiMethodDescriptor<EchoRequest, Object> collideNameMethodDescriptor =
+      ApiMethodDescriptor.<EchoRequest, Object>newBuilder()
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/CollideName")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              ProtoMessageRequestFormatter.<EchoRequest>newBuilder()
+                  .setPath(
+                      "/v1beta1/echo:foo",
+                      request -> {
+                        Map<String, String> fields = new HashMap<>();
+                        ProtoRestSerializer<EchoRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setQueryParamsExtractor(
+                      request -> {
+                        Map<String, List<String>> fields = new HashMap<>();
+                        ProtoRestSerializer<EchoRequest> serializer = ProtoRestSerializer.create();
+                        return fields;
+                      })
+                  .setRequestBodyExtractor(
+                      request ->
+                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                  .build())
+          .setResponseParser(
+              ProtoMessageResponseParser.<Object>newBuilder()
+                  .setDefaultInstance(Object.getDefaultInstance())
+                  .setDefaultTypeRegistry(typeRegistry)
+                  .build())
+          .build();
+
+  private final UnaryCallable<EchoRequest, EchoResponse> echoCallable;
+  private final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable;
+  private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable;
+  private final UnaryCallable<PagedExpandRequest, PagedExpandPagedResponse>
+      pagedExpandPagedCallable;
+  private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> simplePagedExpandCallable;
+  private final UnaryCallable<PagedExpandRequest, SimplePagedExpandPagedResponse>
+      simplePagedExpandPagedCallable;
+  private final UnaryCallable<WaitRequest, Operation> waitCallable;
+  private final OperationCallable<WaitRequest, WaitResponse, WaitMetadata> waitOperationCallable;
+  private final UnaryCallable<BlockRequest, BlockResponse> blockCallable;
+  private final UnaryCallable<EchoRequest, Object> collideNameCallable;
+
+  private final BackgroundResource backgroundResources;
+  private final HttpJsonOperationsStub httpJsonOperationsStub;
+  private final HttpJsonStubCallableFactory callableFactory;
+
+  public static final HttpJsonEchoStub create(EchoStubSettings settings) throws IOException {
+    return new HttpJsonEchoStub(settings, ClientContext.create(settings));
+  }
+
+  public static final HttpJsonEchoStub create(ClientContext clientContext) throws IOException {
+    return new HttpJsonEchoStub(EchoStubSettings.newHttpJsonBuilder().build(), clientContext);
+  }
+
+  public static final HttpJsonEchoStub create(
+      ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
+    return new HttpJsonEchoStub(
+        EchoStubSettings.newHttpJsonBuilder().build(), clientContext, callableFactory);
+  }
+
+  /**
+   * Constructs an instance of HttpJsonEchoStub, using the given settings. This is protected so that
+   * it is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected HttpJsonEchoStub(EchoStubSettings settings, ClientContext clientContext)
+      throws IOException {
+    this(settings, clientContext, new HttpJsonEchoCallableFactory());
+  }
+
+  /**
+   * Constructs an instance of HttpJsonEchoStub, using the given settings. This is protected so that
+   * it is easy to make a subclass, but otherwise, the static factory methods should be preferred.
+   */
+  protected HttpJsonEchoStub(
+      EchoStubSettings settings,
+      ClientContext clientContext,
+      HttpJsonStubCallableFactory callableFactory)
+      throws IOException {
+    this.callableFactory = callableFactory;
+    this.httpJsonOperationsStub =
+        HttpJsonOperationsStub.create(clientContext, callableFactory, typeRegistry);
+
+    HttpJsonCallSettings<EchoRequest, EchoResponse> echoTransportSettings =
+        HttpJsonCallSettings.<EchoRequest, EchoResponse>newBuilder()
+            .setMethodDescriptor(echoMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
+    HttpJsonCallSettings<ExpandRequest, EchoResponse> expandTransportSettings =
+        HttpJsonCallSettings.<ExpandRequest, EchoResponse>newBuilder()
+            .setMethodDescriptor(expandMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
+    HttpJsonCallSettings<PagedExpandRequest, PagedExpandResponse> pagedExpandTransportSettings =
+        HttpJsonCallSettings.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+            .setMethodDescriptor(pagedExpandMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
+    HttpJsonCallSettings<PagedExpandRequest, PagedExpandResponse>
+        simplePagedExpandTransportSettings =
+            HttpJsonCallSettings.<PagedExpandRequest, PagedExpandResponse>newBuilder()
+                .setMethodDescriptor(simplePagedExpandMethodDescriptor)
+                .setTypeRegistry(typeRegistry)
+                .build();
+    HttpJsonCallSettings<WaitRequest, Operation> waitTransportSettings =
+        HttpJsonCallSettings.<WaitRequest, Operation>newBuilder()
+            .setMethodDescriptor(waitMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
+    HttpJsonCallSettings<BlockRequest, BlockResponse> blockTransportSettings =
+        HttpJsonCallSettings.<BlockRequest, BlockResponse>newBuilder()
+            .setMethodDescriptor(blockMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
+    HttpJsonCallSettings<EchoRequest, Object> collideNameTransportSettings =
+        HttpJsonCallSettings.<EchoRequest, Object>newBuilder()
+            .setMethodDescriptor(collideNameMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
+
+    this.echoCallable =
+        callableFactory.createUnaryCallable(
+            echoTransportSettings, settings.echoSettings(), clientContext);
+    this.expandCallable =
+        callableFactory.createServerStreamingCallable(
+            expandTransportSettings, settings.expandSettings(), clientContext);
+    this.pagedExpandCallable =
+        callableFactory.createUnaryCallable(
+            pagedExpandTransportSettings, settings.pagedExpandSettings(), clientContext);
+    this.pagedExpandPagedCallable =
+        callableFactory.createPagedCallable(
+            pagedExpandTransportSettings, settings.pagedExpandSettings(), clientContext);
+    this.simplePagedExpandCallable =
+        callableFactory.createUnaryCallable(
+            simplePagedExpandTransportSettings,
+            settings.simplePagedExpandSettings(),
+            clientContext);
+    this.simplePagedExpandPagedCallable =
+        callableFactory.createPagedCallable(
+            simplePagedExpandTransportSettings,
+            settings.simplePagedExpandSettings(),
+            clientContext);
+    this.waitCallable =
+        callableFactory.createUnaryCallable(
+            waitTransportSettings, settings.waitSettings(), clientContext);
+    this.waitOperationCallable =
+        callableFactory.createOperationCallable(
+            waitTransportSettings,
+            settings.waitOperationSettings(),
+            clientContext,
+            httpJsonOperationsStub);
+    this.blockCallable =
+        callableFactory.createUnaryCallable(
+            blockTransportSettings, settings.blockSettings(), clientContext);
+    this.collideNameCallable =
+        callableFactory.createUnaryCallable(
+            collideNameTransportSettings, settings.collideNameSettings(), clientContext);
+
+    this.backgroundResources =
+        new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+  }
+
+  @InternalApi
+  public static List<ApiMethodDescriptor> getMethodDescriptors() {
+    List<ApiMethodDescriptor> methodDescriptors = new ArrayList<>();
+    methodDescriptors.add(echoMethodDescriptor);
+    methodDescriptors.add(expandMethodDescriptor);
+    methodDescriptors.add(pagedExpandMethodDescriptor);
+    methodDescriptors.add(simplePagedExpandMethodDescriptor);
+    methodDescriptors.add(waitMethodDescriptor);
+    methodDescriptors.add(blockMethodDescriptor);
+    methodDescriptors.add(collideNameMethodDescriptor);
+    return methodDescriptors;
+  }
+
+  public HttpJsonOperationsStub getHttpJsonOperationsStub() {
+    return httpJsonOperationsStub;
+  }
+
+  @Override
+  public UnaryCallable<EchoRequest, EchoResponse> echoCallable() {
+    return echoCallable;
+  }
+
+  @Override
+  public ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable() {
+    return expandCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable() {
+    return pagedExpandCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, PagedExpandPagedResponse> pagedExpandPagedCallable() {
+    return pagedExpandPagedCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, PagedExpandResponse> simplePagedExpandCallable() {
+    return simplePagedExpandCallable;
+  }
+
+  @Override
+  public UnaryCallable<PagedExpandRequest, SimplePagedExpandPagedResponse>
+      simplePagedExpandPagedCallable() {
+    return simplePagedExpandPagedCallable;
+  }
+
+  @Override
+  public UnaryCallable<WaitRequest, Operation> waitCallable() {
+    return waitCallable;
+  }
+
+  @Override
+  public OperationCallable<WaitRequest, WaitResponse, WaitMetadata> waitOperationCallable() {
+    return waitOperationCallable;
+  }
+
+  @Override
+  public UnaryCallable<BlockRequest, BlockResponse> blockCallable() {
+    return blockCallable;
+  }
+
+  @Override
+  public UnaryCallable<EchoRequest, Object> collideNameCallable() {
+    return collideNameCallable;
+  }
+
+  @Override
+  public final void close() {
+    try {
+      backgroundResources.close();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to close resource", e);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    backgroundResources.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return backgroundResources.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return backgroundResources.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    backgroundResources.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return backgroundResources.awaitTermination(duration, unit);
+  }
+}

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposerTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public class HttpJsonServiceStubClassComposerTest {
   @Test
-  public void generateHttpJsonServiceStubClass_simple() {
+  public void generateServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseCompliance();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposerTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 public class ServiceClientTestClassComposerTest {
   @Test
-  public void generateClientTest_echoClient() {
+  public void generateServiceClasses() {
     GapicContext context = RestTestProtoLoader.instance().parseCompliance();
     Service echoProtoService = context.services().get(0);
     GapicClass clazz =

--- a/src/test/proto/echo_grpcrest.proto
+++ b/src/test/proto/echo_grpcrest.proto
@@ -1,0 +1,276 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/longrunning/operations.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
+
+package google.showcase.grpcrest.v1beta1;
+
+option go_package = "github.com/googleapis/gapic-showcase-grpcrest/server/genproto";
+option java_package = "com.google.showcase.grpcrest.v1beta1";
+option java_multiple_files = true;
+
+option (google.api.resource_definition) = {
+  type: "showcase.googleapis.com/AnythingGoes"
+  pattern: "*"
+};
+
+// This service is used showcase the four main types of rpcs - unary, server
+// side streaming, client side streaming, and bidirectional streaming. This
+// service also exposes methods that explicitly implement server delay, and
+// paginated calls. Set the 'showcase-trailer' metadata key on any method
+// to have the values echoed in the response trailers.
+service Echo {
+  // This service is meant to only run locally on the port 7469 (keypad digits
+  // for "show").
+  option (google.api.default_host) = "localhost:7469";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  // This method simply echos the request. This method is showcases unary rpcs.
+  rpc Echo(EchoRequest) returns (EchoResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:echo"
+      body: "*"
+    };
+    option (google.api.method_signature) = "content";
+    option (google.api.method_signature) = "error";
+    option (google.api.method_signature) = "content,severity";
+    option (google.api.method_signature) = "name";
+    option (google.api.method_signature) = "parent";
+    option (google.api.method_signature) = "";
+  }
+
+  // This method split the given content into words and will pass each word back
+  // through the stream. This method showcases server-side streaming rpcs.
+  rpc Expand(ExpandRequest) returns (stream EchoResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:expand"
+      body: "*"
+    };
+    option (google.api.method_signature) = "content,error";
+  }
+
+  // This is similar to the Expand method but instead of returning a stream of
+  // expanded words, this method returns a paged list of expanded words.
+  rpc PagedExpand(PagedExpandRequest) returns (PagedExpandResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:pagedExpand"
+      body: "*"
+    };
+  }
+
+  rpc SimplePagedExpand(PagedExpandRequest) returns (PagedExpandResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:pagedExpand"
+      body: "*"
+    };
+    option (google.api.method_signature) = "";
+  }
+
+  // This method will wait the requested amount of and then return.
+  // This method showcases how a client handles a request timing out.
+  rpc Wait(WaitRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:wait"
+      body: "*"
+    };
+    option (google.longrunning.operation_info) = {
+      response_type: "WaitResponse"
+      metadata_type: "WaitMetadata"
+    };
+    option (google.api.method_signature) = "end_time";
+    option (google.api.method_signature) = "ttl";
+  }
+
+  // This method will block (wait) for the requested amount of time
+  // and then return the response or error.
+  // This method showcases how a client handles delays or retries.
+  rpc Block(BlockRequest) returns (BlockResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:block"
+      body: "*"
+    };
+  };
+
+  // This method primarily tests Java name collisions by using the Object
+  // message.
+  rpc CollideName(EchoRequest) returns (Object) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:foo"
+      body: "*"
+    };
+  }
+}
+
+// A severity enum used to test enum capabilities in GAPIC surfaces
+enum Severity {
+  UNNECESSARY = 0;
+  NECESSARY = 1;
+  URGENT = 2;
+  CRITICAL = 3;
+}
+
+message Foobar {
+  option (google.api.resource) = {
+    type: "showcase.googleapis.com/Foobar"
+    pattern: "projects/{project}/foobars/{foobar}"
+    pattern: "projects/{project}/chocolate/variants/{variant}/foobars/{foobar}"
+    pattern: "foobars/{foobar}"
+    pattern: "bar_foos/{bar_foo}/foobars/{foobar}"
+    pattern: "*"
+  };
+
+  string name = 1;
+  string info = 2;
+}
+
+// The request message used for the Echo, Collect and Chat methods.
+// If content or opt are set in this message then the request will succeed.
+// If status is set in this message
+// then the status will be returned as an error.
+message EchoRequest {
+  string name = 5 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Foobar",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  string parent = 6 [
+    (google.api.resource_reference).child_type =
+        "showcase.googleapis.com/AnythingGoes",
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  oneof response {
+    // The content to be echoed by the server.
+    string content = 1;
+
+    // The error to be thrown by the server.
+    google.rpc.Status error = 2;
+  }
+
+  // The severity to be echoed by the server.
+  Severity severity = 3;
+
+  Foobar foobar = 4;
+}
+
+// The response message for the Echo methods.
+message EchoResponse {
+  // The content specified in the request.
+  string content = 1;
+
+  // The severity specified in the request.
+  Severity severity = 2;
+}
+
+// Tests name collisions with java.lang.Object.
+message Object {
+  // The content specified in the request.
+  string content = 1;
+}
+
+// The request message for the Expand method.
+message ExpandRequest {
+  // The content that will be split into words and returned on the stream.
+  string content = 1;
+
+  // The error that is thrown after all words are sent on the stream.
+  google.rpc.Status error = 2;
+
+  string info = 3;
+}
+
+// The request for the PagedExpand method.
+message PagedExpandRequest {
+  // The string to expand.
+  string content = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The amount of words to returned in each page.
+  int32 page_size = 2;
+
+  // The position of the page to be returned.
+  string page_token = 3;
+}
+
+// The response for the PagedExpand method.
+message PagedExpandResponse {
+  // The words that were expanded.
+  repeated EchoResponse responses = 1;
+
+  // The next page token.
+  string next_page_token = 2;
+}
+
+// The request for Wait method.
+message WaitRequest {
+  oneof end {
+    // The time that this operation will complete.
+    google.protobuf.Timestamp end_time = 1;
+
+    // The duration of this operation.
+    google.protobuf.Duration ttl = 4;
+  }
+
+  oneof response {
+    // The error that will be returned by the server. If this code is specified
+    // to be the OK rpc code, an empty response will be returned.
+    google.rpc.Status error = 2;
+
+    // The response to be returned on operation completion.
+    WaitResponse success = 3;
+  }
+}
+
+// The result of the Wait operation.
+message WaitResponse {
+  // This content of the result.
+  string content = 1;
+}
+
+// The metadata for Wait operation.
+message WaitMetadata {
+  // The time that this operation will complete.
+  google.protobuf.Timestamp end_time = 1;
+}
+
+// The request for Block method.
+message BlockRequest {
+  // The amount of time to block before returning a response.
+  google.protobuf.Duration response_delay = 1;
+
+  oneof response {
+    // The error that will be returned by the server. If this code is specified
+    // to be the OK rpc code, an empty response will be returned.
+    google.rpc.Status error = 2;
+
+    // The response to be returned that will signify successful method call.
+    BlockResponse success = 3;
+  }
+}
+
+// The response for Block method.
+message BlockResponse {
+  // This content can contain anything, the server will not depend on a value
+  // here.
+  string content = 1;
+}


### PR DESCRIPTION
This is for `grpc+rest` clients.

Also add proper `grpc+rest` unit tests which were missing.