### PR TITLE
fix: Multiple REST transport related fixes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -147,6 +147,7 @@ java_binary(
     name = "code_generator_request_file_to_gapic_main",
     main_class = "com.google.api.generator.debug.CodeGeneratorRequestFileToGapicMain",
     runtime_deps = [":gapic_generator_java"] + MAIN_DEPS + MAIN_DEPS_DEBUG_RUNTIME_ONLY,
+    data = [":google/pubsub/v1/pubsub_v1.yaml"],
 )
 
 # another test resource

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -147,7 +147,6 @@ java_binary(
     name = "code_generator_request_file_to_gapic_main",
     main_class = "com.google.api.generator.debug.CodeGeneratorRequestFileToGapicMain",
     runtime_deps = [":gapic_generator_java"] + MAIN_DEPS + MAIN_DEPS_DEBUG_RUNTIME_ONLY,
-    data = [":google/pubsub/v1/pubsub_v1.yaml"],
 )
 
 # another test resource

--- a/scripts/diff_gen_and_golden.sh
+++ b/scripts/diff_gen_and_golden.sh
@@ -23,5 +23,5 @@ find src -type f -name 'PlaceholderFile.java' -delete
 find src -type d -empty -delete
 # This will not print diff_output to the console unless `--test_output=all` option
 # is enabled, it only emits the comparison results to the test.log.
-diff -ru src test/integration/goldens/${API_NAME}/src
-diff -ru samples test/integration/goldens/${API_NAME}/samples
+diff -ru test/integration/goldens/${API_NAME}/src src
+diff -ru test/integration/goldens/${API_NAME}/samples samples

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -130,6 +130,10 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
     return GapicClass.create(kind, classDef);
   }
 
+  protected boolean isSupportedMethod(Method method) {
+    return true;
+  }
+
   private List<AnnotationNode> createClassAnnotations() {
     return Arrays.asList(
         AnnotationNode.builder()
@@ -225,6 +229,9 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
     Map<String, Message> messageTypes = context.messages();
     List<MethodDefinition> javaMethods = new ArrayList<>();
     for (Method method : service.methods()) {
+      if (!isSupportedMethod(method)) {
+        continue;
+      }
       Service matchingService = service;
       if (method.isMixin()) {
         int dotIndex = method.mixedInApiName().lastIndexOf(".");
@@ -388,7 +395,8 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
             DefaultValueComposer.createSimpleMessageBuilderValue(
                 messageTypes.get(methodOutputType.reference().fullName()),
                 resourceNames,
-                messageTypes);
+                messageTypes,
+                method.httpBindingPattern());
       } else {
         // Wrap this in a field so we don't have to split the helper into lots of different methods,
         // or duplicate it for VariableExpr.
@@ -461,9 +469,14 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
       if (getTransportContext().useValuePatterns() && method.hasHttpBindings()) {
         pathParamValuePatterns = method.httpBindings().getPathParametersValuePatterns();
       }
+
       Expr valExpr =
           DefaultValueComposer.createSimpleMessageBuilderValue(
-              requestMessage, resourceNames, messageTypes, pathParamValuePatterns);
+              requestMessage,
+              resourceNames,
+              messageTypes,
+              pathParamValuePatterns,
+              method.httpBindingPattern());
       methodExprs.add(
           AssignmentExpr.builder()
               .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -482,7 +495,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
         argExprs.add(varExpr);
         Expr valExpr =
             DefaultValueComposer.createMethodArgValue(
-                methodArg, resourceNames, messageTypes, valuePatterns);
+                methodArg, resourceNames, messageTypes, valuePatterns, method.httpBindingPattern());
         methodExprs.add(
             AssignmentExpr.builder()
                 .setVariableExpr(varExpr.toBuilder().setIsDecl(true).build())
@@ -770,7 +783,11 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
       }
       Expr valExpr =
           DefaultValueComposer.createSimpleMessageBuilderValue(
-              requestMessage, resourceNames, messageTypes, valuePatterns);
+              requestMessage,
+              resourceNames,
+              messageTypes,
+              valuePatterns,
+              method.httpBindingPattern());
       tryBodyExprs.add(
           AssignmentExpr.builder()
               .setVariableExpr(varExpr.toBuilder().setIsDecl(true).build())
@@ -789,7 +806,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
         argVarExprs.add(varExpr);
         Expr valExpr =
             DefaultValueComposer.createMethodArgValue(
-                methodArg, resourceNames, messageTypes, valuePatterns);
+                methodArg, resourceNames, messageTypes, valuePatterns, method.httpBindingPattern());
         tryBodyExprs.add(
             AssignmentExpr.builder()
                 .setVariableExpr(varExpr.toBuilder().setIsDecl(true).build())

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -396,7 +396,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
                 messageTypes.get(methodOutputType.reference().fullName()),
                 resourceNames,
                 messageTypes,
-                method.httpBindingPattern());
+                method.httpBindings());
       } else {
         // Wrap this in a field so we don't have to split the helper into lots of different methods,
         // or duplicate it for VariableExpr.
@@ -476,7 +476,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
               resourceNames,
               messageTypes,
               pathParamValuePatterns,
-              method.httpBindingPattern());
+              method.httpBindings());
       methodExprs.add(
           AssignmentExpr.builder()
               .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -495,7 +495,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
         argExprs.add(varExpr);
         Expr valExpr =
             DefaultValueComposer.createMethodArgValue(
-                methodArg, resourceNames, messageTypes, valuePatterns, method.httpBindingPattern());
+                methodArg, resourceNames, messageTypes, valuePatterns, method.httpBindings());
         methodExprs.add(
             AssignmentExpr.builder()
                 .setVariableExpr(varExpr.toBuilder().setIsDecl(true).build())
@@ -783,11 +783,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
       }
       Expr valExpr =
           DefaultValueComposer.createSimpleMessageBuilderValue(
-              requestMessage,
-              resourceNames,
-              messageTypes,
-              valuePatterns,
-              method.httpBindingPattern());
+              requestMessage, resourceNames, messageTypes, valuePatterns, method.httpBindings());
       tryBodyExprs.add(
           AssignmentExpr.builder()
               .setVariableExpr(varExpr.toBuilder().setIsDecl(true).build())
@@ -806,7 +802,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
         argVarExprs.add(varExpr);
         Expr valExpr =
             DefaultValueComposer.createMethodArgValue(
-                methodArg, resourceNames, messageTypes, valuePatterns, method.httpBindingPattern());
+                methodArg, resourceNames, messageTypes, valuePatterns, method.httpBindings());
         tryBodyExprs.add(
             AssignmentExpr.builder()
                 .setVariableExpr(varExpr.toBuilder().setIsDecl(true).build())

--- a/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
@@ -255,7 +255,7 @@ public class DefaultValueComposer {
       for (ResourceName resname : resnames) {
         unexaminedResnames.remove(resname);
         if (!resname.isOnlyWildcard()
-            && (bindingPattern == null || resname.matchesBinding(bindingPattern))) {
+            && (bindingPattern == null || resname.getMatchingPattern(bindingPattern) != null)) {
           return createResourceHelperValue(
               resname, false, unexaminedResnames, fieldOrMessageName, null);
         }
@@ -279,15 +279,22 @@ public class DefaultValueComposer {
     if (containsOnlyDeletedTopic) {
       ofMethodName = "ofDeletedTopic";
     } else {
-      for (String pattern : resourceName.patterns()) {
-        if (pattern.equals(ResourceNameConstants.WILDCARD_PATTERN)
-            || pattern.equals(ResourceNameConstants.DELETED_TOPIC_LITERAL)) {
-          continue;
-        }
-        patternPlaceholderTokens.addAll(
-            ResourceNameTokenizer.parseTokenHierarchy(Arrays.asList(pattern)).get(0));
-        break;
+      String matchingPattern = null;
+      if (bindingPattern != null) {
+        matchingPattern = resourceName.getMatchingPattern(bindingPattern);
       }
+      if (matchingPattern == null) {
+        for (String pattern : resourceName.patterns()) {
+          if (pattern.equals(ResourceNameConstants.WILDCARD_PATTERN)
+              || pattern.equals(ResourceNameConstants.DELETED_TOPIC_LITERAL)) {
+            continue;
+          }
+          matchingPattern = pattern;
+          break;
+        }
+      }
+      patternPlaceholderTokens.addAll(
+          ResourceNameTokenizer.parseTokenHierarchy(Arrays.asList(matchingPattern)).get(0));
     }
 
     boolean hasOnePattern = resourceName.patterns().size() == 1;

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -551,7 +551,8 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
           DefaultValueComposer.createSimpleMessageBuilderValue(
               messageTypes.get(methodOutputType.reference().fullName()),
               resourceNames,
-              messageTypes);
+              messageTypes,
+              method.httpBindingPattern());
     } else {
       // Wrap this in a field so we don't have to split the helper into lots of different methods,
       // or duplicate it for VariableExpr.
@@ -608,7 +609,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     Preconditions.checkNotNull(requestMessage);
     Expr valExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
     methodExprs.add(
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -881,7 +882,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     Preconditions.checkNotNull(requestMessage);
     Expr valExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
 
     List<Statement> statements = new ArrayList<>();
     statements.add(

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -552,7 +552,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
               messageTypes.get(methodOutputType.reference().fullName()),
               resourceNames,
               messageTypes,
-              method.httpBindingPattern());
+              method.httpBindings());
     } else {
       // Wrap this in a field so we don't have to split the helper into lots of different methods,
       // or duplicate it for VariableExpr.
@@ -609,7 +609,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     Preconditions.checkNotNull(requestMessage);
     Expr valExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
     methodExprs.add(
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -882,7 +882,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
     Preconditions.checkNotNull(requestMessage);
     Expr valExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
 
     List<Statement> statements = new ArrayList<>();
     statements.add(

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposer.java
@@ -47,7 +47,9 @@ public class HttpJsonServiceClientTestClassComposer extends ServiceClientTestCla
   }
 
   protected boolean isSupportedMethod(Method method) {
-    return method.stream() != Stream.BIDI && method.stream() != Stream.CLIENT;
+    return method.httpBindings() != null
+        && method.stream() != Stream.BIDI
+        && method.stream() != Stream.CLIENT;
   }
 
   @Override

--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/HttpJsonServiceClientTestClassComposer.java
@@ -21,6 +21,8 @@ import com.google.api.generator.gapic.composer.rest.ServiceClientTestClassCompos
 import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.gapic.model.Method;
+import com.google.api.generator.gapic.model.Method.Stream;
 import com.google.api.generator.gapic.model.Service;
 import java.util.Map;
 
@@ -42,6 +44,10 @@ public class HttpJsonServiceClientTestClassComposer extends ServiceClientTestCla
         getTransportContext().classNames().getServiceClientTestClassNames(service).get(0),
         context,
         service);
+  }
+
+  protected boolean isSupportedMethod(Method method) {
+    return method.stream() != Stream.BIDI && method.stream() != Stream.CLIENT;
   }
 
   @Override

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -115,7 +115,9 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
   }
 
   protected boolean isSupportedMethod(Method method) {
-    return method.stream() != Stream.BIDI && method.stream() != Stream.CLIENT;
+    return method.httpBindings() != null
+        && method.stream() != Stream.BIDI
+        && method.stream() != Stream.CLIENT;
   }
 
   @Override

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -56,6 +56,7 @@ import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
+import com.google.api.generator.gapic.model.Method.Stream;
 import com.google.api.generator.gapic.model.OperationResponse;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
@@ -111,6 +112,10 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
             ProtoMessageResponseParser.class,
             ProtoRestSerializer.class,
             TypeRegistry.class));
+  }
+
+  protected boolean isSupportedMethod(Method method) {
+    return method.stream() != Stream.BIDI && method.stream() != Stream.CLIENT;
   }
 
   @Override

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposer.java
@@ -308,7 +308,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -429,7 +429,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -558,7 +558,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -615,7 +615,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposer.java
@@ -308,7 +308,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -429,7 +429,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -558,7 +558,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())
@@ -615,7 +615,7 @@ public class ServiceClientCallableMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
@@ -27,6 +27,7 @@ import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import com.google.api.generator.gapic.composer.defaultvalue.DefaultValueComposer;
+import com.google.api.generator.gapic.model.HttpBindings;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.MethodArgument;
@@ -91,7 +92,7 @@ public class ServiceClientHeaderSampleComposer {
     // Assign method's arguments variable with the default values.
     List<VariableExpr> rpcMethodArgVarExprs = createArgumentVariableExprs(arguments);
     List<Expr> rpcMethodArgDefaultValueExprs =
-        createArgumentDefaultValueExprs(arguments, resourceNames, method.httpBindingPattern());
+        createArgumentDefaultValueExprs(arguments, resourceNames, method.httpBindings());
     List<Expr> rpcMethodArgAssignmentExprs =
         createAssignmentsForVarExprsWithValueExprs(
             rpcMethodArgVarExprs, rpcMethodArgDefaultValueExprs);
@@ -369,7 +370,7 @@ public class ServiceClientHeaderSampleComposer {
   private static List<Expr> createArgumentDefaultValueExprs(
       List<MethodArgument> arguments,
       Map<String, ResourceName> resourceNames,
-      String bindingPattern) {
+      HttpBindings bindings) {
     List<ResourceName> resourceNameList =
         resourceNames.values().stream().collect(Collectors.toList());
     Function<MethodArgument, MethodInvocationExpr> stringResourceNameDefaultValueExpr =
@@ -394,7 +395,7 @@ public class ServiceClientHeaderSampleComposer {
                         resourceNames,
                         Collections.emptyMap(),
                         Collections.emptyMap(),
-                        bindingPattern)
+                        bindings)
                     : stringResourceNameDefaultValueExpr.apply(arg))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
@@ -91,7 +91,7 @@ public class ServiceClientHeaderSampleComposer {
     // Assign method's arguments variable with the default values.
     List<VariableExpr> rpcMethodArgVarExprs = createArgumentVariableExprs(arguments);
     List<Expr> rpcMethodArgDefaultValueExprs =
-        createArgumentDefaultValueExprs(arguments, resourceNames);
+        createArgumentDefaultValueExprs(arguments, resourceNames, method.httpBindingPattern());
     List<Expr> rpcMethodArgAssignmentExprs =
         createAssignmentsForVarExprsWithValueExprs(
             rpcMethodArgVarExprs, rpcMethodArgDefaultValueExprs);
@@ -367,7 +367,9 @@ public class ServiceClientHeaderSampleComposer {
 
   // Create a list of RPC method arguments' default value expression.
   private static List<Expr> createArgumentDefaultValueExprs(
-      List<MethodArgument> arguments, Map<String, ResourceName> resourceNames) {
+      List<MethodArgument> arguments,
+      Map<String, ResourceName> resourceNames,
+      String bindingPattern) {
     List<ResourceName> resourceNameList =
         resourceNames.values().stream().collect(Collectors.toList());
     Function<MethodArgument, MethodInvocationExpr> stringResourceNameDefaultValueExpr =
@@ -378,7 +380,8 @@ public class ServiceClientHeaderSampleComposer {
                         resourceNames.get(arg.field().resourceReference().resourceTypeString()),
                         arg.field().resourceReference().isChildType(),
                         resourceNameList,
-                        arg.field().name()))
+                        arg.field().name(),
+                        null))
                 .setMethodName("toString")
                 .setReturnType(TypeNode.STRING)
                 .build();
@@ -387,7 +390,11 @@ public class ServiceClientHeaderSampleComposer {
             arg ->
                 !SampleComposerUtil.isStringTypedResourceName(arg, resourceNames)
                     ? DefaultValueComposer.createMethodArgValue(
-                        arg, resourceNames, Collections.emptyMap(), Collections.emptyMap())
+                        arg,
+                        resourceNames,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        bindingPattern)
                     : stringResourceNameDefaultValueExpr.apply(arg))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientMethodSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientMethodSampleComposer.java
@@ -96,7 +96,7 @@ public class ServiceClientMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
+            requestMessage, resourceNames, messageTypes, method.httpBindings());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientMethodSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientMethodSampleComposer.java
@@ -96,7 +96,7 @@ public class ServiceClientMethodSampleComposer {
             "Could not find the message type %s.", method.inputType().reference().fullName()));
     Expr requestBuilderExpr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            requestMessage, resourceNames, messageTypes);
+            requestMessage, resourceNames, messageTypes, method.httpBindingPattern());
     AssignmentExpr requestAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(requestVarExpr.toBuilder().setIsDecl(true).build())

--- a/src/main/java/com/google/api/generator/gapic/model/HttpBindings.java
+++ b/src/main/java/com/google/api/generator/gapic/model/HttpBindings.java
@@ -17,7 +17,7 @@ package com.google.api.generator.gapic.model;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,7 +108,7 @@ public abstract class HttpBindings {
   }
 
   public Map<String, String> getPathParametersValuePatterns() {
-    Map<String, String> valuePatterns = new HashMap<>();
+    Map<String, String> valuePatterns = new LinkedHashMap<>();
     for (HttpBinding pathParameter : pathParameters()) {
       valuePatterns.put(pathParameter.lowerCamelName(), pathParameter.valuePattern());
     }

--- a/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -63,11 +63,6 @@ public abstract class Method {
   public abstract HttpBindings httpBindings();
 
   @Nullable
-  public String httpBindingPattern() {
-    return httpBindings() != null ? httpBindings().pattern() : null;
-  }
-
-  @Nullable
   public abstract RoutingHeaderRule routingHeaderRule();
 
   // Example from Expand in echo.proto: Thet TypeNodes that map to

--- a/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -63,6 +63,11 @@ public abstract class Method {
   public abstract HttpBindings httpBindings();
 
   @Nullable
+  public String httpBindingPattern() {
+    return httpBindings() != null ? httpBindings().pattern() : null;
+  }
+
+  @Nullable
   public abstract RoutingHeaderRule routingHeaderRule();
 
   // Example from Expand in echo.proto: Thet TypeNodes that map to

--- a/src/main/java/com/google/api/generator/gapic/model/ResourceName.java
+++ b/src/main/java/com/google/api/generator/gapic/model/ResourceName.java
@@ -20,8 +20,10 @@ import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.api.generator.gapic.utils.ResourceNameConstants;
+import com.google.api.pathtemplate.PathTemplate;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -54,6 +56,25 @@ public abstract class ResourceName {
   public abstract TypeNode type();
 
   public abstract boolean isOnlyWildcard();
+
+  public boolean matchesBinding(String binding) {
+    String resNamePattern = patterns().get(0);
+    PathTemplate restNamePatternTemplate = PathTemplate.create(resNamePattern);
+    ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
+    for (String var : restNamePatternTemplate.vars()) {
+      mb.put(var, var + (var.hashCode() % 100));
+    }
+
+    String resNameValue = restNamePatternTemplate.instantiate(mb.build());
+    PathTemplate bindingTemplate = PathTemplate.create(binding);
+    mb = ImmutableMap.builder();
+    for (String var : bindingTemplate.vars()) {
+      mb.put(var, resNameValue);
+    }
+
+    String url = bindingTemplate.instantiate(mb.build());
+    return bindingTemplate.matches(url);
+  }
 
   // The message in which this resource was defined. Optional.
   // This is expected to be empty for file-level definitions.

--- a/src/main/java/com/google/api/generator/gapic/model/ResourceName.java
+++ b/src/main/java/com/google/api/generator/gapic/model/ResourceName.java
@@ -57,23 +57,29 @@ public abstract class ResourceName {
 
   public abstract boolean isOnlyWildcard();
 
-  public boolean matchesBinding(String binding) {
-    String resNamePattern = patterns().get(0);
-    PathTemplate restNamePatternTemplate = PathTemplate.create(resNamePattern);
-    ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
-    for (String var : restNamePatternTemplate.vars()) {
-      mb.put(var, var + (var.hashCode() % 100));
-    }
-
-    String resNameValue = restNamePatternTemplate.instantiate(mb.build());
+  @Nullable
+  public String getMatchingPattern(String binding) {
     PathTemplate bindingTemplate = PathTemplate.create(binding);
-    mb = ImmutableMap.builder();
-    for (String var : bindingTemplate.vars()) {
-      mb.put(var, resNameValue);
-    }
 
-    String url = bindingTemplate.instantiate(mb.build());
-    return bindingTemplate.matches(url);
+    for (String resNamePattern : patterns()) {
+      PathTemplate restNamePatternTemplate = PathTemplate.create(resNamePattern);
+      ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
+      for (String var : restNamePatternTemplate.vars()) {
+        mb.put(var, var + (var.hashCode() % 100));
+      }
+
+      String resNameValue = restNamePatternTemplate.instantiate(mb.build());
+      mb = ImmutableMap.builder();
+      for (String var : bindingTemplate.vars()) {
+        mb.put(var, resNameValue);
+      }
+
+      String url = bindingTemplate.instantiate(mb.build());
+      if (bindingTemplate.matches(url)) {
+        return resNamePattern;
+      }
+    }
+    return null;
   }
 
   // The message in which this resource was defined. Optional.

--- a/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
@@ -163,7 +163,8 @@ public class DefaultValueComposerTest {
             resourceName,
             false,
             typeStringsToResourceNames.values().stream().collect(Collectors.toList()),
-            "ignored");
+            "ignored",
+            null);
     expr.accept(writerVisitor);
     assertEquals("BillingAccountName.of(\"[BILLING_ACCOUNT]\")", writerVisitor.write());
   }
@@ -180,7 +181,8 @@ public class DefaultValueComposerTest {
             resourceName,
             false,
             typeStringsToResourceNames.values().stream().collect(Collectors.toList()),
-            "ignored");
+            "ignored",
+            null);
     expr.accept(writerVisitor);
     assertEquals(
         "FolderName.ofProjectFolderName(\"[PROJECT]\", \"[FOLDER]\")", writerVisitor.write());
@@ -198,7 +200,8 @@ public class DefaultValueComposerTest {
             resourceName,
             false,
             typeStringsToResourceNames.values().stream().collect(Collectors.toList()),
-            "ignored");
+            "ignored",
+            null);
     expr.accept(writerVisitor);
     assertEquals("DocumentName.ofDocumentName(\"[DOCUMENT]\")", writerVisitor.write());
   }
@@ -221,7 +224,8 @@ public class DefaultValueComposerTest {
             resourceName,
             false,
             typeStringsToResourceNames.values().stream().collect(Collectors.toList()),
-            "ignored");
+            "ignored",
+            null);
     expr.accept(writerVisitor);
     assertEquals("TopicName.ofDeletedTopic()", writerVisitor.write());
   }
@@ -243,7 +247,8 @@ public class DefaultValueComposerTest {
             false,
             Collections.emptyList(),
             fallbackField,
-            /* allowAnonResourceNameClass = */ false);
+            /* allowAnonResourceNameClass = */ false,
+            null);
     expr.accept(writerVisitor);
     assertEquals(
         String.format("\"%s%s\"", fallbackField, fallbackField.hashCode()), writerVisitor.write());
@@ -262,7 +267,7 @@ public class DefaultValueComposerTest {
     String fallbackField = "foobar";
     Expr expr =
         DefaultValueComposer.createResourceHelperValue(
-            resourceName, false, Collections.emptyList(), fallbackField);
+            resourceName, false, Collections.emptyList(), fallbackField, null);
     expr.accept(writerVisitor);
     String expected =
         LineFormatter.lines(
@@ -292,7 +297,7 @@ public class DefaultValueComposerTest {
     Message message = messageTypes.get("com.google.showcase.v1beta1.Foobar");
     Expr expr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            message, typeStringsToResourceNames, messageTypes);
+            message, typeStringsToResourceNames, messageTypes, null);
     expr.accept(writerVisitor);
     assertEquals(
         "Foobar.newBuilder().setName(FoobarName.ofProjectFoobarName(\"[PROJECT]\", \"[FOOBAR]\")"
@@ -309,7 +314,7 @@ public class DefaultValueComposerTest {
     Message message = messageTypes.get("com.google.showcase.v1beta1.EchoRequest");
     Expr expr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            message, typeStringsToResourceNames, messageTypes);
+            message, typeStringsToResourceNames, messageTypes, null);
     expr.accept(writerVisitor);
     assertEquals(
         "EchoRequest.newBuilder().setName("
@@ -329,7 +334,7 @@ public class DefaultValueComposerTest {
     Message message = messageTypes.get("com.google.showcase.v1beta1.PagedExpandResponse");
     Expr expr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            message, typeStringsToResourceNames, messageTypes);
+            message, typeStringsToResourceNames, messageTypes, null);
     expr.accept(writerVisitor);
     assertEquals(
         "PagedExpandResponse.newBuilder().addAllResponses(new ArrayList<EchoResponse>())"
@@ -346,7 +351,7 @@ public class DefaultValueComposerTest {
     Message message = messageTypes.get("com.google.showcase.v1beta1.WaitRequest");
     Expr expr =
         DefaultValueComposer.createSimpleMessageBuilderValue(
-            message, typeStringsToResourceNames, messageTypes);
+            message, typeStringsToResourceNames, messageTypes, null);
     expr.accept(writerVisitor);
     assertEquals("WaitRequest.newBuilder().build()", writerVisitor.write());
   }

--- a/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposerTest.java
@@ -284,6 +284,11 @@ public class DefaultValueComposerTest {
             "return getFieldValuesMap().get(fieldName);\n",
             "}\n",
             "\n",
+            "@Override\n",
+            "public String toString() {\n",
+            "return \"foobar-1268878963\";\n",
+            "}\n",
+            "\n",
             "}");
     assertEquals(expected, writerVisitor.write());
   }
@@ -358,7 +363,7 @@ public class DefaultValueComposerTest {
 
   @Test
   public void createAnonymousResourceNameClass() {
-    Expr expr = DefaultValueComposer.createAnonymousResourceNameClassValue("resource");
+    Expr expr = DefaultValueComposer.createAnonymousResourceNameClassValue("resource", null);
     expr.accept(writerVisitor);
     String expected =
         LineFormatter.lines(
@@ -373,6 +378,11 @@ public class DefaultValueComposerTest {
             "@Override\n",
             "public String getFieldValue(String fieldName) {\n",
             "return getFieldValuesMap().get(fieldName);\n",
+            "}\n",
+            "\n",
+            "@Override\n",
+            "public String toString() {\n",
+            "return \"resource-341064690\";\n",
             "}\n",
             "\n",
             "}");

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
@@ -728,7 +728,7 @@ public class MessagingClient implements BackgroundResource {
    * // This snippet has been automatically generated for illustrative purposes only.
    * // It may require modifications to work in your environment.
    * try (MessagingClient messagingClient = MessagingClient.create()) {
-   *   BlurbName name = BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]");
+   *   BlurbName name = BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]");
    *   Blurb response = messagingClient.getBlurb(name);
    * }
    * }</pre>
@@ -774,9 +774,7 @@ public class MessagingClient implements BackgroundResource {
    * try (MessagingClient messagingClient = MessagingClient.create()) {
    *   GetBlurbRequest request =
    *       GetBlurbRequest.newBuilder()
-   *           .setName(
-   *               BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-   *                   .toString())
+   *           .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
    *           .build();
    *   Blurb response = messagingClient.getBlurb(request);
    * }
@@ -799,9 +797,7 @@ public class MessagingClient implements BackgroundResource {
    * try (MessagingClient messagingClient = MessagingClient.create()) {
    *   GetBlurbRequest request =
    *       GetBlurbRequest.newBuilder()
-   *           .setName(
-   *               BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-   *                   .toString())
+   *           .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
    *           .build();
    *   ApiFuture<Blurb> future = messagingClient.getBlurbCallable().futureCall(request);
    *   // Do something.
@@ -862,7 +858,7 @@ public class MessagingClient implements BackgroundResource {
    * // This snippet has been automatically generated for illustrative purposes only.
    * // It may require modifications to work in your environment.
    * try (MessagingClient messagingClient = MessagingClient.create()) {
-   *   BlurbName name = BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]");
+   *   BlurbName name = BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]");
    *   messagingClient.deleteBlurb(name);
    * }
    * }</pre>
@@ -908,9 +904,7 @@ public class MessagingClient implements BackgroundResource {
    * try (MessagingClient messagingClient = MessagingClient.create()) {
    *   DeleteBlurbRequest request =
    *       DeleteBlurbRequest.newBuilder()
-   *           .setName(
-   *               BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-   *                   .toString())
+   *           .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
    *           .build();
    *   messagingClient.deleteBlurb(request);
    * }
@@ -933,9 +927,7 @@ public class MessagingClient implements BackgroundResource {
    * try (MessagingClient messagingClient = MessagingClient.create()) {
    *   DeleteBlurbRequest request =
    *       DeleteBlurbRequest.newBuilder()
-   *           .setName(
-   *               BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-   *                   .toString())
+   *           .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
    *           .build();
    *   ApiFuture<Empty> future = messagingClient.deleteBlurbCallable().futureCall(request);
    *   // Do something.

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncDeleteBlurb.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncDeleteBlurb.golden
@@ -35,9 +35,7 @@ public class AsyncDeleteBlurb {
     try (MessagingClient messagingClient = MessagingClient.create()) {
       DeleteBlurbRequest request =
           DeleteBlurbRequest.newBuilder()
-              .setName(
-                  BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-                      .toString())
+              .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
               .build();
       ApiFuture<Empty> future = messagingClient.deleteBlurbCallable().futureCall(request);
       // Do something.

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncGetBlurb.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncGetBlurb.golden
@@ -35,9 +35,7 @@ public class AsyncGetBlurb {
     try (MessagingClient messagingClient = MessagingClient.create()) {
       GetBlurbRequest request =
           GetBlurbRequest.newBuilder()
-              .setName(
-                  BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-                      .toString())
+              .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
               .build();
       ApiFuture<Blurb> future = messagingClient.getBlurbCallable().futureCall(request);
       // Do something.

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurb.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurb.golden
@@ -34,9 +34,7 @@ public class SyncDeleteBlurb {
     try (MessagingClient messagingClient = MessagingClient.create()) {
       DeleteBlurbRequest request =
           DeleteBlurbRequest.newBuilder()
-              .setName(
-                  BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-                      .toString())
+              .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
               .build();
       messagingClient.deleteBlurb(request);
     }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurbBlurbname.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncDeleteBlurbBlurbname.golden
@@ -31,7 +31,7 @@ public class SyncDeleteBlurbBlurbname {
     // This snippet has been automatically generated for illustrative purposes only.
     // It may require modifications to work in your environment.
     try (MessagingClient messagingClient = MessagingClient.create()) {
-      BlurbName name = BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]");
+      BlurbName name = BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]");
       messagingClient.deleteBlurb(name);
     }
   }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurb.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurb.golden
@@ -34,9 +34,7 @@ public class SyncGetBlurb {
     try (MessagingClient messagingClient = MessagingClient.create()) {
       GetBlurbRequest request =
           GetBlurbRequest.newBuilder()
-              .setName(
-                  BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]")
-                      .toString())
+              .setName(BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]").toString())
               .build();
       Blurb response = messagingClient.getBlurb(request);
     }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurbBlurbname.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/SyncGetBlurbBlurbname.golden
@@ -31,7 +31,7 @@ public class SyncGetBlurbBlurbname {
     // This snippet has been automatically generated for illustrative purposes only.
     // It may require modifications to work in your environment.
     try (MessagingClient messagingClient = MessagingClient.create()) {
-      BlurbName name = BlurbName.ofUserLegacyUserBlurbName("[USER]", "[LEGACY_USER]", "[BLURB]");
+      BlurbName name = BlurbName.ofRoomBlurbName("[ROOM]", "[BLURB]");
       Blurb response = messagingClient.getBlurb(name);
     }
   }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/ServiceStubSettingsClassComposerTest.java
@@ -29,7 +29,8 @@ public class ServiceStubSettingsClassComposerTest {
   public void generateServiceClasses() {
     GapicContext context = GrpcRestTestProtoLoader.instance().parseShowcaseEcho();
     Service echoProtoService = context.services().get(0);
-    GapicClass clazz = ServiceSettingsClassComposer.instance().generate(context, echoProtoService);
+    GapicClass clazz =
+        ServiceStubSettingsClassComposer.instance().generate(context, echoProtoService);
 
     JavaWriterVisitor visitor = new JavaWriterVisitor();
     clazz.classDefinition().accept(visitor);

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -9,6 +9,7 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.paging.AbstractFixedSizeCollection;
 import com.google.api.gax.paging.AbstractPage;
 import com.google.api.gax.paging.AbstractPagedListResponse;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.ServerStreamingCallable;
@@ -859,6 +860,33 @@ public class EchoClient implements BackgroundResource {
    */
   public final UnaryCallable<EchoRequest, Object> nestedBindingCallable() {
     return stub.nestedBindingCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   BidiStream<EchoRequest, EchoResponse> bidiStream = echoClient.chatCallable().call();
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFooBar(Foobar.newBuilder().build())
+   *           .build();
+   *   bidiStream.send(request);
+   *   for (EchoResponse response : bidiStream) {
+   *     // Do something when a response is received.
+   *   }
+   * }
+   * }</pre>
+   */
+  public final BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
+    return stub.chatCallable();
   }
 
   @Override

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -889,6 +889,57 @@ public class EchoClient implements BackgroundResource {
     return stub.chatCallable();
   }
 
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFooBar(Foobar.newBuilder().build())
+   *           .build();
+   *   EchoResponse response = echoClient.noBinding(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final EchoResponse noBinding(EchoRequest request) {
+    return noBindingCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated for illustrative purposes only.
+   * // It may require modifications to work in your environment.
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   EchoRequest request =
+   *       EchoRequest.newBuilder()
+   *           .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+   *           .setSeverity(Severity.forNumber(0))
+   *           .setFooBar(Foobar.newBuilder().build())
+   *           .build();
+   *   ApiFuture<EchoResponse> future = echoClient.noBindingCallable().futureCall(request);
+   *   // Do something.
+   *   EchoResponse response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
+    return stub.noBindingCallable();
+  }
+
   @Override
   public final void close() {
     stub.close();

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
@@ -10,6 +10,8 @@ import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.grpc.testing.MockStreamObserver;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.StatusCode;
@@ -770,6 +772,64 @@ public class EchoClientTest {
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.
+    }
+  }
+
+  @Test
+  public void chatTest() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+    EchoRequest request =
+        EchoRequest.newBuilder()
+            .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
+            .setFooBar(Foobar.newBuilder().build())
+            .build();
+
+    MockStreamObserver<EchoResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<EchoRequest, EchoResponse> callable = client.chatCallable();
+    ApiStreamObserver<EchoRequest> requestObserver = callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    List<EchoResponse> actualResponses = responseObserver.future().get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+  }
+
+  @Test
+  public void chatExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+    EchoRequest request =
+        EchoRequest.newBuilder()
+            .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
+            .setFooBar(Foobar.newBuilder().build())
+            .build();
+
+    MockStreamObserver<EchoResponse> responseObserver = new MockStreamObserver<>();
+
+    BidiStreamingCallable<EchoRequest, EchoResponse> callable = client.chatCallable();
+    ApiStreamObserver<EchoRequest> requestObserver = callable.bidiStreamingCall(responseObserver);
+
+    requestObserver.onNext(request);
+
+    try {
+      List<EchoResponse> actualResponses = responseObserver.future().get();
+      Assert.fail("No exception thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof InvalidArgumentException);
+      InvalidArgumentException apiException = ((InvalidArgumentException) e.getCause());
+      Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
@@ -832,4 +832,60 @@ public class EchoClientTest {
       Assert.assertEquals(StatusCode.Code.INVALID_ARGUMENT, apiException.getStatusCode().getCode());
     }
   }
+
+  @Test
+  public void noBindingTest() throws Exception {
+    EchoResponse expectedResponse =
+        EchoResponse.newBuilder()
+            .setContent("content951530617")
+            .setSeverity(Severity.forNumber(0))
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    EchoRequest request =
+        EchoRequest.newBuilder()
+            .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+            .setSeverity(Severity.forNumber(0))
+            .setFooBar(Foobar.newBuilder().build())
+            .build();
+
+    EchoResponse actualResponse = client.noBinding(request);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    EchoRequest actualRequest = ((EchoRequest) actualRequests.get(0));
+
+    Assert.assertEquals(request.getName(), actualRequest.getName());
+    Assert.assertEquals(request.getParent(), actualRequest.getParent());
+    Assert.assertEquals(request.getContent(), actualRequest.getContent());
+    Assert.assertEquals(request.getError(), actualRequest.getError());
+    Assert.assertEquals(request.getSeverity(), actualRequest.getSeverity());
+    Assert.assertEquals(request.getFooBar(), actualRequest.getFooBar());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void noBindingExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      EchoRequest request =
+          EchoRequest.newBuilder()
+              .setName(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setParent(FoobarName.ofProjectFoobarName("[PROJECT]", "[FOOBAR]").toString())
+              .setSeverity(Severity.forNumber(0))
+              .setFooBar(Foobar.newBuilder().build())
+              .build();
+      client.noBinding(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
@@ -114,6 +114,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     return ((EchoStubSettings) getStubSettings()).chatSettings();
   }
 
+  /** Returns the object with the settings used for calls to noBinding. */
+  public UnaryCallSettings<EchoRequest, EchoResponse> noBindingSettings() {
+    return ((EchoStubSettings) getStubSettings()).noBindingSettings();
+  }
+
   public static final EchoSettings create(EchoStubSettings stub) throws IOException {
     return new EchoSettings.Builder(stub.toBuilder()).build();
   }
@@ -281,6 +286,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     /** Returns the builder for the settings used for calls to chat. */
     public StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings() {
       return getStubSettingsBuilder().chatSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to noBinding. */
+    public UnaryCallSettings.Builder<EchoRequest, EchoResponse> noBindingSettings() {
+      return getStubSettingsBuilder().noBindingSettings();
     }
 
     @Override

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
@@ -15,6 +15,7 @@ import com.google.api.gax.rpc.ClientSettings;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
@@ -106,6 +107,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
   /** Returns the object with the settings used for calls to nestedBinding. */
   public UnaryCallSettings<EchoRequest, Object> nestedBindingSettings() {
     return ((EchoStubSettings) getStubSettings()).nestedBindingSettings();
+  }
+
+  /** Returns the object with the settings used for calls to chat. */
+  public StreamingCallSettings<EchoRequest, EchoResponse> chatSettings() {
+    return ((EchoStubSettings) getStubSettings()).chatSettings();
   }
 
   public static final EchoSettings create(EchoStubSettings stub) throws IOException {
@@ -270,6 +276,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     /** Returns the builder for the settings used for calls to nestedBinding. */
     public UnaryCallSettings.Builder<EchoRequest, Object> nestedBindingSettings() {
       return getStubSettingsBuilder().nestedBindingSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to chat. */
+    public StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings() {
+      return getStubSettingsBuilder().chatSettings();
     }
 
     @Override

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -15,6 +15,7 @@ import com.google.api.gax.rpc.ClientSettings;
 import com.google.api.gax.rpc.OperationCallSettings;
 import com.google.api.gax.rpc.PagedCallSettings;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
@@ -106,6 +107,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
   /** Returns the object with the settings used for calls to nestedBinding. */
   public UnaryCallSettings<EchoRequest, Object> nestedBindingSettings() {
     return ((EchoStubSettings) getStubSettings()).nestedBindingSettings();
+  }
+
+  /** Returns the object with the settings used for calls to chat. */
+  public StreamingCallSettings<EchoRequest, EchoResponse> chatSettings() {
+    return ((EchoStubSettings) getStubSettings()).chatSettings();
   }
 
   public static final EchoSettings create(EchoStubSettings stub) throws IOException {
@@ -270,6 +276,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     /** Returns the builder for the settings used for calls to nestedBinding. */
     public UnaryCallSettings.Builder<EchoRequest, Object> nestedBindingSettings() {
       return getStubSettingsBuilder().nestedBindingSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to chat. */
+    public StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings() {
+      return getStubSettingsBuilder().chatSettings();
     }
 
     @Override

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -1,33 +1,63 @@
-package com.google.showcase.grpcrest.v1beta1;
+package com.google.showcase.grpcrest.v1beta1.stub;
 
 import static com.google.showcase.grpcrest.v1beta1.EchoClient.PagedExpandPagedResponse;
 import static com.google.showcase.grpcrest.v1beta1.EchoClient.SimplePagedExpandPagedResponse;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
+import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.grpc.ProtoOperationTransformers;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
+import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ClientContext;
-import com.google.api.gax.rpc.ClientSettings;
 import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
 import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StreamingCallSettings;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.longrunning.Operation;
-import com.google.showcase.grpcrest.v1beta1.stub.EchoStubSettings;
+import com.google.showcase.grpcrest.v1beta1.BlockRequest;
+import com.google.showcase.grpcrest.v1beta1.BlockResponse;
+import com.google.showcase.grpcrest.v1beta1.EchoRequest;
+import com.google.showcase.grpcrest.v1beta1.EchoResponse;
+import com.google.showcase.grpcrest.v1beta1.ExpandRequest;
+import com.google.showcase.grpcrest.v1beta1.Object;
+import com.google.showcase.grpcrest.v1beta1.PagedExpandRequest;
+import com.google.showcase.grpcrest.v1beta1.PagedExpandResponse;
+import com.google.showcase.grpcrest.v1beta1.WaitMetadata;
+import com.google.showcase.grpcrest.v1beta1.WaitRequest;
+import com.google.showcase.grpcrest.v1beta1.WaitResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.threeten.bp.Duration;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
- * Settings class to configure an instance of {@link EchoClient}.
+ * Settings class to configure an instance of {@link EchoStub}.
  *
  * <p>The default instance has everything set to sensible defaults:
  *
@@ -45,7 +75,7 @@ import javax.annotation.Generated;
  * <pre>{@code
  * // This snippet has been automatically generated for illustrative purposes only.
  * // It may require modifications to work in your environment.
- * EchoSettings.Builder echoSettingsBuilder = EchoSettings.newBuilder();
+ * EchoStubSettings.Builder echoSettingsBuilder = EchoStubSettings.newBuilder();
  * echoSettingsBuilder
  *     .echoSettings()
  *     .setRetrySettings(
@@ -55,108 +85,274 @@ import javax.annotation.Generated;
  *             .toBuilder()
  *             .setTotalTimeout(Duration.ofSeconds(30))
  *             .build());
- * EchoSettings echoSettings = echoSettingsBuilder.build();
+ * EchoStubSettings echoSettings = echoSettingsBuilder.build();
  * }</pre>
  */
 @BetaApi
 @Generated("by gapic-generator-java")
-public class EchoSettings extends ClientSettings<EchoSettings> {
+public class EchoStubSettings extends StubSettings<EchoStubSettings> {
+  /** The default scopes of the service. */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
+      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+
+  private final UnaryCallSettings<EchoRequest, EchoResponse> echoSettings;
+  private final ServerStreamingCallSettings<ExpandRequest, EchoResponse> expandSettings;
+  private final PagedCallSettings<PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+      pagedExpandSettings;
+  private final PagedCallSettings<
+          PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+      simplePagedExpandSettings;
+  private final UnaryCallSettings<WaitRequest, Operation> waitSettings;
+  private final OperationCallSettings<WaitRequest, WaitResponse, WaitMetadata>
+      waitOperationSettings;
+  private final UnaryCallSettings<BlockRequest, BlockResponse> blockSettings;
+  private final UnaryCallSettings<EchoRequest, Object> collideNameSettings;
+  private final UnaryCallSettings<EchoRequest, Object> nestedBindingSettings;
+  private final StreamingCallSettings<EchoRequest, EchoResponse> chatSettings;
+  private final UnaryCallSettings<EchoRequest, EchoResponse> noBindingSettings;
+
+  private static final PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>
+      PAGED_EXPAND_PAGE_STR_DESC =
+          new PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public PagedExpandRequest injectToken(PagedExpandRequest payload, String token) {
+              return PagedExpandRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public PagedExpandRequest injectPageSize(PagedExpandRequest payload, int pageSize) {
+              return PagedExpandRequest.newBuilder(payload).setPageSize(pageSize).build();
+            }
+
+            @Override
+            public Integer extractPageSize(PagedExpandRequest payload) {
+              return payload.getPageSize();
+            }
+
+            @Override
+            public String extractNextToken(PagedExpandResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<EchoResponse> extractResources(PagedExpandResponse payload) {
+              return payload.getResponsesList() == null
+                  ? ImmutableList.<EchoResponse>of()
+                  : payload.getResponsesList();
+            }
+          };
+
+  private static final PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>
+      SIMPLE_PAGED_EXPAND_PAGE_STR_DESC =
+          new PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>() {
+            @Override
+            public String emptyToken() {
+              return "";
+            }
+
+            @Override
+            public PagedExpandRequest injectToken(PagedExpandRequest payload, String token) {
+              return PagedExpandRequest.newBuilder(payload).setPageToken(token).build();
+            }
+
+            @Override
+            public PagedExpandRequest injectPageSize(PagedExpandRequest payload, int pageSize) {
+              return PagedExpandRequest.newBuilder(payload).setPageSize(pageSize).build();
+            }
+
+            @Override
+            public Integer extractPageSize(PagedExpandRequest payload) {
+              return payload.getPageSize();
+            }
+
+            @Override
+            public String extractNextToken(PagedExpandResponse payload) {
+              return payload.getNextPageToken();
+            }
+
+            @Override
+            public Iterable<EchoResponse> extractResources(PagedExpandResponse payload) {
+              return payload.getResponsesList() == null
+                  ? ImmutableList.<EchoResponse>of()
+                  : payload.getResponsesList();
+            }
+          };
+
+  private static final PagedListResponseFactory<
+          PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+      PAGED_EXPAND_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+              PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>() {
+            @Override
+            public ApiFuture<PagedExpandPagedResponse> getFuturePagedResponse(
+                UnaryCallable<PagedExpandRequest, PagedExpandResponse> callable,
+                PagedExpandRequest request,
+                ApiCallContext context,
+                ApiFuture<PagedExpandResponse> futureResponse) {
+              PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> pageContext =
+                  PageContext.create(callable, PAGED_EXPAND_PAGE_STR_DESC, request, context);
+              return PagedExpandPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
+
+  private static final PagedListResponseFactory<
+          PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+      SIMPLE_PAGED_EXPAND_PAGE_STR_FACT =
+          new PagedListResponseFactory<
+              PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>() {
+            @Override
+            public ApiFuture<SimplePagedExpandPagedResponse> getFuturePagedResponse(
+                UnaryCallable<PagedExpandRequest, PagedExpandResponse> callable,
+                PagedExpandRequest request,
+                ApiCallContext context,
+                ApiFuture<PagedExpandResponse> futureResponse) {
+              PageContext<PagedExpandRequest, PagedExpandResponse, EchoResponse> pageContext =
+                  PageContext.create(callable, SIMPLE_PAGED_EXPAND_PAGE_STR_DESC, request, context);
+              return SimplePagedExpandPagedResponse.createAsync(pageContext, futureResponse);
+            }
+          };
 
   /** Returns the object with the settings used for calls to echo. */
   public UnaryCallSettings<EchoRequest, EchoResponse> echoSettings() {
-    return ((EchoStubSettings) getStubSettings()).echoSettings();
+    return echoSettings;
   }
 
   /** Returns the object with the settings used for calls to expand. */
   public ServerStreamingCallSettings<ExpandRequest, EchoResponse> expandSettings() {
-    return ((EchoStubSettings) getStubSettings()).expandSettings();
+    return expandSettings;
   }
 
   /** Returns the object with the settings used for calls to pagedExpand. */
   public PagedCallSettings<PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
       pagedExpandSettings() {
-    return ((EchoStubSettings) getStubSettings()).pagedExpandSettings();
+    return pagedExpandSettings;
   }
 
   /** Returns the object with the settings used for calls to simplePagedExpand. */
   public PagedCallSettings<PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
       simplePagedExpandSettings() {
-    return ((EchoStubSettings) getStubSettings()).simplePagedExpandSettings();
+    return simplePagedExpandSettings;
   }
 
   /** Returns the object with the settings used for calls to wait. */
   public UnaryCallSettings<WaitRequest, Operation> waitSettings() {
-    return ((EchoStubSettings) getStubSettings()).waitSettings();
+    return waitSettings;
   }
 
   /** Returns the object with the settings used for calls to wait. */
   public OperationCallSettings<WaitRequest, WaitResponse, WaitMetadata> waitOperationSettings() {
-    return ((EchoStubSettings) getStubSettings()).waitOperationSettings();
+    return waitOperationSettings;
   }
 
   /** Returns the object with the settings used for calls to block. */
   public UnaryCallSettings<BlockRequest, BlockResponse> blockSettings() {
-    return ((EchoStubSettings) getStubSettings()).blockSettings();
+    return blockSettings;
   }
 
   /** Returns the object with the settings used for calls to collideName. */
   public UnaryCallSettings<EchoRequest, Object> collideNameSettings() {
-    return ((EchoStubSettings) getStubSettings()).collideNameSettings();
+    return collideNameSettings;
   }
 
   /** Returns the object with the settings used for calls to nestedBinding. */
   public UnaryCallSettings<EchoRequest, Object> nestedBindingSettings() {
-    return ((EchoStubSettings) getStubSettings()).nestedBindingSettings();
+    return nestedBindingSettings;
   }
 
   /** Returns the object with the settings used for calls to chat. */
   public StreamingCallSettings<EchoRequest, EchoResponse> chatSettings() {
-    return ((EchoStubSettings) getStubSettings()).chatSettings();
+    return chatSettings;
   }
 
-  public static final EchoSettings create(EchoStubSettings stub) throws IOException {
-    return new EchoSettings.Builder(stub.toBuilder()).build();
+  /** Returns the object with the settings used for calls to noBinding. */
+  public UnaryCallSettings<EchoRequest, EchoResponse> noBindingSettings() {
+    return noBindingSettings;
+  }
+
+  public EchoStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(GrpcTransportChannel.getGrpcTransportName())) {
+      return GrpcEchoStub.create(this);
+    }
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
+      return HttpJsonEchoStub.create(this);
+    }
+    throw new UnsupportedOperationException(
+        String.format(
+            "Transport not supported: %s", getTransportChannelProvider().getTransportName()));
   }
 
   /** Returns a builder for the default ExecutorProvider for this service. */
   public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
-    return EchoStubSettings.defaultExecutorProviderBuilder();
+    return InstantiatingExecutorProvider.newBuilder();
   }
 
   /** Returns the default service endpoint. */
   public static String getDefaultEndpoint() {
-    return EchoStubSettings.getDefaultEndpoint();
+    return "localhost:7469";
+  }
+
+  /** Returns the default mTLS service endpoint. */
+  public static String getDefaultMtlsEndpoint() {
+    return "localhost:7469";
   }
 
   /** Returns the default service scopes. */
   public static List<String> getDefaultServiceScopes() {
-    return EchoStubSettings.getDefaultServiceScopes();
+    return DEFAULT_SERVICE_SCOPES;
   }
 
   /** Returns a builder for the default credentials for this service. */
   public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
-    return EchoStubSettings.defaultCredentialsProviderBuilder();
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        .setUseJwtAccessWithScope(true);
   }
 
   /** Returns a builder for the default gRPC ChannelProvider for this service. */
   public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
-    return EchoStubSettings.defaultGrpcTransportProviderBuilder();
+    return InstantiatingGrpcChannelProvider.newBuilder()
+        .setMaxInboundMessageSize(Integer.MAX_VALUE);
   }
 
   /** Returns a builder for the default REST ChannelProvider for this service. */
   @BetaApi
   public static InstantiatingHttpJsonChannelProvider.Builder
       defaultHttpJsonTransportProviderBuilder() {
-    return EchoStubSettings.defaultHttpJsonTransportProviderBuilder();
+    return InstantiatingHttpJsonChannelProvider.newBuilder();
   }
 
   public static TransportChannelProvider defaultTransportChannelProvider() {
-    return EchoStubSettings.defaultTransportChannelProvider();
+    return defaultGrpcTransportProviderBuilder().build();
   }
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultGrpcApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
+        .setTransportToken(
+            GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultHttpJsonApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(EchoStubSettings.class))
+        .setTransportToken(
+            GaxHttpJsonProperties.getHttpJsonTokenName(),
+            GaxHttpJsonProperties.getHttpJsonVersion());
+  }
+
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return EchoStubSettings.defaultApiClientHeaderProviderBuilder();
+    return EchoStubSettings.defaultGrpcApiClientHeaderProviderBuilder();
   }
 
   /** Returns a new gRPC builder for this class. */
@@ -165,7 +361,6 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
   }
 
   /** Returns a new REST builder for this class. */
-  @BetaApi
   public static Builder newHttpJsonBuilder() {
     return Builder.createHttpJsonDefault();
   }
@@ -180,40 +375,216 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     return new Builder(this);
   }
 
-  protected EchoSettings(Builder settingsBuilder) throws IOException {
+  protected EchoStubSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
+
+    echoSettings = settingsBuilder.echoSettings().build();
+    expandSettings = settingsBuilder.expandSettings().build();
+    pagedExpandSettings = settingsBuilder.pagedExpandSettings().build();
+    simplePagedExpandSettings = settingsBuilder.simplePagedExpandSettings().build();
+    waitSettings = settingsBuilder.waitSettings().build();
+    waitOperationSettings = settingsBuilder.waitOperationSettings().build();
+    blockSettings = settingsBuilder.blockSettings().build();
+    collideNameSettings = settingsBuilder.collideNameSettings().build();
+    nestedBindingSettings = settingsBuilder.nestedBindingSettings().build();
+    chatSettings = settingsBuilder.chatSettings().build();
+    noBindingSettings = settingsBuilder.noBindingSettings().build();
   }
 
-  /** Builder for EchoSettings. */
-  public static class Builder extends ClientSettings.Builder<EchoSettings, Builder> {
+  /** Builder for EchoStubSettings. */
+  public static class Builder extends StubSettings.Builder<EchoStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+    private final UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoSettings;
+    private final ServerStreamingCallSettings.Builder<ExpandRequest, EchoResponse> expandSettings;
+    private final PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
+        pagedExpandSettings;
+    private final PagedCallSettings.Builder<
+            PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
+        simplePagedExpandSettings;
+    private final UnaryCallSettings.Builder<WaitRequest, Operation> waitSettings;
+    private final OperationCallSettings.Builder<WaitRequest, WaitResponse, WaitMetadata>
+        waitOperationSettings;
+    private final UnaryCallSettings.Builder<BlockRequest, BlockResponse> blockSettings;
+    private final UnaryCallSettings.Builder<EchoRequest, Object> collideNameSettings;
+    private final UnaryCallSettings.Builder<EchoRequest, Object> nestedBindingSettings;
+    private final StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings;
+    private final UnaryCallSettings.Builder<EchoRequest, EchoResponse> noBindingSettings;
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
+        RETRYABLE_CODE_DEFINITIONS;
 
-    protected Builder() throws IOException {
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions =
+          ImmutableMap.builder();
+      definitions.put("no_retry_codes", ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder().setRpcTimeoutMultiplier(1.0).build();
+      definitions.put("no_retry_params", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
       this(((ClientContext) null));
     }
 
     protected Builder(ClientContext clientContext) {
-      super(EchoStubSettings.newBuilder(clientContext));
+      super(clientContext);
+
+      echoSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      expandSettings = ServerStreamingCallSettings.newBuilder();
+      pagedExpandSettings = PagedCallSettings.newBuilder(PAGED_EXPAND_PAGE_STR_FACT);
+      simplePagedExpandSettings = PagedCallSettings.newBuilder(SIMPLE_PAGED_EXPAND_PAGE_STR_FACT);
+      waitSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      waitOperationSettings = OperationCallSettings.newBuilder();
+      blockSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      collideNameSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      nestedBindingSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      chatSettings = StreamingCallSettings.newBuilder();
+      noBindingSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              echoSettings,
+              pagedExpandSettings,
+              simplePagedExpandSettings,
+              waitSettings,
+              blockSettings,
+              collideNameSettings,
+              nestedBindingSettings,
+              noBindingSettings);
+      initDefaults(this);
     }
 
-    protected Builder(EchoSettings settings) {
-      super(settings.getStubSettings().toBuilder());
-    }
+    protected Builder(EchoStubSettings settings) {
+      super(settings);
 
-    protected Builder(EchoStubSettings.Builder stubSettings) {
-      super(stubSettings);
+      echoSettings = settings.echoSettings.toBuilder();
+      expandSettings = settings.expandSettings.toBuilder();
+      pagedExpandSettings = settings.pagedExpandSettings.toBuilder();
+      simplePagedExpandSettings = settings.simplePagedExpandSettings.toBuilder();
+      waitSettings = settings.waitSettings.toBuilder();
+      waitOperationSettings = settings.waitOperationSettings.toBuilder();
+      blockSettings = settings.blockSettings.toBuilder();
+      collideNameSettings = settings.collideNameSettings.toBuilder();
+      nestedBindingSettings = settings.nestedBindingSettings.toBuilder();
+      chatSettings = settings.chatSettings.toBuilder();
+      noBindingSettings = settings.noBindingSettings.toBuilder();
+
+      unaryMethodSettingsBuilders =
+          ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+              echoSettings,
+              pagedExpandSettings,
+              simplePagedExpandSettings,
+              waitSettings,
+              blockSettings,
+              collideNameSettings,
+              nestedBindingSettings,
+              noBindingSettings);
     }
 
     private static Builder createDefault() {
-      return new Builder(EchoStubSettings.newBuilder());
+      Builder builder = new Builder(((ClientContext) null));
+
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setEndpoint(getDefaultEndpoint());
+      builder.setMtlsEndpoint(getDefaultMtlsEndpoint());
+      builder.setSwitchToMtlsEndpointAllowed(true);
+
+      return initDefaults(builder);
     }
 
-    @BetaApi
     private static Builder createHttpJsonDefault() {
-      return new Builder(EchoStubSettings.newHttpJsonBuilder());
+      Builder builder = new Builder(((ClientContext) null));
+
+      builder.setTransportChannelProvider(defaultHttpJsonTransportProviderBuilder().build());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultHttpJsonApiClientHeaderProviderBuilder().build());
+      builder.setEndpoint(getDefaultEndpoint());
+      builder.setMtlsEndpoint(getDefaultMtlsEndpoint());
+      builder.setSwitchToMtlsEndpointAllowed(true);
+
+      return initDefaults(builder);
     }
 
-    public EchoStubSettings.Builder getStubSettingsBuilder() {
-      return ((EchoStubSettings.Builder) getStubSettings());
+    private static Builder initDefaults(Builder builder) {
+      builder
+          .echoSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .expandSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .pagedExpandSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .simplePagedExpandSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .waitSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .blockSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .collideNameSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .nestedBindingSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .noBindingSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .waitOperationSettings()
+          .setInitialCallSettings(
+              UnaryCallSettings.<WaitRequest, OperationSnapshot>newUnaryCallSettingsBuilder()
+                  .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+                  .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"))
+                  .build())
+          .setResponseTransformer(
+              ProtoOperationTransformers.ResponseTransformer.create(WaitResponse.class))
+          .setMetadataTransformer(
+              ProtoOperationTransformers.MetadataTransformer.create(WaitMetadata.class))
+          .setPollingAlgorithm(
+              OperationTimedPollAlgorithm.create(
+                  RetrySettings.newBuilder()
+                      .setInitialRetryDelay(Duration.ofMillis(5000L))
+                      .setRetryDelayMultiplier(1.5)
+                      .setMaxRetryDelay(Duration.ofMillis(45000L))
+                      .setInitialRpcTimeout(Duration.ZERO)
+                      .setRpcTimeoutMultiplier(1.0)
+                      .setMaxRpcTimeout(Duration.ZERO)
+                      .setTotalTimeout(Duration.ofMillis(300000L))
+                      .build()));
+
+      return builder;
     }
 
     /**
@@ -223,69 +594,79 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
      */
     public Builder applyToAllUnaryMethods(
         ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) {
-      super.applyToAllUnaryMethods(
-          getStubSettingsBuilder().unaryMethodSettingsBuilders(), settingsUpdater);
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
       return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
     }
 
     /** Returns the builder for the settings used for calls to echo. */
     public UnaryCallSettings.Builder<EchoRequest, EchoResponse> echoSettings() {
-      return getStubSettingsBuilder().echoSettings();
+      return echoSettings;
     }
 
     /** Returns the builder for the settings used for calls to expand. */
     public ServerStreamingCallSettings.Builder<ExpandRequest, EchoResponse> expandSettings() {
-      return getStubSettingsBuilder().expandSettings();
+      return expandSettings;
     }
 
     /** Returns the builder for the settings used for calls to pagedExpand. */
     public PagedCallSettings.Builder<
             PagedExpandRequest, PagedExpandResponse, PagedExpandPagedResponse>
         pagedExpandSettings() {
-      return getStubSettingsBuilder().pagedExpandSettings();
+      return pagedExpandSettings;
     }
 
     /** Returns the builder for the settings used for calls to simplePagedExpand. */
     public PagedCallSettings.Builder<
             PagedExpandRequest, PagedExpandResponse, SimplePagedExpandPagedResponse>
         simplePagedExpandSettings() {
-      return getStubSettingsBuilder().simplePagedExpandSettings();
+      return simplePagedExpandSettings;
     }
 
     /** Returns the builder for the settings used for calls to wait. */
     public UnaryCallSettings.Builder<WaitRequest, Operation> waitSettings() {
-      return getStubSettingsBuilder().waitSettings();
+      return waitSettings;
     }
 
     /** Returns the builder for the settings used for calls to wait. */
+    @BetaApi(
+        "The surface for use by generated code is not stable yet and may change in the future.")
     public OperationCallSettings.Builder<WaitRequest, WaitResponse, WaitMetadata>
         waitOperationSettings() {
-      return getStubSettingsBuilder().waitOperationSettings();
+      return waitOperationSettings;
     }
 
     /** Returns the builder for the settings used for calls to block. */
     public UnaryCallSettings.Builder<BlockRequest, BlockResponse> blockSettings() {
-      return getStubSettingsBuilder().blockSettings();
+      return blockSettings;
     }
 
     /** Returns the builder for the settings used for calls to collideName. */
     public UnaryCallSettings.Builder<EchoRequest, Object> collideNameSettings() {
-      return getStubSettingsBuilder().collideNameSettings();
+      return collideNameSettings;
     }
 
     /** Returns the builder for the settings used for calls to nestedBinding. */
     public UnaryCallSettings.Builder<EchoRequest, Object> nestedBindingSettings() {
-      return getStubSettingsBuilder().nestedBindingSettings();
+      return nestedBindingSettings;
     }
 
     /** Returns the builder for the settings used for calls to chat. */
     public StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings() {
-      return getStubSettingsBuilder().chatSettings();
+      return chatSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to noBinding. */
+    public UnaryCallSettings.Builder<EchoRequest, EchoResponse> noBindingSettings() {
+      return noBindingSettings;
     }
 
     @Override
-    public EchoSettings build() throws IOException {
-      return new EchoSettings(this);
+    public EchoStubSettings build() throws IOException {
+      return new EchoStubSettings(this);
     }
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
@@ -119,6 +119,14 @@ public class GrpcEchoStub extends EchoStub {
           .setResponseMarshaller(ProtoUtils.marshaller(EchoResponse.getDefaultInstance()))
           .build();
 
+  private static final MethodDescriptor<EchoRequest, EchoResponse> noBindingMethodDescriptor =
+      MethodDescriptor.<EchoRequest, EchoResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/NoBinding")
+          .setRequestMarshaller(ProtoUtils.marshaller(EchoRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(EchoResponse.getDefaultInstance()))
+          .build();
+
   private final UnaryCallable<EchoRequest, EchoResponse> echoCallable;
   private final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable;
   private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable;
@@ -133,6 +141,7 @@ public class GrpcEchoStub extends EchoStub {
   private final UnaryCallable<EchoRequest, Object> collideNameCallable;
   private final UnaryCallable<EchoRequest, Object> nestedBindingCallable;
   private final BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable;
+  private final UnaryCallable<EchoRequest, EchoResponse> noBindingCallable;
 
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
@@ -214,6 +223,10 @@ public class GrpcEchoStub extends EchoStub {
         GrpcCallSettings.<EchoRequest, EchoResponse>newBuilder()
             .setMethodDescriptor(chatMethodDescriptor)
             .build();
+    GrpcCallSettings<EchoRequest, EchoResponse> noBindingTransportSettings =
+        GrpcCallSettings.<EchoRequest, EchoResponse>newBuilder()
+            .setMethodDescriptor(noBindingMethodDescriptor)
+            .build();
 
     this.echoCallable =
         callableFactory.createUnaryCallable(
@@ -255,6 +268,9 @@ public class GrpcEchoStub extends EchoStub {
     this.chatCallable =
         callableFactory.createBidiStreamingCallable(
             chatTransportSettings, settings.chatSettings(), clientContext);
+    this.noBindingCallable =
+        callableFactory.createUnaryCallable(
+            noBindingTransportSettings, settings.noBindingSettings(), clientContext);
 
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -323,6 +339,11 @@ public class GrpcEchoStub extends EchoStub {
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     return chatCallable;
+  }
+
+  @Override
+  public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
+    return noBindingCallable;
   }
 
   @Override

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
@@ -8,6 +8,7 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.grpc.GrpcCallSettings;
 import com.google.api.gax.grpc.GrpcStubCallableFactory;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.ServerStreamingCallable;
@@ -110,6 +111,14 @@ public class GrpcEchoStub extends EchoStub {
           .setResponseMarshaller(ProtoUtils.marshaller(Object.getDefaultInstance()))
           .build();
 
+  private static final MethodDescriptor<EchoRequest, EchoResponse> chatMethodDescriptor =
+      MethodDescriptor.<EchoRequest, EchoResponse>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/Chat")
+          .setRequestMarshaller(ProtoUtils.marshaller(EchoRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(EchoResponse.getDefaultInstance()))
+          .build();
+
   private final UnaryCallable<EchoRequest, EchoResponse> echoCallable;
   private final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable;
   private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable;
@@ -123,6 +132,7 @@ public class GrpcEchoStub extends EchoStub {
   private final UnaryCallable<BlockRequest, BlockResponse> blockCallable;
   private final UnaryCallable<EchoRequest, Object> collideNameCallable;
   private final UnaryCallable<EchoRequest, Object> nestedBindingCallable;
+  private final BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable;
 
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
@@ -200,6 +210,10 @@ public class GrpcEchoStub extends EchoStub {
                   return params.build();
                 })
             .build();
+    GrpcCallSettings<EchoRequest, EchoResponse> chatTransportSettings =
+        GrpcCallSettings.<EchoRequest, EchoResponse>newBuilder()
+            .setMethodDescriptor(chatMethodDescriptor)
+            .build();
 
     this.echoCallable =
         callableFactory.createUnaryCallable(
@@ -238,6 +252,9 @@ public class GrpcEchoStub extends EchoStub {
     this.nestedBindingCallable =
         callableFactory.createUnaryCallable(
             nestedBindingTransportSettings, settings.nestedBindingSettings(), clientContext);
+    this.chatCallable =
+        callableFactory.createBidiStreamingCallable(
+            chatTransportSettings, settings.chatSettings(), clientContext);
 
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -301,6 +318,11 @@ public class GrpcEchoStub extends EchoStub {
   @Override
   public UnaryCallable<EchoRequest, Object> nestedBindingCallable() {
     return nestedBindingCallable;
+  }
+
+  @Override
+  public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
+    return chatCallable;
   }
 
   @Override

--- a/src/test/java/com/google/api/generator/gapic/model/ResourceNameTest.java
+++ b/src/test/java/com/google/api/generator/gapic/model/ResourceNameTest.java
@@ -1,0 +1,74 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.model;
+
+import com.google.api.generator.gapic.model.HttpBindings.HttpVerb;
+import com.google.common.truth.Truth;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ResourceNameTest {
+  private final ResourceName resName =
+      ResourceName.builder()
+          .setVariableName("topic")
+          .setPakkage("com.google.pubsub.v1")
+          .setResourceTypeString("pubsub.googleapis.com/Topic")
+          .setPatterns(Arrays.asList("_deleted-topic_", "projects/{project}/topics/{topic}"))
+          .setParentMessageName("com.google.pubsub.v1.Topic")
+          .build();
+
+  @Test
+  public void getMatchingPattern() {
+    HttpBindings bindings =
+        HttpBindings.builder()
+            .setHttpVerb(HttpVerb.PUT)
+            .setPattern("/v1/{name=projects/*/topics/*}")
+            .setAdditionalPatterns(Collections.emptyList())
+            .setIsAsteriskBody(true)
+            .build();
+
+    String matchingPattern = resName.getMatchingPattern(bindings);
+    Truth.assertThat(matchingPattern).isEqualTo("projects/{project}/topics/{topic}");
+  }
+
+  @Test
+  public void getMatchingPatternFromAdditionalPattern() {
+    HttpBindings bindings =
+        HttpBindings.builder()
+            .setHttpVerb(HttpVerb.PUT)
+            .setPattern("/v1/{name=projects/*/subscriptions/*}")
+            .setAdditionalPatterns(Collections.singletonList("/v1/{name=projects/*/topics/*}"))
+            .setIsAsteriskBody(true)
+            .build();
+
+    String matchingPattern = resName.getMatchingPattern(bindings);
+    Truth.assertThat(matchingPattern).isEqualTo("projects/{project}/topics/{topic}");
+  }
+
+  @Test
+  public void getMatchingPatternNoMatch() {
+    HttpBindings bindings =
+        HttpBindings.builder()
+            .setHttpVerb(HttpVerb.PUT)
+            .setPattern("/v1/{name=projects/*/subscriptions/*}")
+            .setAdditionalPatterns(Collections.singletonList("/v1/{name=projects/*/stuff/*}"))
+            .setIsAsteriskBody(true)
+            .build();
+
+    String matchingPattern = resName.getMatchingPattern(bindings);
+    Truth.assertThat(matchingPattern).isNull();
+  }
+}

--- a/src/test/proto/echo_grpcrest.proto
+++ b/src/test/proto/echo_grpcrest.proto
@@ -135,6 +135,8 @@ service Echo {
       }
     };
   }
+
+  rpc Chat(stream EchoRequest) returns (stream EchoResponse);
 }
 
 // Generator should not fail when encounter a service without methods

--- a/src/test/proto/echo_grpcrest.proto
+++ b/src/test/proto/echo_grpcrest.proto
@@ -136,7 +136,14 @@ service Echo {
     };
   }
 
-  rpc Chat(stream EchoRequest) returns (stream EchoResponse);
+  rpc Chat(stream EchoRequest) returns (stream EchoResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/chat:chat"
+      body: "error"
+    };
+  }
+
+  rpc NoBinding(EchoRequest) returns (EchoResponse);
 }
 
 // Generator should not fail when encounter a service without methods

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/batchgetassetshistory/AsyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/batchgetassetshistory/AsyncBatchGetAssetsHistory.java
@@ -22,7 +22,6 @@ import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest;
 import com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse;
 import com.google.cloud.asset.v1.ContentType;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.TimeWindow;
 import java.util.ArrayList;
 
@@ -38,7 +37,7 @@ public class AsyncBatchGetAssetsHistory {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       BatchGetAssetsHistoryRequest request =
           BatchGetAssetsHistoryRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
               .addAllAssetNames(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))
               .setReadTimeWindow(TimeWindow.newBuilder().build())

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/batchgetassetshistory/SyncBatchGetAssetsHistory.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/batchgetassetshistory/SyncBatchGetAssetsHistory.java
@@ -21,7 +21,6 @@ import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest;
 import com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse;
 import com.google.cloud.asset.v1.ContentType;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.TimeWindow;
 import java.util.ArrayList;
 
@@ -37,7 +36,7 @@ public class SyncBatchGetAssetsHistory {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       BatchGetAssetsHistoryRequest request =
           BatchGetAssetsHistoryRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
               .addAllAssetNames(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))
               .setReadTimeWindow(TimeWindow.newBuilder().build())

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/exportassets/AsyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/exportassets/AsyncExportAssets.java
@@ -21,7 +21,6 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.asset.v1.ExportAssetsRequest;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.OutputConfig;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Timestamp;
@@ -39,7 +38,7 @@ public class AsyncExportAssets {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       ExportAssetsRequest request =
           ExportAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ExportAssetsRequest-846449128".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/exportassets/AsyncExportAssetsLRO.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/exportassets/AsyncExportAssetsLRO.java
@@ -22,7 +22,6 @@ import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.asset.v1.ExportAssetsRequest;
 import com.google.cloud.asset.v1.ExportAssetsResponse;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.OutputConfig;
 import com.google.protobuf.Timestamp;
 import java.util.ArrayList;
@@ -39,7 +38,7 @@ public class AsyncExportAssetsLRO {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       ExportAssetsRequest request =
           ExportAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ExportAssetsRequest-846449128".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/exportassets/SyncExportAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/exportassets/SyncExportAssets.java
@@ -21,7 +21,6 @@ import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.asset.v1.ExportAssetsRequest;
 import com.google.cloud.asset.v1.ExportAssetsResponse;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.OutputConfig;
 import com.google.protobuf.Timestamp;
 import java.util.ArrayList;
@@ -38,7 +37,7 @@ public class SyncExportAssets {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       ExportAssetsRequest request =
           ExportAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ExportAssetsRequest-846449128".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/AsyncListAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/AsyncListAssets.java
@@ -21,7 +21,6 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.asset.v1.Asset;
 import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.ListAssetsRequest;
 import com.google.protobuf.Timestamp;
 import java.util.ArrayList;
@@ -38,7 +37,7 @@ public class AsyncListAssets {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       ListAssetsRequest request =
           ListAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ListAssetsRequest-221586066".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/AsyncListAssetsPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/AsyncListAssetsPaged.java
@@ -20,7 +20,6 @@ package com.google.cloud.asset.v1.samples;
 import com.google.cloud.asset.v1.Asset;
 import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.ListAssetsRequest;
 import com.google.cloud.asset.v1.ListAssetsResponse;
 import com.google.common.base.Strings;
@@ -39,7 +38,7 @@ public class AsyncListAssetsPaged {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       ListAssetsRequest request =
           ListAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ListAssetsRequest-221586066".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/SyncListAssets.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/SyncListAssets.java
@@ -20,7 +20,6 @@ package com.google.cloud.asset.v1.samples;
 import com.google.cloud.asset.v1.Asset;
 import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
-import com.google.cloud.asset.v1.FeedName;
 import com.google.cloud.asset.v1.ListAssetsRequest;
 import com.google.protobuf.Timestamp;
 import java.util.ArrayList;
@@ -37,7 +36,7 @@ public class SyncListAssets {
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
       ListAssetsRequest request =
           ListAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ListAssetsRequest-221586066".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/SyncListAssetsResourcename.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/SyncListAssetsResourcename.java
@@ -38,13 +38,18 @@ public class SyncListAssetsResourcename {
             @Override
             public Map<String, String> getFieldValuesMap() {
               Map<String, String> fieldValuesMap = new HashMap<>();
-              fieldValuesMap.put("parent", "parent-995424086");
+              fieldValuesMap.put("parent", "parent-4715/parent-4715");
               return fieldValuesMap;
             }
 
             @Override
             public String getFieldValue(String fieldName) {
               return getFieldValuesMap().get(fieldName);
+            }
+
+            @Override
+            public String toString() {
+              return "parent-4715/parent-4715";
             }
           };
       for (Asset element : assetServiceClient.listAssets(parent).iterateAll()) {

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/SyncListAssetsResourcename.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/SyncListAssetsResourcename.java
@@ -20,7 +20,8 @@ package com.google.cloud.asset.v1.samples;
 import com.google.api.resourcenames.ResourceName;
 import com.google.cloud.asset.v1.Asset;
 import com.google.cloud.asset.v1.AssetServiceClient;
-import com.google.cloud.asset.v1.FeedName;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SyncListAssetsResourcename {
 
@@ -32,7 +33,20 @@ public class SyncListAssetsResourcename {
     // This snippet has been automatically generated for illustrative purposes only.
     // It may require modifications to work in your environment.
     try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
-      ResourceName parent = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
+      ResourceName parent =
+          new ResourceName() {
+            @Override
+            public Map<String, String> getFieldValuesMap() {
+              Map<String, String> fieldValuesMap = new HashMap<>();
+              fieldValuesMap.put("parent", "parent-995424086");
+              return fieldValuesMap;
+            }
+
+            @Override
+            public String getFieldValue(String fieldName) {
+              return getFieldValuesMap().get(fieldName);
+            }
+          };
       for (Asset element : assetServiceClient.listAssets(parent).iterateAll()) {
         // doThingsWith(element);
       }

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -51,7 +51,7 @@ import javax.annotation.Generated;
  * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
  *   BatchGetAssetsHistoryRequest request =
  *       BatchGetAssetsHistoryRequest.newBuilder()
- *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+ *           .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
  *           .addAllAssetNames(new ArrayList<String>())
  *           .setContentType(ContentType.forNumber(0))
  *           .setReadTimeWindow(TimeWindow.newBuilder().build())
@@ -190,7 +190,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   ExportAssetsRequest request =
    *       ExportAssetsRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("ExportAssetsRequest-846449128".toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
@@ -228,7 +228,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   ExportAssetsRequest request =
    *       ExportAssetsRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("ExportAssetsRequest-846449128".toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
@@ -266,7 +266,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   ExportAssetsRequest request =
    *       ExportAssetsRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("ExportAssetsRequest-846449128".toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
@@ -293,7 +293,20 @@ public class AssetServiceClient implements BackgroundResource {
    * // This snippet has been automatically generated for illustrative purposes only.
    * // It may require modifications to work in your environment.
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
-   *   ResourceName parent = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
+   *   ResourceName parent =
+   *       new ResourceName() {
+   *         {@literal @}Override
+   *         public Map<String, String> getFieldValuesMap() {
+   *           Map<String, String> fieldValuesMap = new HashMap<>();
+   *           fieldValuesMap.put("parent", "parent-995424086");
+   *           return fieldValuesMap;
+   *         }
+   *
+   *         {@literal @}Override
+   *         public String getFieldValue(String fieldName) {
+   *           return getFieldValuesMap().get(fieldName);
+   *         }
+   *       };
    *   for (Asset element : assetServiceClient.listAssets(parent).iterateAll()) {
    *     // doThingsWith(element);
    *   }
@@ -352,7 +365,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   ListAssetsRequest request =
    *       ListAssetsRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("ListAssetsRequest-221586066".toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
@@ -385,7 +398,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   ListAssetsRequest request =
    *       ListAssetsRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("ListAssetsRequest-221586066".toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
@@ -417,7 +430,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   ListAssetsRequest request =
    *       ListAssetsRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("ListAssetsRequest-221586066".toString())
    *           .setReadTime(Timestamp.newBuilder().build())
    *           .addAllAssetTypes(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
@@ -460,7 +473,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   BatchGetAssetsHistoryRequest request =
    *       BatchGetAssetsHistoryRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
    *           .addAllAssetNames(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
    *           .setReadTimeWindow(TimeWindow.newBuilder().build())
@@ -494,7 +507,7 @@ public class AssetServiceClient implements BackgroundResource {
    * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
    *   BatchGetAssetsHistoryRequest request =
    *       BatchGetAssetsHistoryRequest.newBuilder()
-   *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+   *           .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
    *           .addAllAssetNames(new ArrayList<String>())
    *           .setContentType(ContentType.forNumber(0))
    *           .setReadTimeWindow(TimeWindow.newBuilder().build())

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -298,13 +298,18 @@ public class AssetServiceClient implements BackgroundResource {
    *         {@literal @}Override
    *         public Map<String, String> getFieldValuesMap() {
    *           Map<String, String> fieldValuesMap = new HashMap<>();
-   *           fieldValuesMap.put("parent", "parent-995424086");
+   *           fieldValuesMap.put("parent", "parent-4715/parent-4715");
    *           return fieldValuesMap;
    *         }
    *
    *         {@literal @}Override
    *         public String getFieldValue(String fieldName) {
    *           return getFieldValuesMap().get(fieldName);
+   *         }
+   *
+   *         {@literal @}Override
+   *         public String toString() {
+   *           return "parent-4715/parent-4715";
    *         }
    *       };
    *   for (Asset element : assetServiceClient.listAssets(parent).iterateAll()) {

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
@@ -177,13 +177,18 @@ public class AssetServiceClientTest {
           @Override
           public Map<String, String> getFieldValuesMap() {
             Map<String, String> fieldValuesMap = new HashMap<>();
-            fieldValuesMap.put("parent", "parent-995424086");
+            fieldValuesMap.put("parent", "parent-4715/parent-4715");
             return fieldValuesMap;
           }
 
           @Override
           public String getFieldValue(String fieldName) {
             return getFieldValuesMap().get(fieldName);
+          }
+
+          @Override
+          public String toString() {
+            return "parent-4715/parent-4715";
           }
         };
 
@@ -216,13 +221,18 @@ public class AssetServiceClientTest {
             @Override
             public Map<String, String> getFieldValuesMap() {
               Map<String, String> fieldValuesMap = new HashMap<>();
-              fieldValuesMap.put("parent", "parent-995424086");
+              fieldValuesMap.put("parent", "parent-4715/parent-4715");
               return fieldValuesMap;
             }
 
             @Override
             public String getFieldValue(String fieldName) {
               return getFieldValuesMap().get(fieldName);
+            }
+
+            @Override
+            public String toString() {
+              return "parent-4715/parent-4715";
             }
           };
       client.listAssets(parent);

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClientTest.java
@@ -41,7 +41,9 @@ import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Generated;
@@ -108,7 +110,7 @@ public class AssetServiceClientTest {
 
     ExportAssetsRequest request =
         ExportAssetsRequest.newBuilder()
-            .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+            .setParent("ExportAssetsRequest-846449128".toString())
             .setReadTime(Timestamp.newBuilder().build())
             .addAllAssetTypes(new ArrayList<String>())
             .setContentType(ContentType.forNumber(0))
@@ -144,7 +146,7 @@ public class AssetServiceClientTest {
     try {
       ExportAssetsRequest request =
           ExportAssetsRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("ExportAssetsRequest-846449128".toString())
               .setReadTime(Timestamp.newBuilder().build())
               .addAllAssetTypes(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))
@@ -170,7 +172,20 @@ public class AssetServiceClientTest {
             .build();
     mockAssetService.addResponse(expectedResponse);
 
-    ResourceName parent = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
+    ResourceName parent =
+        new ResourceName() {
+          @Override
+          public Map<String, String> getFieldValuesMap() {
+            Map<String, String> fieldValuesMap = new HashMap<>();
+            fieldValuesMap.put("parent", "parent-995424086");
+            return fieldValuesMap;
+          }
+
+          @Override
+          public String getFieldValue(String fieldName) {
+            return getFieldValuesMap().get(fieldName);
+          }
+        };
 
     ListAssetsPagedResponse pagedListResponse = client.listAssets(parent);
 
@@ -196,7 +211,20 @@ public class AssetServiceClientTest {
     mockAssetService.addException(exception);
 
     try {
-      ResourceName parent = FeedName.ofProjectFeedName("[PROJECT]", "[FEED]");
+      ResourceName parent =
+          new ResourceName() {
+            @Override
+            public Map<String, String> getFieldValuesMap() {
+              Map<String, String> fieldValuesMap = new HashMap<>();
+              fieldValuesMap.put("parent", "parent-995424086");
+              return fieldValuesMap;
+            }
+
+            @Override
+            public String getFieldValue(String fieldName) {
+              return getFieldValuesMap().get(fieldName);
+            }
+          };
       client.listAssets(parent);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
@@ -258,7 +286,7 @@ public class AssetServiceClientTest {
 
     BatchGetAssetsHistoryRequest request =
         BatchGetAssetsHistoryRequest.newBuilder()
-            .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+            .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
             .addAllAssetNames(new ArrayList<String>())
             .setContentType(ContentType.forNumber(0))
             .setReadTimeWindow(TimeWindow.newBuilder().build())
@@ -293,7 +321,7 @@ public class AssetServiceClientTest {
     try {
       BatchGetAssetsHistoryRequest request =
           BatchGetAssetsHistoryRequest.newBuilder()
-              .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+              .setParent("BatchGetAssetsHistoryRequest1575208378".toString())
               .addAllAssetNames(new ArrayList<String>())
               .setContentType(ContentType.forNumber(0))
               .setReadTimeWindow(TimeWindow.newBuilder().build())

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/package-info.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/package-info.java
@@ -29,7 +29,7 @@
  * try (AssetServiceClient assetServiceClient = AssetServiceClient.create()) {
  *   BatchGetAssetsHistoryRequest request =
  *       BatchGetAssetsHistoryRequest.newBuilder()
- *           .setParent(FeedName.ofProjectFeedName("[PROJECT]", "[FEED]").toString())
+ *           .setParent(BillingAccountName.of("[BILLING_ACCOUNT]").toString())
  *           .addAllAssetNames(new ArrayList<String>())
  *           .setContentType(ContentType.forNumber(0))
  *           .setReadTimeWindow(TimeWindow.newBuilder().build())

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/AsyncTestIamPermissions.java
@@ -18,8 +18,8 @@ package com.google.cloud.kms.v1.samples;
 
 // [START kms_v1_generated_keymanagementserviceclient_testiampermissions_async]
 import com.google.api.core.ApiFuture;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
-import com.google.cloud.kms.v1.KeyRingName;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import java.util.ArrayList;
@@ -37,7 +37,9 @@ public class AsyncTestIamPermissions {
         KeyManagementServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+              .setResource(
+                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+                      .toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/AsyncTestIamPermissions.java
@@ -18,8 +18,8 @@ package com.google.cloud.kms.v1.samples;
 
 // [START kms_v1_generated_keymanagementserviceclient_testiampermissions_async]
 import com.google.api.core.ApiFuture;
-import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.kms.v1.KeyRingName;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import java.util.ArrayList;
@@ -37,9 +37,7 @@ public class AsyncTestIamPermissions {
         KeyManagementServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(
-                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
-                      .toString())
+              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/SyncTestIamPermissions.java
@@ -17,8 +17,8 @@
 package com.google.cloud.kms.v1.samples;
 
 // [START kms_v1_generated_keymanagementserviceclient_testiampermissions_sync]
-import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.kms.v1.KeyRingName;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import java.util.ArrayList;
@@ -36,9 +36,7 @@ public class SyncTestIamPermissions {
         KeyManagementServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(
-                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
-                      .toString())
+              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = keyManagementServiceClient.testIamPermissions(request);

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/testiampermissions/SyncTestIamPermissions.java
@@ -17,8 +17,8 @@
 package com.google.cloud.kms.v1.samples;
 
 // [START kms_v1_generated_keymanagementserviceclient_testiampermissions_sync]
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
-import com.google.cloud.kms.v1.KeyRingName;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import java.util.ArrayList;
@@ -36,7 +36,9 @@ public class SyncTestIamPermissions {
         KeyManagementServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+              .setResource(
+                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+                      .toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = keyManagementServiceClient.testIamPermissions(request);

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -3553,7 +3553,9 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *     KeyManagementServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+   *           .setResource(
+   *               CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+   *                   .toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = keyManagementServiceClient.testIamPermissions(request);
@@ -3581,7 +3583,9 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *     KeyManagementServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+   *           .setResource(
+   *               CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+   *                   .toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -3553,9 +3553,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *     KeyManagementServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(
-   *               CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
-   *                   .toString())
+   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = keyManagementServiceClient.testIamPermissions(request);
@@ -3583,9 +3581,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *     KeyManagementServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(
-   *               CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
-   *                   .toString())
+   *           .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
@@ -2371,9 +2371,7 @@ public class KeyManagementServiceClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(
-                CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
-                    .toString())
+            .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -2400,9 +2398,7 @@ public class KeyManagementServiceClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(
-                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
-                      .toString())
+              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClientTest.java
@@ -2371,7 +2371,9 @@ public class KeyManagementServiceClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+            .setResource(
+                CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+                    .toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -2398,7 +2400,9 @@ public class KeyManagementServiceClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(KeyRingName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]").toString())
+              .setResource(
+                  CryptoKeyName.of("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
+                      .toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/AsyncGetIamPolicy.java
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class AsyncGetIamPolicy {
 
@@ -36,7 +36,7 @@ public class AsyncGetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       ApiFuture<Policy> future = schemaServiceClient.getIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/AsyncGetIamPolicy.java
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class AsyncGetIamPolicy {
 
@@ -36,7 +36,7 @@ public class AsyncGetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       ApiFuture<Policy> future = schemaServiceClient.getIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/SyncGetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class SyncGetIamPolicy {
 
@@ -35,7 +35,7 @@ public class SyncGetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       Policy response = schemaServiceClient.getIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/getiampolicy/SyncGetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class SyncGetIamPolicy {
 
@@ -35,7 +35,7 @@ public class SyncGetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       Policy response = schemaServiceClient.getIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/AsyncSetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class AsyncSetIamPolicy {
 
@@ -35,7 +35,7 @@ public class AsyncSetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       ApiFuture<Policy> future = schemaServiceClient.setIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/AsyncSetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class AsyncSetIamPolicy {
 
@@ -35,7 +35,7 @@ public class AsyncSetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       ApiFuture<Policy> future = schemaServiceClient.setIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/SyncSetIamPolicy.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class SyncSetIamPolicy {
 
@@ -34,7 +34,7 @@ public class SyncSetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       Policy response = schemaServiceClient.setIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/setiampolicy/SyncSetIamPolicy.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class SyncSetIamPolicy {
 
@@ -34,7 +34,7 @@ public class SyncSetIamPolicy {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       Policy response = schemaServiceClient.setIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/AsyncTestIamPermissions.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.SnapshotName;
 import java.util.ArrayList;
 
 public class AsyncTestIamPermissions {
@@ -36,7 +36,7 @@ public class AsyncTestIamPermissions {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/AsyncTestIamPermissions.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.SubscriptionName;
 import java.util.ArrayList;
 
 public class AsyncTestIamPermissions {
@@ -36,7 +36,7 @@ public class AsyncTestIamPermissions {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/SyncTestIamPermissions.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.SubscriptionName;
 import java.util.ArrayList;
 
 public class SyncTestIamPermissions {
@@ -35,7 +35,7 @@ public class SyncTestIamPermissions {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = schemaServiceClient.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/testiampermissions/SyncTestIamPermissions.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SchemaServiceClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.SnapshotName;
 import java.util.ArrayList;
 
 public class SyncTestIamPermissions {
@@ -35,7 +35,7 @@ public class SyncTestIamPermissions {
     try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = schemaServiceClient.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/AsyncGetIamPolicy.java
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class AsyncGetIamPolicy {
 
@@ -36,7 +36,7 @@ public class AsyncGetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       ApiFuture<Policy> future = subscriptionAdminClient.getIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/AsyncGetIamPolicy.java
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class AsyncGetIamPolicy {
 
@@ -36,7 +36,7 @@ public class AsyncGetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       ApiFuture<Policy> future = subscriptionAdminClient.getIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/SyncGetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class SyncGetIamPolicy {
 
@@ -35,7 +35,7 @@ public class SyncGetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       Policy response = subscriptionAdminClient.getIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/getiampolicy/SyncGetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class SyncGetIamPolicy {
 
@@ -35,7 +35,7 @@ public class SyncGetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       Policy response = subscriptionAdminClient.getIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/AsyncSetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class AsyncSetIamPolicy {
 
@@ -35,7 +35,7 @@ public class AsyncSetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       ApiFuture<Policy> future = subscriptionAdminClient.setIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/AsyncSetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class AsyncSetIamPolicy {
 
@@ -35,7 +35,7 @@ public class AsyncSetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       ApiFuture<Policy> future = subscriptionAdminClient.setIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/SyncSetIamPolicy.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class SyncSetIamPolicy {
 
@@ -34,7 +34,7 @@ public class SyncSetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       Policy response = subscriptionAdminClient.setIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/setiampolicy/SyncSetIamPolicy.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class SyncSetIamPolicy {
 
@@ -34,7 +34,7 @@ public class SyncSetIamPolicy {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       Policy response = subscriptionAdminClient.setIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/AsyncTestIamPermissions.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.SubscriptionName;
 import java.util.ArrayList;
 
 public class AsyncTestIamPermissions {
@@ -36,7 +36,7 @@ public class AsyncTestIamPermissions {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/AsyncTestIamPermissions.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.SnapshotName;
 import java.util.ArrayList;
 
 public class AsyncTestIamPermissions {
@@ -36,7 +36,7 @@ public class AsyncTestIamPermissions {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/SyncTestIamPermissions.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.SubscriptionName;
 import java.util.ArrayList;
 
 public class SyncTestIamPermissions {
@@ -35,7 +35,7 @@ public class SyncTestIamPermissions {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = subscriptionAdminClient.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/testiampermissions/SyncTestIamPermissions.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.SnapshotName;
 import java.util.ArrayList;
 
 public class SyncTestIamPermissions {
@@ -35,7 +35,7 @@ public class SyncTestIamPermissions {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = subscriptionAdminClient.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/AsyncGetIamPolicy.java
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class AsyncGetIamPolicy {
 
@@ -36,7 +36,7 @@ public class AsyncGetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       ApiFuture<Policy> future = topicAdminClient.getIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/AsyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/AsyncGetIamPolicy.java
@@ -22,7 +22,7 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class AsyncGetIamPolicy {
 
@@ -36,7 +36,7 @@ public class AsyncGetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       ApiFuture<Policy> future = topicAdminClient.getIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/SyncGetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class SyncGetIamPolicy {
 
@@ -35,7 +35,7 @@ public class SyncGetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       Policy response = topicAdminClient.getIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/SyncGetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/getiampolicy/SyncGetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.GetPolicyOptions;
 import com.google.iam.v1.Policy;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class SyncGetIamPolicy {
 
@@ -35,7 +35,7 @@ public class SyncGetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       Policy response = topicAdminClient.getIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/AsyncSetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class AsyncSetIamPolicy {
 
@@ -35,7 +35,7 @@ public class AsyncSetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       ApiFuture<Policy> future = topicAdminClient.setIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/AsyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/AsyncSetIamPolicy.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class AsyncSetIamPolicy {
 
@@ -35,7 +35,7 @@ public class AsyncSetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       ApiFuture<Policy> future = topicAdminClient.setIamPolicyCallable().futureCall(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/SyncSetIamPolicy.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 
 public class SyncSetIamPolicy {
 
@@ -34,7 +34,7 @@ public class SyncSetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       Policy response = topicAdminClient.setIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/SyncSetIamPolicy.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/setiampolicy/SyncSetIamPolicy.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.SetIamPolicyRequest;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.TopicName;
 
 public class SyncSetIamPolicy {
 
@@ -34,7 +34,7 @@ public class SyncSetIamPolicy {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       Policy response = topicAdminClient.setIamPolicy(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/AsyncTestIamPermissions.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.SubscriptionName;
 import java.util.ArrayList;
 
 public class AsyncTestIamPermissions {
@@ -36,7 +36,7 @@ public class AsyncTestIamPermissions {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/AsyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/AsyncTestIamPermissions.java
@@ -21,7 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.SnapshotName;
 import java.util.ArrayList;
 
 public class AsyncTestIamPermissions {
@@ -36,7 +36,7 @@ public class AsyncTestIamPermissions {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/SyncTestIamPermissions.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.SubscriptionName;
 import java.util.ArrayList;
 
 public class SyncTestIamPermissions {
@@ -35,7 +35,7 @@ public class SyncTestIamPermissions {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = topicAdminClient.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/SyncTestIamPermissions.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/testiampermissions/SyncTestIamPermissions.java
@@ -20,7 +20,7 @@ package com.google.cloud.pubsub.v1.samples;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
-import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.SnapshotName;
 import java.util.ArrayList;
 
 public class SyncTestIamPermissions {
@@ -35,7 +35,7 @@ public class SyncTestIamPermissions {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       TestIamPermissionsResponse response = topicAdminClient.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -825,7 +825,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   Policy response = schemaServiceClient.setIamPolicy(request);
@@ -853,7 +853,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = schemaServiceClient.setIamPolicyCallable().futureCall(request);
@@ -879,7 +879,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   Policy response = schemaServiceClient.getIamPolicy(request);
@@ -906,7 +906,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = schemaServiceClient.getIamPolicyCallable().futureCall(request);
@@ -936,7 +936,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = schemaServiceClient.testIamPermissions(request);
@@ -967,7 +967,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -825,7 +825,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   Policy response = schemaServiceClient.setIamPolicy(request);
@@ -853,7 +853,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = schemaServiceClient.setIamPolicyCallable().futureCall(request);
@@ -879,7 +879,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   Policy response = schemaServiceClient.getIamPolicy(request);
@@ -906,7 +906,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = schemaServiceClient.getIamPolicyCallable().futureCall(request);
@@ -936,7 +936,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = schemaServiceClient.testIamPermissions(request);
@@ -967,7 +967,7 @@ public class SchemaServiceClient implements BackgroundResource {
    * try (SchemaServiceClient schemaServiceClient = SchemaServiceClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
@@ -45,6 +45,8 @@ import com.google.pubsub.v1.ListSchemasResponse;
 import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.Schema;
 import com.google.pubsub.v1.SchemaName;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.TopicName;
 import com.google.pubsub.v1.ValidateMessageRequest;
 import com.google.pubsub.v1.ValidateMessageResponse;
 import com.google.pubsub.v1.ValidateSchemaRequest;
@@ -565,7 +567,7 @@ public class SchemaServiceClientTest {
 
     SetIamPolicyRequest request =
         SetIamPolicyRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
             .setPolicy(Policy.newBuilder().build())
             .build();
 
@@ -592,7 +594,7 @@ public class SchemaServiceClientTest {
     try {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       client.setIamPolicy(request);
@@ -614,7 +616,7 @@ public class SchemaServiceClientTest {
 
     GetIamPolicyRequest request =
         GetIamPolicyRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
             .setOptions(GetPolicyOptions.newBuilder().build())
             .build();
 
@@ -641,7 +643,7 @@ public class SchemaServiceClientTest {
     try {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       client.getIamPolicy(request);
@@ -659,7 +661,7 @@ public class SchemaServiceClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -686,7 +688,7 @@ public class SchemaServiceClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClientTest.java
@@ -45,8 +45,7 @@ import com.google.pubsub.v1.ListSchemasResponse;
 import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.Schema;
 import com.google.pubsub.v1.SchemaName;
-import com.google.pubsub.v1.SubscriptionName;
-import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.SnapshotName;
 import com.google.pubsub.v1.ValidateMessageRequest;
 import com.google.pubsub.v1.ValidateMessageResponse;
 import com.google.pubsub.v1.ValidateSchemaRequest;
@@ -567,7 +566,7 @@ public class SchemaServiceClientTest {
 
     SetIamPolicyRequest request =
         SetIamPolicyRequest.newBuilder()
-            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .setPolicy(Policy.newBuilder().build())
             .build();
 
@@ -594,7 +593,7 @@ public class SchemaServiceClientTest {
     try {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       client.setIamPolicy(request);
@@ -616,7 +615,7 @@ public class SchemaServiceClientTest {
 
     GetIamPolicyRequest request =
         GetIamPolicyRequest.newBuilder()
-            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .setOptions(GetPolicyOptions.newBuilder().build())
             .build();
 
@@ -643,7 +642,7 @@ public class SchemaServiceClientTest {
     try {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       client.getIamPolicy(request);
@@ -661,7 +660,7 @@ public class SchemaServiceClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -688,7 +687,7 @@ public class SchemaServiceClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -2438,7 +2438,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   Policy response = subscriptionAdminClient.setIamPolicy(request);
@@ -2466,7 +2466,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = subscriptionAdminClient.setIamPolicyCallable().futureCall(request);
@@ -2492,7 +2492,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   Policy response = subscriptionAdminClient.getIamPolicy(request);
@@ -2519,7 +2519,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = subscriptionAdminClient.getIamPolicyCallable().futureCall(request);
@@ -2549,7 +2549,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = subscriptionAdminClient.testIamPermissions(request);
@@ -2580,7 +2580,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -2438,7 +2438,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   Policy response = subscriptionAdminClient.setIamPolicy(request);
@@ -2466,7 +2466,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = subscriptionAdminClient.setIamPolicyCallable().futureCall(request);
@@ -2492,7 +2492,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   Policy response = subscriptionAdminClient.getIamPolicy(request);
@@ -2519,7 +2519,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = subscriptionAdminClient.getIamPolicyCallable().futureCall(request);
@@ -2549,7 +2549,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = subscriptionAdminClient.testIamPermissions(request);
@@ -2580,7 +2580,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    * try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -1685,7 +1685,7 @@ public class SubscriptionAdminClientTest {
 
     SetIamPolicyRequest request =
         SetIamPolicyRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
             .setPolicy(Policy.newBuilder().build())
             .build();
 
@@ -1712,7 +1712,7 @@ public class SubscriptionAdminClientTest {
     try {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       client.setIamPolicy(request);
@@ -1734,7 +1734,7 @@ public class SubscriptionAdminClientTest {
 
     GetIamPolicyRequest request =
         GetIamPolicyRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
             .setOptions(GetPolicyOptions.newBuilder().build())
             .build();
 
@@ -1761,7 +1761,7 @@ public class SubscriptionAdminClientTest {
     try {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       client.getIamPolicy(request);
@@ -1779,7 +1779,7 @@ public class SubscriptionAdminClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -1806,7 +1806,7 @@ public class SubscriptionAdminClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -1685,7 +1685,7 @@ public class SubscriptionAdminClientTest {
 
     SetIamPolicyRequest request =
         SetIamPolicyRequest.newBuilder()
-            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .setPolicy(Policy.newBuilder().build())
             .build();
 
@@ -1712,7 +1712,7 @@ public class SubscriptionAdminClientTest {
     try {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       client.setIamPolicy(request);
@@ -1734,7 +1734,7 @@ public class SubscriptionAdminClientTest {
 
     GetIamPolicyRequest request =
         GetIamPolicyRequest.newBuilder()
-            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .setOptions(GetPolicyOptions.newBuilder().build())
             .build();
 
@@ -1761,7 +1761,7 @@ public class SubscriptionAdminClientTest {
     try {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       client.getIamPolicy(request);
@@ -1779,7 +1779,7 @@ public class SubscriptionAdminClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -1806,7 +1806,7 @@ public class SubscriptionAdminClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -1193,7 +1193,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   Policy response = topicAdminClient.setIamPolicy(request);
@@ -1221,7 +1221,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = topicAdminClient.setIamPolicyCallable().futureCall(request);
@@ -1247,7 +1247,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   Policy response = topicAdminClient.getIamPolicy(request);
@@ -1274,7 +1274,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = topicAdminClient.getIamPolicyCallable().futureCall(request);
@@ -1304,7 +1304,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = topicAdminClient.testIamPermissions(request);
@@ -1335,7 +1335,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(ProjectName.of("[PROJECT]").toString())
+   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -1193,7 +1193,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   Policy response = topicAdminClient.setIamPolicy(request);
@@ -1221,7 +1221,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   SetIamPolicyRequest request =
    *       SetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setPolicy(Policy.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = topicAdminClient.setIamPolicyCallable().futureCall(request);
@@ -1247,7 +1247,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   Policy response = topicAdminClient.getIamPolicy(request);
@@ -1274,7 +1274,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   GetIamPolicyRequest request =
    *       GetIamPolicyRequest.newBuilder()
-   *           .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .setOptions(GetPolicyOptions.newBuilder().build())
    *           .build();
    *   ApiFuture<Policy> future = topicAdminClient.getIamPolicyCallable().futureCall(request);
@@ -1304,7 +1304,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   TestIamPermissionsResponse response = topicAdminClient.testIamPermissions(request);
@@ -1335,7 +1335,7 @@ public class TopicAdminClient implements BackgroundResource {
    * try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
    *   TestIamPermissionsRequest request =
    *       TestIamPermissionsRequest.newBuilder()
-   *           .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+   *           .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
    *           .addAllPermissions(new ArrayList<String>())
    *           .build();
    *   ApiFuture<TestIamPermissionsResponse> future =

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
@@ -56,6 +56,7 @@ import com.google.pubsub.v1.PublishRequest;
 import com.google.pubsub.v1.PublishResponse;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.SchemaSettings;
+import com.google.pubsub.v1.SnapshotName;
 import com.google.pubsub.v1.SubscriptionName;
 import com.google.pubsub.v1.Topic;
 import com.google.pubsub.v1.TopicName;
@@ -810,7 +811,7 @@ public class TopicAdminClientTest {
 
     SetIamPolicyRequest request =
         SetIamPolicyRequest.newBuilder()
-            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .setPolicy(Policy.newBuilder().build())
             .build();
 
@@ -837,7 +838,7 @@ public class TopicAdminClientTest {
     try {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       client.setIamPolicy(request);
@@ -859,7 +860,7 @@ public class TopicAdminClientTest {
 
     GetIamPolicyRequest request =
         GetIamPolicyRequest.newBuilder()
-            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .setOptions(GetPolicyOptions.newBuilder().build())
             .build();
 
@@ -886,7 +887,7 @@ public class TopicAdminClientTest {
     try {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       client.getIamPolicy(request);
@@ -904,7 +905,7 @@ public class TopicAdminClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+            .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -931,7 +932,7 @@ public class TopicAdminClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
+              .setResource(SnapshotName.of("[PROJECT]", "[SNAPSHOT]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClientTest.java
@@ -810,7 +810,7 @@ public class TopicAdminClientTest {
 
     SetIamPolicyRequest request =
         SetIamPolicyRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
             .setPolicy(Policy.newBuilder().build())
             .build();
 
@@ -837,7 +837,7 @@ public class TopicAdminClientTest {
     try {
       SetIamPolicyRequest request =
           SetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setPolicy(Policy.newBuilder().build())
               .build();
       client.setIamPolicy(request);
@@ -859,7 +859,7 @@ public class TopicAdminClientTest {
 
     GetIamPolicyRequest request =
         GetIamPolicyRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
             .setOptions(GetPolicyOptions.newBuilder().build())
             .build();
 
@@ -886,7 +886,7 @@ public class TopicAdminClientTest {
     try {
       GetIamPolicyRequest request =
           GetIamPolicyRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(TopicName.ofProjectTopicName("[PROJECT]", "[TOPIC]").toString())
               .setOptions(GetPolicyOptions.newBuilder().build())
               .build();
       client.getIamPolicy(request);
@@ -904,7 +904,7 @@ public class TopicAdminClientTest {
 
     TestIamPermissionsRequest request =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(ProjectName.of("[PROJECT]").toString())
+            .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
             .addAllPermissions(new ArrayList<String>())
             .build();
 
@@ -931,7 +931,7 @@ public class TopicAdminClientTest {
     try {
       TestIamPermissionsRequest request =
           TestIamPermissionsRequest.newBuilder()
-              .setResource(ProjectName.of("[PROJECT]").toString())
+              .setResource(SubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]").toString())
               .addAllPermissions(new ArrayList<String>())
               .build();
       client.testIamPermissions(request);


### PR DESCRIPTION
1) Stop failing for grpc+rest and rest transports in case if there are bidi- or client- streaming methods (generated a method throwing "Unimplemented" exception if called)
2) Make sure that the resource name suggested for wildcard resource names actually matches url pattern (most of the changes in goldens are caused by this change)
3) Fix the order of "actual" and "expected" in diff_gen_and_golden to match
4) Fix multipattern `of%Name` method resoluiton to make sure that the chosen pattern matches url pattern (the changes in `MessagingClient.golden` and related files are caused by this change).
5) Fix anonymous resource name class construction (add proper toString() method matching pattern)
6) Gracefully treat methods without http bindings as not supported in rest transport (instead of failing on generation)