### PR TITLE
fix: make `BetaApi` the `getHttpJsonOperationsClient()` in case of multitransport clients

### DIFF
--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -172,6 +172,7 @@ public class EchoClient implements BackgroundResource {
    * Returns the OperationsClient that can be used to query the status of a long-running operation
    * returned by another API method call.
    */
+  @BetaApi
   public final OperationsClient getHttpJsonOperationsClient() {
     return httpJsonOperationsClient;
   }


### PR DESCRIPTION
All multitransport user-facing features are already declared `BetaApi`, `getHttpJsonOperationsClient()` was missing it by  mistake.