### PR TITLE
feat: Add support for rest numeric enums.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,7 +33,7 @@ jvm_maven_import_external(
 # which in its turn, prioritizes actual generated clients runtime dependencies
 # over the generator dependencies.
 
-_gax_java_version = "2.12.2"
+_gax_java_version = "2.19.0"
 
 http_archive(
     name = "com_google_api_gax_java",

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -189,6 +189,7 @@ def _java_gapic_srcjar(
         service_yaml,
         # possible values are: "grpc", "rest", "grpc+rest"
         transport,
+        rest_numeric_enums,
         # Can be used to provide a java_library with a customized generator,
         # like the one which dumps descriptor to a file for future debugging.
         java_generator_name = "java_gapic",
@@ -212,6 +213,9 @@ def _java_gapic_srcjar(
 
     if transport:
         opt_args.append("transport=%s" % transport)
+
+    if rest_numeric_enums:
+        opt_args.append("rest-numeric-enums")
 
     # Produces the GAPIC metadata file if this flag is set. to any value.
     # Protoc invocation: --java_gapic_opt=metadata
@@ -240,6 +244,7 @@ def java_gapic_library(
         test_deps = [],
         # possible values are: "grpc", "rest", "grpc+rest"
         transport = None,
+        rest_numeric_enums = False,
         **kwargs):
     srcjar_name = name + "_srcjar"
     raw_srcjar_name = srcjar_name + "_raw"
@@ -251,6 +256,7 @@ def java_gapic_library(
         gapic_yaml = gapic_yaml,
         service_yaml = service_yaml,
         transport = transport,
+        rest_numeric_enums = rest_numeric_enums,
         java_generator_name = "java_gapic",
         **kwargs
     )
@@ -391,6 +397,7 @@ def java_generator_request_dump(
         gapic_yaml = None,
         service_yaml = None,
         transport = None,
+        rest_numeric_enums = False,
         **kwargs):
     _java_gapic_srcjar(
         name = name,
@@ -399,6 +406,7 @@ def java_generator_request_dump(
         gapic_yaml = gapic_yaml,
         service_yaml = service_yaml,
         transport = transport,
+        rest_numeric_enums = rest_numeric_enums,
         java_generator_name = "code_generator_request_dumper",
         **kwargs
     )

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -187,7 +187,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
             protoMethodNameToDescriptorVarExprs,
             callableClassMemberVarExprs,
             classMemberVarExprs,
-            messageTypes);
+            messageTypes,
+            context.restNumericEnumsEnabled());
 
     StubCommentComposer commentComposer =
         new StubCommentComposer(getTransportContext().transportNames().get(0));
@@ -225,7 +226,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
       Service service,
       Method protoMethod,
       VariableExpr methodDescriptorVarExpr,
-      Map<String, Message> messageTypes);
+      Map<String, Message> messageTypes,
+      boolean restNumericEnumsEnabled);
 
   protected boolean generateOperationsStubLogic(Service service) {
     return true;
@@ -274,7 +276,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
       Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs,
       Map<String, VariableExpr> callableClassMemberVarExprs,
       Map<String, VariableExpr> classMemberVarExprs,
-      Map<String, Message> messageTypes) {
+      Map<String, Message> messageTypes,
+      boolean restNumericEnumsEnabled) {
     List<Statement> classStatements = new ArrayList<>();
 
     classStatements.addAll(createTypeRegistry(service));
@@ -284,7 +287,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
     for (Statement statement :
         createMethodDescriptorVariableDecls(
-            service, protoMethodNameToDescriptorVarExprs, messageTypes)) {
+            service, protoMethodNameToDescriptorVarExprs, messageTypes, restNumericEnumsEnabled)) {
       classStatements.add(statement);
       classStatements.add(EMPTY_LINE_STATEMENT);
     }
@@ -301,13 +304,18 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
   protected List<Statement> createMethodDescriptorVariableDecls(
       Service service,
       Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs,
-      Map<String, Message> messageTypes) {
+      Map<String, Message> messageTypes,
+      boolean restNumericEnumsEnabled) {
     return service.methods().stream()
         .filter(this::isSupportedMethod)
         .map(
             m ->
                 createMethodDescriptorVariableDecl(
-                    service, m, protoMethodNameToDescriptorVarExprs.get(m.name()), messageTypes))
+                    service,
+                    m,
+                    protoMethodNameToDescriptorVarExprs.get(m.name()),
+                    messageTypes,
+                    restNumericEnumsEnabled))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -95,7 +95,8 @@ public class GrpcServiceStubClassComposer extends AbstractTransportServiceStubCl
       Service service,
       Method protoMethod,
       VariableExpr methodDescriptorVarExpr,
-      Map<String, Message> messageTypes) {
+      Map<String, Message> messageTypes,
+      boolean restNumericEnumsEnabled) {
     MethodInvocationExpr methodDescriptorMaker =
         MethodInvocationExpr.builder()
             .setMethodName("newBuilder")

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -129,7 +129,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       Service service,
       Method protoMethod,
       VariableExpr methodDescriptorVarExpr,
-      Map<String, Message> messageTypes) {
+      Map<String, Message> messageTypes,
+      boolean restNumericEnumsEnabled) {
     MethodInvocationExpr expr =
         MethodInvocationExpr.builder()
             .setMethodName("newBuilder")
@@ -152,7 +153,11 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
     expr = methodMaker.apply("setHttpMethod", getHttpMethodTypeExpr(protoMethod)).apply(expr);
     expr = methodMaker.apply("setType", getMethodTypeExpr(protoMethod)).apply(expr);
     expr =
-        methodMaker.apply("setRequestFormatter", getRequestFormatterExpr(protoMethod)).apply(expr);
+        methodMaker
+            .apply(
+                "setRequestFormatter",
+                getRequestFormatterExpr(protoMethod, restNumericEnumsEnabled))
+            .apply(expr);
     expr = methodMaker.apply("setResponseParser", setResponseParserExpr(protoMethod)).apply(expr);
 
     if (protoMethod.isOperationPollingMethod() || protoMethod.hasLro()) {
@@ -320,7 +325,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                 .build();
   }
 
-  private List<Expr> getRequestFormatterExpr(Method protoMethod) {
+  private List<Expr> getRequestFormatterExpr(Method protoMethod, boolean restNumericEnumsEnabled) {
     BiFunction<String, List<Expr>, Function<MethodInvocationExpr, MethodInvocationExpr>>
         methodMaker = getMethodMaker();
 
@@ -351,7 +356,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                         protoMethod,
                         extractorVarType,
                         protoMethod.httpBindings().pathParameters(),
-                        "putPathParam")))
+                        "putPathParam",
+                        restNumericEnumsEnabled)))
             .apply(expr);
 
     if (!protoMethod.httpBindings().lowerCamelAdditionalPatterns().isEmpty()) {
@@ -387,7 +393,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                         protoMethod,
                         extractorVarType,
                         protoMethod.httpBindings().queryParameters(),
-                        "putQueryParam")))
+                        "putQueryParam",
+                        restNumericEnumsEnabled)))
             .apply(expr);
 
     extractorVarType = TypeNode.STRING;
@@ -404,7 +411,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                             ? protoMethod.httpBindings().pathParameters()
                             : protoMethod.httpBindings().bodyParameters(),
                         "toBody",
-                        asteriskBody)))
+                        asteriskBody,
+                        restNumericEnumsEnabled)))
             .apply(expr);
     expr = methodMaker.apply("build", Collections.emptyList()).apply(expr);
 
@@ -771,7 +779,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       TypeNode extractorReturnType,
       Set<HttpBinding> httpBindingFieldNames,
       String serializerMethodName,
-      boolean asteriskBody) {
+      boolean asteriskBody,
+      boolean restNumericEnumEnabled) {
     List<Statement> bodyStatements = new ArrayList<>();
 
     Expr returnExpr = null;
@@ -787,7 +796,6 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
             Variable.builder().setType(method.inputType()).setName("request").build());
     Expr bodyRequestExpr = requestVarExpr;
     String requestMethodPrefix = "get";
-    String bodyParamName = null;
 
     if (asteriskBody) {
       bodyRequestExpr =
@@ -805,7 +813,6 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       // Handle foo.bar cases by descending into the subfields.
       MethodInvocationExpr.Builder requestFieldMethodExprBuilder =
           MethodInvocationExpr.builder().setExprReferenceExpr(prevExpr);
-      bodyParamName = JavaStyle.toLowerCamelCase(httpBindingFieldName.name());
       String[] descendantFields = httpBindingFieldName.name().split("\\.");
       if (asteriskBody && descendantFields.length > 1) {
         // This is the `body: "*"` case, do not clean nested body fields as it a very rare, not
@@ -839,10 +846,15 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                 .setExprReferenceExpr(prevExpr)
                 .setMethodName("build")
                 .build();
-        bodyParamName = "*";
       }
-      paramsPutArgs.add(ValueExpr.withValue(StringObjectValue.withValue(bodyParamName)));
       paramsPutArgs.add(prevExpr);
+
+      PrimitiveValue primitiveValue =
+          PrimitiveValue.builder()
+              .setType(TypeNode.BOOLEAN)
+              .setValue(String.valueOf(restNumericEnumEnabled))
+              .build();
+      paramsPutArgs.add(ValueExpr.withValue(primitiveValue));
 
       returnExpr =
           MethodInvocationExpr.builder()
@@ -866,7 +878,8 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       Method method,
       TypeNode extractorReturnType,
       Set<HttpBinding> httpBindingFieldNames,
-      String serializerMethodName) {
+      String serializerMethodName,
+      boolean restNumericEnumsEnabled) {
     List<Statement> bodyStatements = new ArrayList<>();
 
     VariableExpr fieldsVarExpr =
@@ -978,6 +991,23 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       } else {
         bodyStatements.add(ExprStatement.withExpr(paramsPutExpr));
       }
+    }
+
+    if (restNumericEnumsEnabled && serializerMethodName.equals("putQueryParam")) {
+      ImmutableList.Builder<Expr> paramsPutArgs = ImmutableList.builder();
+
+      paramsPutArgs.add(fieldsVarExpr);
+      paramsPutArgs.add(ValueExpr.withValue(StringObjectValue.withValue("$alt")));
+      paramsPutArgs.add(ValueExpr.withValue(StringObjectValue.withValue("json;enum-encoding=int")));
+
+      Expr paramsPutExpr =
+          MethodInvocationExpr.builder()
+              .setExprReferenceExpr(serializerVarExpr)
+              .setMethodName(serializerMethodName)
+              .setArguments(paramsPutArgs.build())
+              .setReturnType(extractorReturnType)
+              .build();
+      bodyStatements.add(ExprStatement.withExpr(paramsPutExpr));
     }
 
     // Overrides FieldsExtractor

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -796,6 +796,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
             Variable.builder().setType(method.inputType()).setName("request").build());
     Expr bodyRequestExpr = requestVarExpr;
     String requestMethodPrefix = "get";
+    String bodyParamName = null;
 
     if (asteriskBody) {
       bodyRequestExpr =
@@ -813,6 +814,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       // Handle foo.bar cases by descending into the subfields.
       MethodInvocationExpr.Builder requestFieldMethodExprBuilder =
           MethodInvocationExpr.builder().setExprReferenceExpr(prevExpr);
+      bodyParamName = JavaStyle.toLowerCamelCase(httpBindingFieldName.name());
       String[] descendantFields = httpBindingFieldName.name().split("\\.");
       if (asteriskBody && descendantFields.length > 1) {
         // This is the `body: "*"` case, do not clean nested body fields as it a very rare, not
@@ -846,7 +848,9 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                 .setExprReferenceExpr(prevExpr)
                 .setMethodName("build")
                 .build();
+        bodyParamName = "*";
       }
+      paramsPutArgs.add(ValueExpr.withValue(StringObjectValue.withValue(bodyParamName)));
       paramsPutArgs.add(prevExpr);
 
       PrimitiveValue primitiveValue =

--- a/src/main/java/com/google/api/generator/gapic/model/GapicContext.java
+++ b/src/main/java/com/google/api/generator/gapic/model/GapicContext.java
@@ -47,6 +47,8 @@ public abstract class GapicContext {
 
   public abstract boolean gapicMetadataEnabled();
 
+  public abstract boolean restNumericEnumsEnabled();
+
   public GapicMetadata gapicMetadata() {
     return gapicMetadata;
   }
@@ -81,7 +83,8 @@ public abstract class GapicContext {
   public static Builder builder() {
     return new AutoValue_GapicContext.Builder()
         .setMixinServices(Collections.emptyList())
-        .setGapicMetadataEnabled(false);
+        .setGapicMetadataEnabled(false)
+        .setRestNumericEnumsEnabled(false);
   }
 
   @AutoValue.Builder
@@ -107,6 +110,8 @@ public abstract class GapicContext {
     public abstract Builder setServiceYamlProto(com.google.api.Service serviceYamlProto);
 
     public abstract Builder setGapicMetadataEnabled(boolean gapicMetadataEnabled);
+
+    public abstract Builder setRestNumericEnumsEnabled(boolean restNumericEnumsEnabled);
 
     public abstract Builder setTransport(Transport transport);
 

--- a/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -120,6 +120,7 @@ public class Parser {
     Optional<String> transportOpt = PluginArgumentParser.parseTransport(request);
 
     boolean willGenerateMetadata = PluginArgumentParser.hasMetadataFlag(request);
+    boolean willGenerateNumericEnum = PluginArgumentParser.hasNumericEnumFlag(request);
 
     Optional<String> serviceConfigPathOpt = PluginArgumentParser.parseJsonConfigPath(request);
     Optional<GapicServiceConfig> serviceConfigOpt =
@@ -216,6 +217,7 @@ public class Parser {
         .setGapicMetadataEnabled(willGenerateMetadata)
         .setServiceYamlProto(serviceYamlProtoOpt.orElse(null))
         .setTransport(transport)
+        .setRestNumericEnumsEnabled(willGenerateNumericEnum)
         .build();
   }
 

--- a/src/main/java/com/google/api/generator/gapic/protoparser/PluginArgumentParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/PluginArgumentParser.java
@@ -95,7 +95,7 @@ public class PluginArgumentParser {
 
   @VisibleForTesting
   static boolean hasFlag(String pluginProtocArgument, String flagKey) {
-    return Arrays.asList(pluginProtocArgument.split(COMMA)).contains(flagKey);
+    return Arrays.stream(pluginProtocArgument.split(COMMA)).anyMatch(s -> s.equals(flagKey));
   }
 
   private static Optional<String> parseFileArgument(

--- a/src/main/java/com/google/api/generator/gapic/protoparser/PluginArgumentParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/PluginArgumentParser.java
@@ -29,6 +29,7 @@ public class PluginArgumentParser {
   @VisibleForTesting static final String KEY_GRPC_SERVICE_CONFIG = "grpc-service-config";
   @VisibleForTesting static final String KEY_GAPIC_CONFIG = "gapic-config";
   @VisibleForTesting static final String KEY_METADATA = "metadata";
+  @VisibleForTesting static final String KEY_NUMERIC_ENUM = "rest-numeric-enums";
   @VisibleForTesting static final String KEY_SERVICE_YAML_CONFIG = "api-service-config";
   @VisibleForTesting static final String KEY_TRANSPORT = "transport";
 
@@ -53,7 +54,11 @@ public class PluginArgumentParser {
   }
 
   static boolean hasMetadataFlag(CodeGeneratorRequest request) {
-    return hasMetadataFlag(request.getParameter());
+    return hasFlag(request.getParameter(), KEY_METADATA);
+  }
+
+  static boolean hasNumericEnumFlag(CodeGeneratorRequest request) {
+    return hasFlag(request.getParameter(), KEY_NUMERIC_ENUM);
   }
 
   /** Expects a comma-separated list of file paths. */
@@ -89,8 +94,8 @@ public class PluginArgumentParser {
   }
 
   @VisibleForTesting
-  static boolean hasMetadataFlag(String pluginProtocArgument) {
-    return Arrays.stream(pluginProtocArgument.split(COMMA)).anyMatch(s -> s.equals(KEY_METADATA));
+  static boolean hasFlag(String pluginProtocArgument, String flagKey) {
+    return Arrays.asList(pluginProtocArgument.split(COMMA)).contains(flagKey);
   }
 
   private static Optional<String> parseFileArgument(

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -78,7 +78,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()
@@ -112,7 +112,7 @@ public class HttpJsonEchoStub extends EchoStub {
                         return fields;
                       })
                   .setRequestBodyExtractor(
-                      request -> ProtoRestSerializer.create().toBody("error", request.getError()))
+                      request -> ProtoRestSerializer.create().toBody(request.getError(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()
@@ -146,7 +146,8 @@ public class HttpJsonEchoStub extends EchoStub {
                           })
                       .setRequestBodyExtractor(
                           request ->
-                              ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                              ProtoRestSerializer.create()
+                                  .toBody(request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
@@ -180,7 +181,8 @@ public class HttpJsonEchoStub extends EchoStub {
                           })
                       .setRequestBodyExtractor(
                           request ->
-                              ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                              ProtoRestSerializer.create()
+                                  .toBody(request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
@@ -211,7 +213,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Operation>newBuilder()
@@ -245,7 +247,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<BlockResponse>newBuilder()
@@ -276,7 +278,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Object>newBuilder()
@@ -312,7 +314,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Object>newBuilder()

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -78,7 +78,8 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
+                          ProtoRestSerializer.create()
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()
@@ -112,7 +113,8 @@ public class HttpJsonEchoStub extends EchoStub {
                         return fields;
                       })
                   .setRequestBodyExtractor(
-                      request -> ProtoRestSerializer.create().toBody(request.getError(), false))
+                      request ->
+                          ProtoRestSerializer.create().toBody("error", request.getError(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()
@@ -147,7 +149,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody(request.toBuilder().build(), false))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
@@ -182,7 +184,7 @@ public class HttpJsonEchoStub extends EchoStub {
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody(request.toBuilder().build(), false))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
@@ -213,7 +215,8 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
+                          ProtoRestSerializer.create()
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Operation>newBuilder()
@@ -247,7 +250,8 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
+                          ProtoRestSerializer.create()
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<BlockResponse>newBuilder()
@@ -278,7 +282,8 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
+                          ProtoRestSerializer.create()
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Object>newBuilder()
@@ -314,7 +319,8 @@ public class HttpJsonEchoStub extends EchoStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody(request.toBuilder().build(), false))
+                          ProtoRestSerializer.create()
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Object>newBuilder()

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/RestTestProtoLoader.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/RestTestProtoLoader.java
@@ -73,6 +73,7 @@ public class RestTestProtoLoader extends TestProtoLoader {
         .setServiceConfig(config)
         .setHelperResourceNames(outputResourceNames)
         .setTransport(getTransport())
+        .setRestNumericEnumsEnabled(true)
         .build();
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
@@ -55,11 +55,13 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<RepeatRequest> serializer =
                                 ProtoRestSerializer.create();
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
-                              ProtoRestSerializer.create().toBody("*", request.toBuilder().build()))
+                              ProtoRestSerializer.create()
+                                  .toBody(request.toBuilder().build(), true))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -92,10 +94,11 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             serializer.putQueryParam(fields, "name", request.getName());
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
-                          request -> ProtoRestSerializer.create().toBody("info", request.getInfo()))
+                          request -> ProtoRestSerializer.create().toBody(request.getInfo(), true))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -129,6 +132,7 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             serializer.putQueryParam(fields, "name", request.getName());
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -177,6 +181,7 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             serializer.putQueryParam(fields, "name", request.getName());
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -223,6 +228,7 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             serializer.putQueryParam(fields, "name", request.getName());
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -266,6 +272,7 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             serializer.putQueryParam(fields, "name", request.getName());
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
+                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)

--- a/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
@@ -61,7 +61,7 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody(request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), true))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -98,7 +98,8 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             return fields;
                           })
                       .setRequestBodyExtractor(
-                          request -> ProtoRestSerializer.create().toBody(request.getInfo(), true))
+                          request ->
+                              ProtoRestSerializer.create().toBody("info", request.getInfo(), true))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()

--- a/src/test/java/com/google/api/generator/gapic/protoparser/PluginArgumentParserTest.java
+++ b/src/test/java/com/google/api/generator/gapic/protoparser/PluginArgumentParserTest.java
@@ -14,10 +14,13 @@
 
 package com.google.api.generator.gapic.protoparser;
 
+import static com.google.api.generator.gapic.protoparser.PluginArgumentParser.KEY_METADATA;
+import static com.google.api.generator.gapic.protoparser.PluginArgumentParser.KEY_NUMERIC_ENUM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -226,26 +229,44 @@ public class PluginArgumentParserTest {
   }
 
   @Test
-  public void parseMetadataFlag_noneFound() {
+  public void hasMetadataFlag() {
+    CodeGeneratorRequest request =
+        CodeGeneratorRequest.newBuilder()
+            .setParameter(String.join(",", KEY_METADATA, "does-not-matter"))
+            .build();
+    assertTrue(PluginArgumentParser.hasMetadataFlag(request));
+  }
+
+  @Test
+  public void hasNumericEnumFlag() {
+    CodeGeneratorRequest request =
+        CodeGeneratorRequest.newBuilder()
+            .setParameter(String.join(",", KEY_NUMERIC_ENUM, "does-not-matter"))
+            .build();
+    assertTrue(PluginArgumentParser.hasNumericEnumFlag(request));
+  }
+
+  @Test
+  public void hasFlag_noneFound() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =
         String.join(",", Arrays.asList(createGrpcServiceConfig(jsonPath), gapicPath));
-    assertFalse(PluginArgumentParser.hasMetadataFlag(rawArgument));
+    assertFalse(PluginArgumentParser.hasFlag(rawArgument, KEY_METADATA));
 
     // Wrong casing.
     rawArgument =
         String.join(",", Arrays.asList("Metadata", createGrpcServiceConfig(jsonPath), gapicPath));
-    assertFalse(PluginArgumentParser.hasMetadataFlag(rawArgument));
+    assertFalse(PluginArgumentParser.hasFlag(rawArgument, KEY_METADATA));
   }
 
   @Test
-  public void parseMetadataFlag_flagFound() {
+  public void hasFlag_flagFound() {
     String jsonPath = "/tmp/foo_grpc_service_config.json";
     String gapicPath = "";
     String rawArgument =
         String.join(",", Arrays.asList("metadata", createGrpcServiceConfig(jsonPath), gapicPath));
-    assertTrue(PluginArgumentParser.hasMetadataFlag(rawArgument));
+    assertTrue(PluginArgumentParser.hasFlag(rawArgument, KEY_METADATA));
   }
 
   private static String createGrpcServiceConfig(String path) {

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
@@ -192,8 +192,7 @@ public class HttpJsonAddressesStub extends AddressesStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create()
-                              .toBody("addressResource", request.getAddressResource()))
+                          ProtoRestSerializer.create().toBody(request.getAddressResource(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Operation>newBuilder()

--- a/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
+++ b/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
@@ -192,7 +192,8 @@ public class HttpJsonAddressesStub extends AddressesStub {
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody(request.getAddressResource(), false))
+                          ProtoRestSerializer.create()
+                              .toBody("addressResource", request.getAddressResource(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Operation>newBuilder()


### PR DESCRIPTION
See b/232457244 for exact requirements. In short, this PR added four things:
1. Add a flag to the Java microgenerator Bazel plugin to determine whether we need to generate a client library that supports rest numeric enums. This flag is to make sure we only generate client libraries with numeric enums for the services that have already upgraded to the latest ESF. See go/gapic-numericenum-release for details.
2. Serialize enum object to int if the above flag is set to true
3. Add a query parameter `$alt=json;enum-encoding=int` to every request if the above flag is set to true so that the backend will return response with numeric enums.
4. Upgrade gax-java to the latest since it's dependent on https://github.com/googleapis/gax-java/pull/1743.