### PR TITLE
chore: move googleapis dependency to WORKSPACE and update docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,79 +12,6 @@
     cp .githooks/pre-commit .git/hooks/pre-commit
     ```
 
-## Running the Plugin
-
-1.  Clone [googleapis](https://github.com/googleapis/googleapis) and
-    [gapic-showcase](https://github.com/googleapis/gapic-showcase/).
-
-2.  Copy the protos from Showcase into googleapis/google/showcase.
-
-    ```sh
-    mkdir googleapis/google/showcase
-    cp -r gapic-showcase/schema/google/showcase/v1beta1 googleapis/google/showcase/v1beta1
-    ```
-
-3.  Add the new microgenerator rules to
-    `googleapis/google/showcase/v1beta1/BUILD.bazel` file as follows:
-
-    ```python
-    load(
-        "@com_google_googleapis_imports//:imports.bzl",
-        # Existing rules here.
-        "java_gapic_assembly_gradle_pkg",
-        "java_gapic_library",
-        "java_proto_library",
-        "proto_library_with_info",
-    )
-
-    proto_library_with_info(
-        name = "showcase_proto_with_info",
-        deps = [
-            ":showcase_proto",
-        ],
-    )
-
-    java_proto_library(
-        name = "showcase_java_proto",
-        deps = [
-            ":showcase_proto",
-        ],
-    )
-
-    # This should either replace the existing monolith target or have a unique name
-    # that includes "java_gapic".
-    java_gapic_library(
-        name = "showcase_java_gapic",
-        srcs = [":showcase_proto_with_info"],
-        grpc_service_config = "showcase_grpc_service_config.json",
-        test_deps = [
-            ":showcase_java_grpc",
-        ],
-        deps = [
-            ":showcase_java_proto",
-        ],
-    )
-
-    java_gapic_assembly_gradle_pkg(
-        # This name should be unique from the existing target name.
-        name = "google-cloud-showcase-v1beta1-java",
-        deps = [
-            # This is the new microgen target above.
-            ":showcase_java_gapic",
-            # The following targets already exist.
-            ":showcase_java_grpc",
-            ":showcase_java_proto",
-            ":showcase_proto",
-        ],
-    )
-    ```
-
-4.  Build the new target.
-
-    ```sh
-    bazel build //google/showcase/v1beta1:showcase_java_gapic
-    ```
-
 ## Code Formatting
 
 -   Run linter checks without actually doing the formatting.
@@ -166,4 +93,77 @@
 
     ```sh
     bazel run //test/integration:update_redis
+    ```
+
+## Running the Plugin
+
+1.  Clone [googleapis](https://github.com/googleapis/googleapis) and
+    [gapic-showcase](https://github.com/googleapis/gapic-showcase/).
+
+2.  Copy the protos from Showcase into googleapis/google/showcase.
+
+    ```sh
+    mkdir googleapis/google/showcase
+    cp -r gapic-showcase/schema/google/showcase/v1beta1 googleapis/google/showcase/v1beta1
+    ```
+
+3.  Add the new microgenerator rules to
+    `googleapis/google/showcase/v1beta1/BUILD.bazel` file as follows:
+
+    ```python
+    load(
+        "@com_google_googleapis_imports//:imports.bzl",
+        # Existing rules here.
+        "java_gapic_assembly_gradle_pkg",
+        "java_gapic_library",
+        "java_proto_library",
+        "proto_library_with_info",
+    )
+
+    proto_library_with_info(
+        name = "showcase_proto_with_info",
+        deps = [
+            ":showcase_proto",
+        ],
+    )
+
+    java_proto_library(
+        name = "showcase_java_proto",
+        deps = [
+            ":showcase_proto",
+        ],
+    )
+
+    # This should either replace the existing monolith target or have a unique name
+    # that includes "java_gapic".
+    java_gapic_library(
+        name = "showcase_java_gapic",
+        srcs = [":showcase_proto_with_info"],
+        grpc_service_config = "showcase_grpc_service_config.json",
+        test_deps = [
+            ":showcase_java_grpc",
+        ],
+        deps = [
+            ":showcase_java_proto",
+        ],
+    )
+
+    java_gapic_assembly_gradle_pkg(
+        # This name should be unique from the existing target name.
+        name = "google-cloud-showcase-v1beta1-java",
+        deps = [
+            # This is the new microgen target above.
+            ":showcase_java_gapic",
+            # The following targets already exist.
+            ":showcase_java_grpc",
+            ":showcase_java_proto",
+            ":showcase_proto",
+        ],
+    )
+    ```
+
+4.  Build the new target.
+
+    ```sh
+    bazel build //google/showcase/v1beta1:showcase_java_gapic
     ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,6 +52,14 @@ load("@com_google_api_gax_java//:repositories.bzl", "com_google_api_gax_java_rep
 
 com_google_api_gax_java_repositories()
 
+http_archive(
+        name = "com_google_googleapis",
+        strip_prefix = "googleapis-44d6bef0ca6db8bba3fb324c8186e694bcc4829c",
+        urls = [
+            "https://github.com/googleapis/googleapis/archive/44d6bef0ca6db8bba3fb324c8186e694bcc4829c.zip",
+        ],
+    )
+
 load("//:repositories.bzl", "gapic_generator_java_repositories")
 
 gapic_generator_java_repositories()

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -57,15 +57,6 @@ def gapic_generator_java_repositories():
     )
 
     _maybe(
-        http_archive,
-        name = "com_google_googleapis",
-        strip_prefix = "googleapis-44d6bef0ca6db8bba3fb324c8186e694bcc4829c",
-        urls = [
-            "https://github.com/googleapis/googleapis/archive/44d6bef0ca6db8bba3fb324c8186e694bcc4829c.zip",
-        ],
-    )
-
-    _maybe(
         native.bind,
         name = "guava",
         actual = "@com_google_guava_guava//jar",

--- a/test/integration/goldens/README.md
+++ b/test/integration/goldens/README.md
@@ -1,7 +1,7 @@
 # Goldens Files For Integration Test
 
 This folder contains goldens files that are expected to be generated from Java Microgenerator
-against differenct APIs. For example `redis` folder has all the Java source files in the generated 
+against different APIs. For example `redis` folder has all the Java source files in the generated 
 Redis client library. They are all actual Java files, but used as goldens.
 
 ## Purpose
@@ -20,5 +20,11 @@ If the actual generated Java source files are not identical with the goldens fil
 update the goldens using source files. Run the command below to overwrite the goldens files in `redis` folder.
 
 ```sh
-bazel run //test/integration:redis_update
+bazel run //test/integration:update_redis
 ```
+
+## Adding new integration tests
+
+If you are adding a new API for integration testing, be sure to add it in the `BUILD.bazel` under the `Integration Test Rules` and add the `java_gapic_test` rules for the new API under the `API Library Rules` section.
+
+You need to manually create a new directory for your new API under the `test/integration/goldens` with the same name you've used for the `Integration Test Rules`. Then when you run the command to update goldens (above), it will automatically create the goldens needed.


### PR DESCRIPTION
- Moves the `com_google_googleapis` dependency into `WORKSPACE`
- Updates a couple docs for readability and fixing some small typos
