### PR TITLE
fix(bazel): do not print current working directory

### DIFF
--- a/rules_java_gapic/java_gapic_pkg.bzl
+++ b/rules_java_gapic/java_gapic_pkg.bzl
@@ -87,7 +87,7 @@ def _gapic_pkg_tar_impl(ctx):
     cd {package_dir_path}/{tar_cd_suffix}
 
     tar -zchpf {tar_prefix}/{package_dir}.tar.gz {tar_prefix}/*
-    cd -
+    cd - > /dev/null
     mv {package_dir_path}/{package_dir}.tar.gz {pkg}
     rm -rf {package_dir_path}
     """.format(
@@ -213,7 +213,7 @@ def _java_gapic_build_configs_pkg_impl(ctx):
     chmod 644 {package_dir_path}/*
     cd {package_dir_path}/{tar_cd_suffix}
     tar -zchpf {tar_prefix}/{package_dir}.tar.gz {tar_prefix}/*
-    cd -
+    cd - > /dev/null
     mv {package_dir_path}/{package_dir}.tar.gz {pkg}
     """.format(
         templates = " ".join(["'%s'" % f.path for f in expanded_templates]),
@@ -286,7 +286,7 @@ def _java_gapic_srcs_pkg_impl(ctx):
     done
     cd {package_dir_path}/{tar_cd_suffix}
     tar -zchpf {tar_prefix}/{package_dir}.tar.gz {tar_prefix}/*
-    cd -
+    cd - > /dev/null
     mv {package_dir_path}/{package_dir}.tar.gz {pkg}
     """.format(
         srcs = " ".join(["'%s'" % f.path for f in srcs]),


### PR DESCRIPTION
Each use of `cd -` prints the directory it's returning to. Let's not print it to save some log lines.

```
INFO: From Action google/cloud/commerce/consumer/procurement/v1alpha1/google-cloud-consumer-procurement-v1alpha1-java.tar.gz:
/bazel_root/1d081bf08a15278ca34ce779797e8450/sandbox/processwrapper-sandbox/15758/execroot/com_google_googleapis
INFO: From Action google/cloud/videointelligence/v1/gapi-cloud-videointelligence-v1-go.tar.gz:
/bazel_root/1d081bf08a15278ca34ce779797e8450/sandbox/processwrapper-sandbox/25287/execroot/com_google_googleapis
```
