### PR TITLE
fix(bazel): do not emit empty rm commands

### DIFF
--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -269,7 +269,7 @@ def _java_gapic_srcs_pkg_impl(ctx):
 
         # Remove empty files. If there are no resource names, one such file might have
         # been created. See java_gapic.bzl.
-        rm $(find {package_dir_path}/src/main/java -size 0)
+        find {package_dir_path}/src/main/java -type f -size 0 | while read f; do rm -f $f; done
 
         if [ -d {package_dir_path}/src/main/java/samples ]; then
             mv {package_dir_path}/src/main/java/samples {package_dir_path}


### PR DESCRIPTION
The googleapis Bazel build logs have a lot of

```
INFO: From Action google/cloud/aiplatform/v1beta1/proto-google-cloud-aiplatform-v1beta1-java-srcs_pkg.tar.gz:
rm: missing operand
Try 'rm --help' for more information.
rm: missing operand
Try 'rm --help' for more information.
rm: missing operand
Try 'rm --help' for more information.
rm: missing operand
Try 'rm --help' for more information.
rm: missing operand
Try 'rm --help' for more information.
rm: missing operand
Try 'rm --help' for more information.
```

I'm assuming it can only come from the line I'm changing here, in case if there are no files with zero size. I'm changing it so that it will only called `rm` if needed.