### PR TITLE
chore: avoid using implicitly declared samples target in BUILD.bazel

### DIFF
--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -317,6 +317,7 @@ java_gapic_srcs_pkg = rule(
 def java_gapic_assembly_gradle_pkg(
         name,
         deps,
+        includeSamples = False,
         assembly_name = None,
         transport = None,
         **kwargs):
@@ -341,9 +342,9 @@ def java_gapic_assembly_gradle_pkg(
     processed_deps = {}  #there is no proper Set in Starlark
     for dep in deps:
         # Use contains instead of endswith since microgenerator testing may use differently-named targets.
-        if "samples" in dep:
-            samples.append(dep)
-        elif "_java_gapic" in dep:
+        if "_java_gapic" in dep:
+            if includeSamples:
+                samples.append(dep + "_samples")
             _put_dep_in_a_bucket(dep, client_deps, processed_deps)
             _put_dep_in_a_bucket("%s_test" % dep, client_test_deps, processed_deps)
             _put_dep_in_a_bucket("%s_resource_name" % dep, proto_deps, processed_deps)

--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -317,7 +317,7 @@ java_gapic_srcs_pkg = rule(
 def java_gapic_assembly_gradle_pkg(
         name,
         deps,
-        includeSamples = False,
+        include_samples = False,
         assembly_name = None,
         transport = None,
         **kwargs):
@@ -343,7 +343,7 @@ def java_gapic_assembly_gradle_pkg(
     for dep in deps:
         # Use contains instead of endswith since microgenerator testing may use differently-named targets.
         if "_java_gapic" in dep:
-            if includeSamples:
+            if include_samples:
                 samples.append(dep + "_samples")
             _put_dep_in_a_bucket(dep, client_deps, processed_deps)
             _put_dep_in_a_bucket("%s_test" % dep, client_test_deps, processed_deps)


### PR DESCRIPTION
Now to include samples in the package we have to pass `include_samples = True` in the build file such as:

```
java_gapic_assembly_gradle_pkg(
    name = "google-cloud-accessapproval-v1-java",
    deps = [
        ":accessapproval_java_gapic",
        ":accessapproval_java_grpc",
        ":accessapproval_java_proto",
        ":accessapproval_proto",
    ],
    include_samples = True,
)
```

Not including (as currently is) will result in no samples being included allowing us to roll out slower. This isn't whether samples will be generated but whether they would be included in the assembly package, that would require a more complicated change.

Follow up to: cl/446288272