### PR TITLE
fix: [REGAPIC] Fix repeated fields handling for query parameters

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -907,7 +907,9 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       for (int i = 0; i < descendantFields.length; i++) {
         String currFieldName = descendantFields[i];
         String bindingFieldMethodName =
-            String.format("get%s", JavaStyle.toUpperCamelCase(currFieldName));
+            (i < descendantFields.length - 1 || !httpBindingFieldName.isRepeated())
+                ? String.format("get%s", JavaStyle.toUpperCamelCase(currFieldName))
+                : String.format("get%sList", JavaStyle.toUpperCamelCase(currFieldName));
         requestFieldGetterExprBuilder =
             requestFieldGetterExprBuilder.setMethodName(bindingFieldMethodName);
 

--- a/src/main/java/com/google/api/generator/gapic/model/HttpBindings.java
+++ b/src/main/java/com/google/api/generator/gapic/model/HttpBindings.java
@@ -40,12 +40,15 @@ public abstract class HttpBindings {
 
     public abstract boolean isOptional();
 
+    public abstract boolean isRepeated();
+
     @Nullable
     public abstract String valuePattern();
 
-    public static HttpBinding create(String name, boolean isOptional, String valuePattern) {
+    public static HttpBinding create(
+        String name, boolean isOptional, boolean isRepeated, String valuePattern) {
       return new AutoValue_HttpBindings_HttpBinding(
-          name, JavaStyle.toLowerCamelCase(name), isOptional, valuePattern);
+          name, JavaStyle.toLowerCamelCase(name), isOptional, isRepeated, valuePattern);
     }
 
     // Do not forget to keep it in sync with equals() implementation.

--- a/src/main/java/com/google/api/generator/gapic/protoparser/HttpRuleParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/HttpRuleParser.java
@@ -128,7 +128,7 @@ public class HttpRuleParser {
           patternSampleValues != null ? patternSampleValues.get(paramName) : null;
       String[] subFields = paramName.split("\\.");
       if (inputMessage == null) {
-        httpBindings.add(HttpBinding.create(paramName, false, patternSampleValue));
+        httpBindings.add(HttpBinding.create(paramName, false, false, patternSampleValue));
         continue;
       }
       Message nestedMessage = inputMessage;
@@ -150,7 +150,8 @@ public class HttpRuleParser {
           }
           Field field = nestedMessage.fieldMap().get(subFieldName);
           httpBindings.add(
-              HttpBinding.create(paramName, field.isProto3Optional(), patternSampleValue));
+              HttpBinding.create(
+                  paramName, field.isProto3Optional(), field.isRepeated(), patternSampleValue));
         }
       }
     }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -407,7 +407,10 @@ public class EchoClient implements BackgroundResource {
    * // It may require modifications to work in your environment.
    * try (EchoClient echoClient = EchoClient.create()) {
    *   ExpandRequest request =
-   *       ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
+   *       ExpandRequest.newBuilder()
+   *           .setContent("content951530617")
+   *           .addAllInfo(new ArrayList<String>())
+   *           .build();
    *   ServerStream<EchoResponse> stream = echoClient.expandCallable().call(request);
    *   for (EchoResponse response : stream) {
    *     // Do something when a response is received.

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
@@ -23,6 +23,7 @@ import com.google.protobuf.Timestamp;
 import com.google.rpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -400,7 +401,10 @@ public class EchoClientTest {
             .build();
     mockEcho.addResponse(expectedResponse);
     ExpandRequest request =
-        ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
+        ExpandRequest.newBuilder()
+            .setContent("content951530617")
+            .addAllInfo(new ArrayList<String>())
+            .build();
 
     MockStreamObserver<EchoResponse> responseObserver = new MockStreamObserver<>();
 
@@ -417,7 +421,10 @@ public class EchoClientTest {
     StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
     mockEcho.addException(exception);
     ExpandRequest request =
-        ExpandRequest.newBuilder().setContent("content951530617").setInfo("info3237038").build();
+        ExpandRequest.newBuilder()
+            .setContent("content951530617")
+            .addAllInfo(new ArrayList<String>())
+            .build();
 
     MockStreamObserver<EchoResponse> responseObserver = new MockStreamObserver<>();
 

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -108,11 +108,12 @@ public class HttpJsonEchoStub extends EchoStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<ExpandRequest> serializer =
                             ProtoRestSerializer.create();
+                        serializer.putQueryParam(fields, "content", request.getContent());
+                        serializer.putQueryParam(fields, "info", request.getInfoList());
                         return fields;
                       })
                   .setRequestBodyExtractor(
-                      request ->
-                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                      request -> ProtoRestSerializer.create().toBody("error", request.getError()))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()

--- a/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
+++ b/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
@@ -33,7 +33,7 @@ public class MethodTest {
           .build();
   private static final HttpBindings HTTP_BINDINGS =
       HttpBindings.builder()
-          .setPathParameters(ImmutableSet.of(HttpBinding.create("table", true, "")))
+          .setPathParameters(ImmutableSet.of(HttpBinding.create("table", true, false, "")))
           .setPattern("/pattern/test")
           .setIsAsteriskBody(false)
           .setHttpVerb(HttpVerb.GET)

--- a/src/test/proto/echo_grpcrest.proto
+++ b/src/test/proto/echo_grpcrest.proto
@@ -65,7 +65,7 @@ service Echo {
   rpc Expand(ExpandRequest) returns (stream EchoResponse) {
     option (google.api.http) = {
       post: "/v1beta1/echo:expand"
-      body: "*"
+      body: "error"
     };
     option (google.api.method_signature) = "content,error";
   }
@@ -202,7 +202,7 @@ message ExpandRequest {
   // The error that is thrown after all words are sent on the stream.
   google.rpc.Status error = 2;
 
-  string info = 3;
+  repeated string info = 3;
 }
 
 // The request for the PagedExpand method.


### PR DESCRIPTION
if a field is declared as repeated in proto then its getter's name is `get<FieldName>List` not `get<FieldName>` instead.