### PR TITLE
fix(ast): removed lambda void return type check

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
+++ b/src/main/java/com/google/api/generator/engine/ast/LambdaExpr.java
@@ -67,9 +67,6 @@ public abstract class LambdaExpr implements Expr {
 
     public LambdaExpr build() {
       LambdaExpr lambdaExpr = autoBuild();
-      Preconditions.checkState(
-          !lambdaExpr.returnExpr().expr().type().equals(TypeNode.VOID),
-          "Lambdas cannot return void-typed expressions.");
       // Must be a declaration.
       lambdaExpr.arguments().stream()
           .forEach(

--- a/src/test/java/com/google/api/generator/engine/ast/LambdaExprTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/LambdaExprTest.java
@@ -85,17 +85,16 @@ public class LambdaExprTest {
   }
 
   @Test
-  public void invalidLambdaExpr_returnsVoid() {
-    assertThrows(
-        IllegalStateException.class,
-        () ->
-            LambdaExpr.builder()
-                .setReturnExpr(
-                    MethodInvocationExpr.builder()
-                        .setMethodName("foo")
-                        .setReturnType(TypeNode.VOID)
-                        .build())
-                .build());
+  public void validLambdaExpr_returnsVoid() {
+    LambdaExpr voidLambda =
+        LambdaExpr.builder()
+            .setReturnExpr(
+                MethodInvocationExpr.builder()
+                    .setMethodName("foo")
+                    .setReturnType(TypeNode.VOID)
+                    .build())
+            .build();
+    assertEquals(TypeNode.VOID, voidLambda.returnExpr().type());
   }
 
   @Test


### PR DESCRIPTION
Fix for Issue #843. This pull request modifies allows the creation of lambda expressions that have _void_ as return type. The main change was made in `ast/LambdaExpr.java` 