### PR TITLE
fix: use correct paginated field name

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientCallableMethodSampleComposer.java
@@ -186,7 +186,11 @@ public class ServiceClientCallableMethodSampleComposer {
     MethodInvocationExpr getResponseListMethodInvocationExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(responseVarExpr)
-            .setMethodName("getResponsesList")
+            .setMethodName(
+                "get"
+                    + JavaStyle.toUpperCamelCase(
+                        String.format("%s", repeatedPagedResultsField.name()))
+                    + "List")
             .build();
     ForStatement responseForStatements =
         ForStatement.builder()

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/IdentityClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/IdentityClient.golden
@@ -625,7 +625,7 @@ public class IdentityClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListUsersResponse response = identityClient.listUsersCallable().call(request);
-   *     for (User element : response.getResponsesList()) {
+   *     for (User element : response.getUsersList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
@@ -494,7 +494,7 @@ public class MessagingClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListRoomsResponse response = messagingClient.listRoomsCallable().call(request);
-   *     for (Room element : response.getResponsesList()) {
+   *     for (Room element : response.getRoomsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1079,7 +1079,7 @@ public class MessagingClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListBlurbsResponse response = messagingClient.listBlurbsCallable().call(request);
-   *     for (Blurb element : response.getResponsesList()) {
+   *     for (Blurb element : response.getBlurbsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncListUsersPaged.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/identityclient/AsyncListUsersPaged.golden
@@ -40,7 +40,7 @@ public class AsyncListUsersPaged {
               .build();
       while (true) {
         ListUsersResponse response = identityClient.listUsersCallable().call(request);
-        for (User element : response.getResponsesList()) {
+        for (User element : response.getUsersList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListBlurbsPaged.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListBlurbsPaged.golden
@@ -42,7 +42,7 @@ public class AsyncListBlurbsPaged {
               .build();
       while (true) {
         ListBlurbsResponse response = messagingClient.listBlurbsCallable().call(request);
-        for (Blurb element : response.getResponsesList()) {
+        for (Blurb element : response.getBlurbsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListRoomsPaged.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/samples/messagingclient/AsyncListRoomsPaged.golden
@@ -40,7 +40,7 @@ public class AsyncListRoomsPaged {
               .build();
       while (true) {
         ListRoomsResponse response = messagingClient.listRoomsCallable().call(request);
-        for (Room element : response.getResponsesList()) {
+        for (Room element : response.getRoomsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/AsyncListAssetsPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/listassets/AsyncListAssetsPaged.java
@@ -48,7 +48,7 @@ public class AsyncListAssetsPaged {
               .build();
       while (true) {
         ListAssetsResponse response = assetServiceClient.listAssetsCallable().call(request);
-        for (Asset element : response.getResponsesList()) {
+        for (Asset element : response.getAssetsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/searchalliampolicies/AsyncSearchAllIamPoliciesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/searchalliampolicies/AsyncSearchAllIamPoliciesPaged.java
@@ -46,7 +46,7 @@ public class AsyncSearchAllIamPoliciesPaged {
       while (true) {
         SearchAllIamPoliciesResponse response =
             assetServiceClient.searchAllIamPoliciesCallable().call(request);
-        for (IamPolicySearchResult element : response.getResponsesList()) {
+        for (IamPolicySearchResult element : response.getResultsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/searchallresources/AsyncSearchAllResourcesPaged.java
+++ b/test/integration/goldens/asset/samples/snippets/generated/main/java/com/google/cloud/asset/v1/assetserviceclient/searchallresources/AsyncSearchAllResourcesPaged.java
@@ -48,7 +48,7 @@ public class AsyncSearchAllResourcesPaged {
       while (true) {
         SearchAllResourcesResponse response =
             assetServiceClient.searchAllResourcesCallable().call(request);
-        for (ResourceSearchResult element : response.getResponsesList()) {
+        for (ResourceSearchResult element : response.getResultsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -445,7 +445,7 @@ public class AssetServiceClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListAssetsResponse response = assetServiceClient.listAssetsCallable().call(request);
-   *     for (Asset element : response.getResponsesList()) {
+   *     for (Asset element : response.getAssetsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1150,7 +1150,7 @@ public class AssetServiceClient implements BackgroundResource {
    *   while (true) {
    *     SearchAllResourcesResponse response =
    *         assetServiceClient.searchAllResourcesCallable().call(request);
-   *     for (ResourceSearchResult element : response.getResponsesList()) {
+   *     for (ResourceSearchResult element : response.getResultsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1341,7 +1341,7 @@ public class AssetServiceClient implements BackgroundResource {
    *   while (true) {
    *     SearchAllIamPoliciesResponse response =
    *         assetServiceClient.searchAllIamPoliciesCallable().call(request);
-   *     for (IamPolicySearchResult element : response.getResponsesList()) {
+   *     for (IamPolicySearchResult element : response.getResultsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressesclient/aggregatedlist/AsyncAggregatedListPaged.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressesclient/aggregatedlist/AsyncAggregatedListPaged.java
@@ -45,7 +45,7 @@ public class AsyncAggregatedListPaged {
               .build();
       while (true) {
         AddressAggregatedList response = addressesClient.aggregatedListCallable().call(request);
-        for (Map.Entry<String, AddressesScopedList> element : response.getResponsesList()) {
+        for (Map.Entry<String, AddressesScopedList> element : response.getItemsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressesclient/list/AsyncListPaged.java
+++ b/test/integration/goldens/compute/samples/snippets/generated/main/java/com/google/cloud/compute/v1small/addressesclient/list/AsyncListPaged.java
@@ -44,7 +44,7 @@ public class AsyncListPaged {
               .build();
       while (true) {
         AddressList response = addressesClient.listCallable().call(request);
-        for (Address element : response.getResponsesList()) {
+        for (Address element : response.getItemsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
@@ -269,7 +269,7 @@ public class AddressesClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     AddressAggregatedList response = addressesClient.aggregatedListCallable().call(request);
-   *     for (Map.Entry<String, AddressesScopedList> element : response.getResponsesList()) {
+   *     for (Map.Entry<String, AddressesScopedList> element : response.getItemsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -649,7 +649,7 @@ public class AddressesClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     AddressList response = addressesClient.listCallable().call(request);
-   *     for (Address element : response.getResponsesList()) {
+   *     for (Address element : response.getItemsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listcryptokeys/AsyncListCryptoKeysPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listcryptokeys/AsyncListCryptoKeysPaged.java
@@ -46,7 +46,7 @@ public class AsyncListCryptoKeysPaged {
       while (true) {
         ListCryptoKeysResponse response =
             keyManagementServiceClient.listCryptoKeysCallable().call(request);
-        for (CryptoKey element : response.getResponsesList()) {
+        for (CryptoKey element : response.getCryptoKeysList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listcryptokeyversions/AsyncListCryptoKeyVersionsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listcryptokeyversions/AsyncListCryptoKeyVersionsPaged.java
@@ -48,7 +48,7 @@ public class AsyncListCryptoKeyVersionsPaged {
       while (true) {
         ListCryptoKeyVersionsResponse response =
             keyManagementServiceClient.listCryptoKeyVersionsCallable().call(request);
-        for (CryptoKeyVersion element : response.getResponsesList()) {
+        for (CryptoKeyVersion element : response.getCryptoKeyVersionsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listimportjobs/AsyncListImportJobsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listimportjobs/AsyncListImportJobsPaged.java
@@ -46,7 +46,7 @@ public class AsyncListImportJobsPaged {
       while (true) {
         ListImportJobsResponse response =
             keyManagementServiceClient.listImportJobsCallable().call(request);
-        for (ImportJob element : response.getResponsesList()) {
+        for (ImportJob element : response.getImportJobsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listkeyrings/AsyncListKeyRingsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listkeyrings/AsyncListKeyRingsPaged.java
@@ -46,7 +46,7 @@ public class AsyncListKeyRingsPaged {
       while (true) {
         ListKeyRingsResponse response =
             keyManagementServiceClient.listKeyRingsCallable().call(request);
-        for (KeyRing element : response.getResponsesList()) {
+        for (KeyRing element : response.getKeyRingsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listlocations/AsyncListLocationsPaged.java
+++ b/test/integration/goldens/kms/samples/snippets/generated/main/java/com/google/cloud/kms/v1/keymanagementserviceclient/listlocations/AsyncListLocationsPaged.java
@@ -44,7 +44,7 @@ public class AsyncListLocationsPaged {
       while (true) {
         ListLocationsResponse response =
             keyManagementServiceClient.listLocationsCallable().call(request);
-        for (Location element : response.getResponsesList()) {
+        for (Location element : response.getLocationsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -320,7 +320,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *   while (true) {
    *     ListKeyRingsResponse response =
    *         keyManagementServiceClient.listKeyRingsCallable().call(request);
-   *     for (KeyRing element : response.getResponsesList()) {
+   *     for (KeyRing element : response.getKeyRingsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -481,7 +481,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *   while (true) {
    *     ListCryptoKeysResponse response =
    *         keyManagementServiceClient.listCryptoKeysCallable().call(request);
-   *     for (CryptoKey element : response.getResponsesList()) {
+   *     for (CryptoKey element : response.getCryptoKeysList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -656,7 +656,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *   while (true) {
    *     ListCryptoKeyVersionsResponse response =
    *         keyManagementServiceClient.listCryptoKeyVersionsCallable().call(request);
-   *     for (CryptoKeyVersion element : response.getResponsesList()) {
+   *     for (CryptoKeyVersion element : response.getCryptoKeyVersionsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -818,7 +818,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *   while (true) {
    *     ListImportJobsResponse response =
    *         keyManagementServiceClient.listImportJobsCallable().call(request);
-   *     for (ImportJob element : response.getResponsesList()) {
+   *     for (ImportJob element : response.getImportJobsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -3476,7 +3476,7 @@ public class KeyManagementServiceClient implements BackgroundResource {
    *   while (true) {
    *     ListLocationsResponse response =
    *         keyManagementServiceClient.listLocationsCallable().call(request);
-   *     for (Location element : response.getResponsesList()) {
+   *     for (Location element : response.getLocationsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryserviceclient/listbooks/AsyncListBooksPaged.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryserviceclient/listbooks/AsyncListBooksPaged.java
@@ -42,7 +42,7 @@ public class AsyncListBooksPaged {
               .build();
       while (true) {
         ListBooksResponse response = libraryServiceClient.listBooksCallable().call(request);
-        for (Book element : response.getResponsesList()) {
+        for (Book element : response.getBooksList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryserviceclient/listshelves/AsyncListShelvesPaged.java
+++ b/test/integration/goldens/library/samples/snippets/generated/main/java/com/google/cloud/example/library/v1/libraryserviceclient/listshelves/AsyncListShelvesPaged.java
@@ -40,7 +40,7 @@ public class AsyncListShelvesPaged {
               .build();
       while (true) {
         ListShelvesResponse response = libraryServiceClient.listShelvesCallable().call(request);
-        for (Shelf element : response.getResponsesList()) {
+        for (Shelf element : response.getShelvesList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
+++ b/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
@@ -410,7 +410,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListShelvesResponse response = libraryServiceClient.listShelvesCallable().call(request);
-   *     for (Shelf element : response.getResponsesList()) {
+   *     for (Shelf element : response.getShelvesList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1047,7 +1047,7 @@ public class LibraryServiceClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListBooksResponse response = libraryServiceClient.listBooksCallable().call(request);
-   *     for (Book element : response.getResponsesList()) {
+   *     for (Book element : response.getBooksList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listbuckets/AsyncListBucketsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listbuckets/AsyncListBucketsPaged.java
@@ -42,7 +42,7 @@ public class AsyncListBucketsPaged {
               .build();
       while (true) {
         ListBucketsResponse response = configClient.listBucketsCallable().call(request);
-        for (LogBucket element : response.getResponsesList()) {
+        for (LogBucket element : response.getBucketsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listexclusions/AsyncListExclusionsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listexclusions/AsyncListExclusionsPaged.java
@@ -42,7 +42,7 @@ public class AsyncListExclusionsPaged {
               .build();
       while (true) {
         ListExclusionsResponse response = configClient.listExclusionsCallable().call(request);
-        for (LogExclusion element : response.getResponsesList()) {
+        for (LogExclusion element : response.getExclusionsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listsinks/AsyncListSinksPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listsinks/AsyncListSinksPaged.java
@@ -42,7 +42,7 @@ public class AsyncListSinksPaged {
               .build();
       while (true) {
         ListSinksResponse response = configClient.listSinksCallable().call(request);
-        for (LogSink element : response.getResponsesList()) {
+        for (LogSink element : response.getSinksList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listviews/AsyncListViewsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/configclient/listviews/AsyncListViewsPaged.java
@@ -41,7 +41,7 @@ public class AsyncListViewsPaged {
               .build();
       while (true) {
         ListViewsResponse response = configClient.listViewsCallable().call(request);
-        for (LogView element : response.getResponsesList()) {
+        for (LogView element : response.getViewsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingclient/listlogentries/AsyncListLogEntriesPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingclient/listlogentries/AsyncListLogEntriesPaged.java
@@ -44,7 +44,7 @@ public class AsyncListLogEntriesPaged {
               .build();
       while (true) {
         ListLogEntriesResponse response = loggingClient.listLogEntriesCallable().call(request);
-        for (LogEntry element : response.getResponsesList()) {
+        for (LogEntry element : response.getEntriesList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingclient/listlogs/AsyncListLogsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingclient/listlogs/AsyncListLogsPaged.java
@@ -43,7 +43,7 @@ public class AsyncListLogsPaged {
               .build();
       while (true) {
         ListLogsResponse response = loggingClient.listLogsCallable().call(request);
-        for (String element : response.getResponsesList()) {
+        for (String element : response.getLogNamesList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingclient/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptorsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/loggingclient/listmonitoredresourcedescriptors/AsyncListMonitoredResourceDescriptorsPaged.java
@@ -41,7 +41,7 @@ public class AsyncListMonitoredResourceDescriptorsPaged {
       while (true) {
         ListMonitoredResourceDescriptorsResponse response =
             loggingClient.listMonitoredResourceDescriptorsCallable().call(request);
-        for (MonitoredResourceDescriptor element : response.getResponsesList()) {
+        for (MonitoredResourceDescriptor element : response.getResourceDescriptorsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsclient/listlogmetrics/AsyncListLogMetricsPaged.java
+++ b/test/integration/goldens/logging/samples/snippets/generated/main/java/com/google/cloud/logging/v2/metricsclient/listlogmetrics/AsyncListLogMetricsPaged.java
@@ -42,7 +42,7 @@ public class AsyncListLogMetricsPaged {
               .build();
       while (true) {
         ListLogMetricsResponse response = metricsClient.listLogMetricsCallable().call(request);
-        for (LogMetric element : response.getResponsesList()) {
+        for (LogMetric element : response.getMetricsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
@@ -438,7 +438,7 @@ public class ConfigClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListBucketsResponse response = configClient.listBucketsCallable().call(request);
-   *     for (LogBucket element : response.getResponsesList()) {
+   *     for (LogBucket element : response.getBucketsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -849,7 +849,7 @@ public class ConfigClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListViewsResponse response = configClient.listViewsCallable().call(request);
-   *     for (LogView element : response.getResponsesList()) {
+   *     for (LogView element : response.getViewsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1298,7 +1298,7 @@ public class ConfigClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListSinksResponse response = configClient.listSinksCallable().call(request);
-   *     for (LogSink element : response.getResponsesList()) {
+   *     for (LogSink element : response.getSinksList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -2239,7 +2239,7 @@ public class ConfigClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListExclusionsResponse response = configClient.listExclusionsCallable().call(request);
-   *     for (LogExclusion element : response.getResponsesList()) {
+   *     for (LogExclusion element : response.getExclusionsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
@@ -648,7 +648,7 @@ public class LoggingClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListLogEntriesResponse response = loggingClient.listLogEntriesCallable().call(request);
-   *     for (LogEntry element : response.getResponsesList()) {
+   *     for (LogEntry element : response.getEntriesList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -744,7 +744,7 @@ public class LoggingClient implements BackgroundResource {
    *   while (true) {
    *     ListMonitoredResourceDescriptorsResponse response =
    *         loggingClient.listMonitoredResourceDescriptorsCallable().call(request);
-   *     for (MonitoredResourceDescriptor element : response.getResponsesList()) {
+   *     for (MonitoredResourceDescriptor element : response.getResourceDescriptorsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -988,7 +988,7 @@ public class LoggingClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListLogsResponse response = loggingClient.listLogsCallable().call(request);
-   *     for (String element : response.getResponsesList()) {
+   *     for (String element : response.getLogNamesList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
+++ b/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
@@ -286,7 +286,7 @@ public class MetricsClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListLogMetricsResponse response = metricsClient.listLogMetricsCallable().call(request);
-   *     for (LogMetric element : response.getResponsesList()) {
+   *     for (LogMetric element : response.getMetricsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/listschemas/AsyncListSchemasPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/schemaserviceclient/listschemas/AsyncListSchemasPaged.java
@@ -44,7 +44,7 @@ public class AsyncListSchemasPaged {
               .build();
       while (true) {
         ListSchemasResponse response = schemaServiceClient.listSchemasCallable().call(request);
-        for (Schema element : response.getResponsesList()) {
+        for (Schema element : response.getSchemasList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/listsnapshots/AsyncListSnapshotsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/listsnapshots/AsyncListSnapshotsPaged.java
@@ -43,7 +43,7 @@ public class AsyncListSnapshotsPaged {
       while (true) {
         ListSnapshotsResponse response =
             subscriptionAdminClient.listSnapshotsCallable().call(request);
-        for (Snapshot element : response.getResponsesList()) {
+        for (Snapshot element : response.getSnapshotsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/listsubscriptions/AsyncListSubscriptionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/subscriptionadminclient/listsubscriptions/AsyncListSubscriptionsPaged.java
@@ -43,7 +43,7 @@ public class AsyncListSubscriptionsPaged {
       while (true) {
         ListSubscriptionsResponse response =
             subscriptionAdminClient.listSubscriptionsCallable().call(request);
-        for (Subscription element : response.getResponsesList()) {
+        for (Subscription element : response.getSubscriptionsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/listtopics/AsyncListTopicsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/listtopics/AsyncListTopicsPaged.java
@@ -42,7 +42,7 @@ public class AsyncListTopicsPaged {
               .build();
       while (true) {
         ListTopicsResponse response = topicAdminClient.listTopicsCallable().call(request);
-        for (Topic element : response.getResponsesList()) {
+        for (Topic element : response.getTopicsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/listtopicsnapshots/AsyncListTopicSnapshotsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/listtopicsnapshots/AsyncListTopicSnapshotsPaged.java
@@ -42,7 +42,7 @@ public class AsyncListTopicSnapshotsPaged {
       while (true) {
         ListTopicSnapshotsResponse response =
             topicAdminClient.listTopicSnapshotsCallable().call(request);
-        for (String element : response.getResponsesList()) {
+        for (String element : response.getSnapshotsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/listtopicsubscriptions/AsyncListTopicSubscriptionsPaged.java
+++ b/test/integration/goldens/pubsub/samples/snippets/generated/main/java/com/google/cloud/pubsub/v1/topicadminclient/listtopicsubscriptions/AsyncListTopicSubscriptionsPaged.java
@@ -42,7 +42,7 @@ public class AsyncListTopicSubscriptionsPaged {
       while (true) {
         ListTopicSubscriptionsResponse response =
             topicAdminClient.listTopicSubscriptionsCallable().call(request);
-        for (String element : response.getResponsesList()) {
+        for (String element : response.getSubscriptionsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -531,7 +531,7 @@ public class SchemaServiceClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListSchemasResponse response = schemaServiceClient.listSchemasCallable().call(request);
-   *     for (Schema element : response.getResponsesList()) {
+   *     for (Schema element : response.getSchemasList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -849,7 +849,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    *   while (true) {
    *     ListSubscriptionsResponse response =
    *         subscriptionAdminClient.listSubscriptionsCallable().call(request);
-   *     for (Subscription element : response.getResponsesList()) {
+   *     for (Subscription element : response.getSubscriptionsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1891,7 +1891,7 @@ public class SubscriptionAdminClient implements BackgroundResource {
    *   while (true) {
    *     ListSnapshotsResponse response =
    *         subscriptionAdminClient.listSnapshotsCallable().call(request);
-   *     for (Snapshot element : response.getResponsesList()) {
+   *     for (Snapshot element : response.getSnapshotsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -676,7 +676,7 @@ public class TopicAdminClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListTopicsResponse response = topicAdminClient.listTopicsCallable().call(request);
-   *     for (Topic element : response.getResponsesList()) {
+   *     for (Topic element : response.getTopicsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -828,7 +828,7 @@ public class TopicAdminClient implements BackgroundResource {
    *   while (true) {
    *     ListTopicSubscriptionsResponse response =
    *         topicAdminClient.listTopicSubscriptionsCallable().call(request);
-   *     for (String element : response.getResponsesList()) {
+   *     for (String element : response.getSubscriptionsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -996,7 +996,7 @@ public class TopicAdminClient implements BackgroundResource {
    *   while (true) {
    *     ListTopicSnapshotsResponse response =
    *         topicAdminClient.listTopicSnapshotsCallable().call(request);
-   *     for (String element : response.getResponsesList()) {
+   *     for (String element : response.getSnapshotsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredisclient/listinstances/AsyncListInstancesPaged.java
+++ b/test/integration/goldens/redis/samples/snippets/generated/main/java/com/google/cloud/redis/v1beta1/cloudredisclient/listinstances/AsyncListInstancesPaged.java
@@ -42,7 +42,7 @@ public class AsyncListInstancesPaged {
               .build();
       while (true) {
         ListInstancesResponse response = cloudRedisClient.listInstancesCallable().call(request);
-        for (Instance element : response.getResponsesList()) {
+        for (Instance element : response.getInstancesList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -368,7 +368,7 @@ public class CloudRedisClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListInstancesResponse response = cloudRedisClient.listInstancesCallable().call(request);
-   *     for (Instance element : response.getResponsesList()) {
+   *     for (Instance element : response.getInstancesList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listbuckets/AsyncListBucketsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listbuckets/AsyncListBucketsPaged.java
@@ -47,7 +47,7 @@ public class AsyncListBucketsPaged {
               .build();
       while (true) {
         ListBucketsResponse response = storageClient.listBucketsCallable().call(request);
-        for (Bucket element : response.getResponsesList()) {
+        for (Bucket element : response.getBucketsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listhmackeys/AsyncListHmacKeysPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listhmackeys/AsyncListHmacKeysPaged.java
@@ -46,7 +46,7 @@ public class AsyncListHmacKeysPaged {
               .build();
       while (true) {
         ListHmacKeysResponse response = storageClient.listHmacKeysCallable().call(request);
-        for (HmacKeyMetadata element : response.getResponsesList()) {
+        for (HmacKeyMetadata element : response.getHmacKeysList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listnotifications/AsyncListNotificationsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listnotifications/AsyncListNotificationsPaged.java
@@ -43,7 +43,7 @@ public class AsyncListNotificationsPaged {
       while (true) {
         ListNotificationsResponse response =
             storageClient.listNotificationsCallable().call(request);
-        for (Notification element : response.getResponsesList()) {
+        for (Notification element : response.getNotificationsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listobjects/AsyncListObjectsPaged.java
+++ b/test/integration/goldens/storage/samples/snippets/generated/main/java/com/google/storage/v2/storageclient/listobjects/AsyncListObjectsPaged.java
@@ -52,7 +52,7 @@ public class AsyncListObjectsPaged {
               .build();
       while (true) {
         ListObjectsResponse response = storageClient.listObjectsCallable().call(request);
-        for (Object element : response.getResponsesList()) {
+        for (Object element : response.getObjectsList()) {
           // doThingsWith(element);
         }
         String nextPageToken = response.getNextPageToken();

--- a/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
+++ b/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
@@ -640,7 +640,7 @@ public class StorageClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListBucketsResponse response = storageClient.listBucketsCallable().call(request);
-   *     for (Bucket element : response.getResponsesList()) {
+   *     for (Bucket element : response.getBucketsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -1654,7 +1654,7 @@ public class StorageClient implements BackgroundResource {
    *   while (true) {
    *     ListNotificationsResponse response =
    *         storageClient.listNotificationsCallable().call(request);
-   *     for (Notification element : response.getResponsesList()) {
+   *     for (Notification element : response.getNotificationsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -2349,7 +2349,7 @@ public class StorageClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListObjectsResponse response = storageClient.listObjectsCallable().call(request);
-   *     for (Object element : response.getResponsesList()) {
+   *     for (Object element : response.getObjectsList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -3200,7 +3200,7 @@ public class StorageClient implements BackgroundResource {
    *           .build();
    *   while (true) {
    *     ListHmacKeysResponse response = storageClient.listHmacKeysCallable().call(request);
-   *     for (HmacKeyMetadata element : response.getResponsesList()) {
+   *     for (HmacKeyMetadata element : response.getHmacKeysList()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-java/issues/880

Uses the correct (e.g. proto-defined) repeated field name for paginated methods instead of the default name of 'responses'. 