### PR TITLE
feat(ast): add support for LambdaExpr to infer type from return expr type

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
@@ -25,8 +25,6 @@ import java.util.stream.Collectors;
 
 @AutoValue
 public abstract class LambdaExpr implements Expr {
-  @Override
-  public abstract TypeNode type();
 
   public abstract ImmutableList<VariableExpr> arguments();
 

--- a/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
@@ -26,7 +26,9 @@ import java.util.stream.Collectors;
 @AutoValue
 public abstract class LambdaExpr implements Expr {
   @Override
-  public abstract TypeNode type();
+  public TypeNode type() {
+    return returnExpr().expr().type();
+  }
 
   public abstract ImmutableList<VariableExpr> arguments();
 
@@ -42,21 +44,16 @@ public abstract class LambdaExpr implements Expr {
   public static Builder builder() {
     return new AutoValue_LambdaExpr.Builder()
         .setArguments(Collections.emptyList())
-        .setBody(Collections.emptyList())
-        .setType(TypeNode.VOID);
+        .setBody(Collections.emptyList());
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
-    abstract Builder setType(TypeNode type);
-
     public Builder setArguments(VariableExpr... arguments) {
       return setArguments(Arrays.asList(arguments));
     }
 
     public abstract Builder setArguments(List<VariableExpr> arguments);
-
-    abstract ReturnExpr returnExpr();
 
     public abstract Builder setBody(List<Statement> body);
 
@@ -69,13 +66,10 @@ public abstract class LambdaExpr implements Expr {
     public abstract LambdaExpr autoBuild();
 
     public LambdaExpr build() {
-      Preconditions.checkState(
-          !returnExpr().expr().type().equals(TypeNode.VOID),
-          "Lambdas cannot return void-typed expressions.");
-
-      setType(returnExpr().expr().type());
-
       LambdaExpr lambdaExpr = autoBuild();
+      Preconditions.checkState(
+          !lambdaExpr.returnExpr().expr().type().equals(TypeNode.VOID),
+          "Lambdas cannot return void-typed expressions.");
       // Must be a declaration.
       lambdaExpr.arguments().stream()
           .forEach(

--- a/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 
 @AutoValue
 public abstract class LambdaExpr implements Expr {
+  @Override
+  public abstract TypeNode type();
 
   public abstract ImmutableList<VariableExpr> arguments();
 

--- a/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
@@ -26,11 +26,7 @@ import java.util.stream.Collectors;
 @AutoValue
 public abstract class LambdaExpr implements Expr {
   @Override
-  public TypeNode type() {
-    // TODO(v2): Support set of FunctionalInterface  parameterized on the args and return type,
-    // which would enable assignment to an appropriate variable.
-    return TypeNode.VOID;
-  }
+  public abstract TypeNode type();
 
   public abstract ImmutableList<VariableExpr> arguments();
 
@@ -46,16 +42,21 @@ public abstract class LambdaExpr implements Expr {
   public static Builder builder() {
     return new AutoValue_LambdaExpr.Builder()
         .setArguments(Collections.emptyList())
-        .setBody(Collections.emptyList());
+        .setBody(Collections.emptyList())
+        .setType(TypeNode.VOID);
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
+    abstract Builder setType(TypeNode type);
+
     public Builder setArguments(VariableExpr... arguments) {
       return setArguments(Arrays.asList(arguments));
     }
 
     public abstract Builder setArguments(List<VariableExpr> arguments);
+
+    abstract ReturnExpr returnExpr();
 
     public abstract Builder setBody(List<Statement> body);
 
@@ -68,10 +69,13 @@ public abstract class LambdaExpr implements Expr {
     public abstract LambdaExpr autoBuild();
 
     public LambdaExpr build() {
-      LambdaExpr lambdaExpr = autoBuild();
       Preconditions.checkState(
-          !lambdaExpr.returnExpr().expr().type().equals(TypeNode.VOID),
+          !returnExpr().expr().type().equals(TypeNode.VOID),
           "Lambdas cannot return void-typed expressions.");
+
+      setType(returnExpr().expr().type());
+
+      LambdaExpr lambdaExpr = autoBuild();
       // Must be a declaration.
       lambdaExpr.arguments().stream()
           .forEach(

--- a/src/test/java/com/google/api/generator/engine/ast/LambdaExprTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/LambdaExprTest.java
@@ -14,6 +14,7 @@
 
 package com.google.api.generator.engine.ast;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
@@ -25,6 +26,15 @@ public class LambdaExprTest {
     LambdaExpr.builder()
         .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
         .build();
+  }
+
+  @Test
+  public void validLambdaExpr_inferTypeFromReturnExpr() {
+    LambdaExpr lambdaExpr =
+        LambdaExpr.builder()
+            .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
+            .build();
+    assertEquals(TypeNode.STRING, lambdaExpr.type());
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
+++ b/src/test/java/com/google/api/generator/engine/writer/JavaWriterVisitorTest.java
@@ -2346,6 +2346,23 @@ public class JavaWriterVisitorTest {
   }
 
   @Test
+  public void writeLambdaExpr_assignToVariable() {
+    LambdaExpr lambdaExpr =
+        LambdaExpr.builder()
+            .setReturnExpr(ValueExpr.withValue(StringObjectValue.withValue("foo")))
+            .build();
+    AssignmentExpr assignmentExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(
+                VariableExpr.withVariable(
+                    Variable.builder().setName("word").setType(TypeNode.STRING).build()))
+            .setValueExpr(lambdaExpr)
+            .build();
+    assignmentExpr.accept(writerVisitor);
+    assertEquals("word = () -> \"foo\"", writerVisitor.write());
+  }
+
+  @Test
   public void writeLambdaExpr_oneParameter() {
     VariableExpr argVarExpr =
         VariableExpr.builder()


### PR DESCRIPTION
This will enable it to be assigned to an appropriate variable

**Before this change:**  cannot assign a lambda expression to a variable because its type is always `VOID`. 
**After this change:** lambda expression builder will infer type from `returnExpr`’s expression type. Allowing it to be assigned to an appropriate variable. Because `returnExpr` is a required field, its type should always be accessible.
**Example:** a naive sample usage is provided in [JavaWriterVisitorTest.java](https://github.com/googleapis/gapic-generator-java/pull/1011/files#diff-60163f71e845b4cc97f9ccd7101646aa243fa5317a77cd326a7f61143618f62f) as test. Another example is what I am trying to generate for spring autoconfig code: `this.projectIdProvider = () -> clientProperties.getProjectId();`. Ideally through method reference, but lambda assignment does the same thing and it’s an easier feature addition.