### PR TITLE
fix(Spring CodeGen): Add Spring dependencies to build files and use static types instead of vapor references

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,7 +52,7 @@ SPING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_autoconfigure",
     "@maven//:org_springframework_boot_spring_boot",
     "@maven//:org_springframework_spring_context",
-    "@maven//:com_google_cloud_spring_cloud_gcp_core"
+    "@maven//:com_google_cloud_spring_cloud_gcp_core",
 ]
 
 proto_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,8 @@ SPING_DEPS = [
     "@maven//:org_springframework_boot_spring_boot_starter",
     "@maven//:org_springframework_boot_spring_boot_autoconfigure",
     "@maven//:org_springframework_boot_spring_boot",
+    "@maven//:org_springframework_spring_context",
+    "@maven//:com_google_cloud_spring_cloud_gcp_core"
 ]
 
 proto_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,6 +47,12 @@ TEST_DEPS = [
     "@io_github_java_diff_utils//jar",
 ]
 
+SPING_DEPS = [
+    "@maven//:org_springframework_boot_spring_boot_starter",
+    "@maven//:org_springframework_boot_spring_boot_autoconfigure",
+    "@maven//:org_springframework_boot_spring_boot",
+]
+
 proto_library(
     name = "service_config_proto",
     srcs = ["src/main/proto/service_config.proto"],
@@ -100,7 +106,7 @@ java_library(
     name = "gapic_generator_java",
     srcs = glob(["src/main/java/**/*.java"]),
     plugins = [":autovalue_plugin"],
-    deps = MAIN_DEPS,
+    deps = MAIN_DEPS + SPING_DEPS,
 )
 
 java_library(
@@ -112,7 +118,7 @@ java_library(
 java_binary(
     name = "protoc-gen-java_gapic",
     main_class = "com.google.api.generator.Main",
-    runtime_deps = [":gapic_generator_java"] + MAIN_DEPS,
+    runtime_deps = [":gapic_generator_java"] + MAIN_DEPS + SPING_DEPS,
 )
 
 # Request dumper binary, which dumps the CodeGeneratorRequest to a file on disk

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,8 +79,13 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "pr
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+
+SRING_MAVEN_ARTIFACTS = [
+    "org.springframework.boot:spring-boot-starter:2.6.9",
+]
+
 maven_install(
-    artifacts = PROTOBUF_MAVEN_ARTIFACTS,
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS + SRING_MAVEN_ARTIFACTS,
     generate_compat_repositories = True,
     repositories = [
         "https://repo.maven.apache.org/maven2/",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,6 +82,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 SRING_MAVEN_ARTIFACTS = [
     "org.springframework.boot:spring-boot-starter:2.6.9",
+    "com.google.cloud:spring-cloud-gcp-core:3.3.0",
 ]
 
 maven_install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,7 +81,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 
 SRING_MAVEN_ARTIFACTS = [
-    "org.springframework.boot:spring-boot-starter:2.6.9",
+    "org.springframework.boot:spring-boot-starter:2.7.4",
     "com.google.cloud:spring-cloud-gcp-core:3.3.0",
 ]
 

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -225,13 +225,19 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     AnnotationNode conditionalOnPropertyNode =
         AnnotationNode.builder()
             .setType(STATIC_TYPES.get("ConditionalOnProperty"))
-            .setDescription("value = \"spring.cloud.gcp.language.enabled\", matchIfMissing = false")
+            .setDescription(
+                "value = \""
+                    + Utils.springPropertyPrefix(libName, service.name())
+                    + ".enabled\", matchIfMissing = false")
             .build();
     AnnotationNode conditionalOnClassNode =
         AnnotationNode.builder()
             .setType(STATIC_TYPES.get("ConditionalOnClass"))
-            // TODO: change after annotation feature merged. need to produce XXX.class
-            .setDescription("value = " + ClassNames.getServiceClientClassName(service) + ".class")
+            .setDescription(
+                "value = "
+                    + ClassNames.getServiceClientClassName(service)
+                    + ".class") // TODO: change after annotation feature merged. need to produce
+            // XXX.class
             .build();
     AnnotationNode configurationNode =
         AnnotationNode.builder()
@@ -778,6 +784,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             VaporReference.builder()
                 .setName(service.name() + "SpringAutoConfig")
                 .setPakkage(packageName)
+                .build());
 
     TypeNode serviceClient =
         TypeNode.withReference(
@@ -801,9 +808,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     typeMap.put(service.name() + "Properties", clientProperties);
     typeMap.put(service.name() + "AutoConfig", clientAutoconfig);
-    typeMap.put("GcpProjectIdProvider", gcpProjectIdProvider);
-    typeMap.put("Credentials", credentials);
-    typeMap.put("DefaultCredentialsProvider", defaultCredentialsProvider);
     typeMap.put("ServiceClient", serviceClient);
     typeMap.put("ServiceSettings", serviceSettings);
     typeMap.put("ServiceSettingsBuilder", serviceSettingsBuilder);

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -139,22 +139,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
       GapicServiceConfig serviceConfig) {
 
     String serviceName = service.name();
-    // TODO create CredentialsProvider bean instead.
-    // // private final CredentialsProvider credentialsProvider;
-    // Variable credentialsProviderVar =
-    //     Variable.builder()
-    //         .setName("credentialsProvider")
-    //         .setType(types.get("CredentialsProvider"))
-    //         .build();
-    // VariableExpr credentialsProviderVarExpr =
-    //     VariableExpr.builder()
-    //         .setVariable(credentialsProviderVar)
-    //         .setScope(ScopeNode.PRIVATE)
-    //         .setIsFinal(true)
-    //         .setIsDecl(true)
-    //         .build();
-    // ExprStatement credentialsProviderVarStatement =
-    //     ExprStatement.withExpr(credentialsProviderVarExpr);
 
     // private final LanguageProperties clientProperties;
     Variable clientPropertiesVar =
@@ -170,21 +154,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .setIsDecl(true)
             .build();
     ExprStatement clientPropertiesStatement = ExprStatement.withExpr(clientPropertiesVarExpr);
-
-    // // private final GcpProjectIdProvider projectIdProvider;
-    // Variable projectIdProviderVar =
-    //     Variable.builder()
-    //         .setName("projectIdProvider")
-    //         .setType(types.get("GcpProjectIdProvider"))
-    //         .build();
-    // VariableExpr projectIdProviderVarExpr =
-    //     VariableExpr.builder()
-    //         .setVariable(projectIdProviderVar)
-    //         .setScope(ScopeNode.PRIVATE)
-    //         .setIsFinal(true)
-    //         .setIsDecl(true)
-    //         .build();
-    // ExprStatement projectIdProviderStatement = ExprStatement.withExpr(projectIdProviderVarExpr);
 
     // Declare the RETRY_PARAM_DEFINITIONS map.
     ExprStatement retryPramStatement =
@@ -206,20 +175,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
   private static MethodDefinition createConstructor(
       String serviceName, String className, Map<String, TypeNode> types) {
-    /// constructor
-    // VariableExpr credentialsProviderBuilderVarExpr =
-    //     VariableExpr.withVariable(
-    //         Variable.builder()
-    //             .setName("coreCredentialsProvider")
-    //             .setType(types.get("CredentialsProvider"))
-    //             .build());
-    //
-    // VariableExpr coreProjectIdProviderVarExpr =
-    //     VariableExpr.withVariable(
-    //         Variable.builder()
-    //             .setName("coreProjectIdProvider")
-    //             .setType(types.get("GcpProjectIdProvider"))
-    //             .build());
 
     VariableExpr propertiesVarExpr =
         VariableExpr.withVariable(
@@ -227,11 +182,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
                 .setName("clientProperties")
                 .setType(types.get(serviceName + "Properties"))
                 .build());
-    // Variable projectIdProviderVar =
-    //     Variable.builder()
-    //         .setName("projectIdProvider")
-    //         .setType(types.get("GcpProjectIdProvider"))
-    //         .build();
+
     Variable clientPropertiesVar =
         Variable.builder()
             .setName("clientProperties")
@@ -253,147 +204,11 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     ExprStatement thisPropertiesAssignmentStatement =
         ExprStatement.withExpr(thisPropertiesAssignmentExpr);
 
-    // /**
-    //  * if (properties.getCredentials().hasKey()) { this.credentialsProvider = new
-    //  * DefaultCredentialsProvider(properties); } else { this.credentialsProvider =
-    //  * coreCredentialsProvider; }
-    //  */
-    //
-    // // expr: properties.getCredentials().hasKey()
-    //
-    // MethodInvocationExpr getCredentialsExpr =
-    //     MethodInvocationExpr.builder()
-    //         .setMethodName("getCredentials")
-    //         .setExprReferenceExpr(propertiesVarExpr)
-    //         .setReturnType(types.get("Credentials"))
-    //         .build();
-    // MethodInvocationExpr hasKeyExpr =
-    //     MethodInvocationExpr.builder()
-    //         .setMethodName("hasKey")
-    //         .setExprReferenceExpr(getCredentialsExpr)
-    //         .setReturnType(TypeNode.BOOLEAN)
-    //         .build();
-    //
-    // // if body: this.credentialsProvider = new DefaultCredentialsProvider(properties)
-    // CastExpr castExpr =
-    //     CastExpr.builder()
-    //         .setExpr(
-    //             NewObjectExpr.builder()
-    //                 .setType(types.get("DefaultCredentialsProvider"))
-    //                 .setArguments(propertiesVarExpr)
-    //                 .build())
-    //         .setType(types.get("CredentialsProvider"))
-    //         .build();
-    // Variable credentialsProviderVar =
-    //     Variable.builder()
-    //         .setName("credentialsProvider")
-    //         .setType(types.get("CredentialsProvider"))
-    //         .build();
-    // AssignmentExpr credentialsProviderssignExpr =
-    //     AssignmentExpr.builder()
-    //         .setVariableExpr(
-    //             VariableExpr.withVariable(credentialsProviderVar)
-    //                 .toBuilder()
-    //                 .setExprReferenceExpr(thisExpr)
-    //                 .build())
-    //         .setValueExpr(castExpr)
-    //         .build();
-    //
-    // // else body: this.credentialsProvider = coreCredentialsProvider;
-    // List<Expr> coreCredentialsProviderAssignmentExprs = new ArrayList<>();
-    // coreCredentialsProviderAssignmentExprs.add(
-    //     AssignmentExpr.builder()
-    //         .setVariableExpr(
-    //             VariableExpr.withVariable(credentialsProviderVar)
-    //                 .toBuilder()
-    //                 .setExprReferenceExpr(thisExpr)
-    //                 .build())
-    //         .setValueExpr(
-    //             CastExpr.builder()
-    //                 .setExpr(coreProjectIdProviderVarExpr)
-    //                 .setType(types.get("CredentialsProvider"))
-    //                 .build())
-    //         .build());
-    //
-    // IfStatement credentialIfStatement =
-    //     IfStatement.builder()
-    //         .setConditionExpr(hasKeyExpr)
-    //         .setBody(Arrays.asList(ExprStatement.withExpr(credentialsProviderssignExpr)))
-    //         .setElseBody(
-    //             coreCredentialsProviderAssignmentExprs.stream()
-    //                 .map(e -> ExprStatement.withExpr(e))
-    //                 .collect(Collectors.toList()))
-    //         .build();
-    //
-    // /**
-    //  * if (clientProperties.getProjectId() != null) { this.projectIdProvider =
-    //  * clientProperties::getProjectId; } else { this.projectIdProvider = coreProjectIdProvider; }
-    //  */
-    // // else body: this.projectIdProvider = coreProjectIdProvider;
-    // List<Expr> ctorAssignmentExprs = new ArrayList<>();
-    // ctorAssignmentExprs.add(
-    //     AssignmentExpr.builder()
-    //         .setVariableExpr(
-    //             VariableExpr.withVariable(projectIdProviderVar)
-    //                 .toBuilder()
-    //                 .setExprReferenceExpr(thisExpr)
-    //                 .build())
-    //         .setValueExpr(coreProjectIdProviderVarExpr)
-    //         .build());
-    //
-    // // expr: clientProperties.getProjectId() != null
-    // MethodInvocationExpr getProjectIdExpr =
-    //     MethodInvocationExpr.builder()
-    //         .setMethodName("getProjectId")
-    //         .setExprReferenceExpr(
-    //             VariableExpr.withVariable(clientPropertiesVar).toBuilder().build())
-    //         // .setStaticReferenceType(clientType)
-    //         .setReturnType(types.get("CredentialsProvider")) // fake it
-    //         .build();
-    // RelationalOperationExpr notEqualSentence =
-    //     RelationalOperationExpr.notEqualToWithExprs(getProjectIdExpr,
-    // ValueExpr.createNullExpr());
-    //
-    // // () -> clientProperties.getProjectId();
-    // LambdaExpr lambdaExpr = LambdaExpr.builder().setReturnExpr(getProjectIdExpr).build();
-    //
-    // // this.projectIdProvider = () -> clientProperties.getProjectId();
-    // AssignmentExpr projectIdProviderAssignExpr =
-    //     AssignmentExpr.builder()
-    //         .setVariableExpr(
-    //             VariableExpr.withVariable(projectIdProviderVar)
-    //                 .toBuilder()
-    //                 .setExprReferenceExpr(thisExpr)
-    //                 .build())
-    //         .setValueExpr(
-    //             CastExpr.builder()
-    //                 .setExpr(lambdaExpr)
-    //                 .setType(types.get("GcpProjectIdProvider"))
-    //                 .build())
-    //         .build();
-    //
-    // IfStatement projectIdProviderIfStatement =
-    //     IfStatement.builder()
-    //         .setConditionExpr(notEqualSentence)
-    //         .setBody(Arrays.asList(ExprStatement.withExpr(projectIdProviderAssignExpr)))
-    //         .setElseBody(
-    //             ctorAssignmentExprs.stream()
-    //                 .map(e -> ExprStatement.withExpr(e))
-    //                 .collect(Collectors.toList()))
-    //         .build();
-
     return MethodDefinition.constructorBuilder()
         .setScope(ScopeNode.PROTECTED)
         .setReturnType(types.get(className))
-        .setArguments(
-            Arrays.asList(
-                // credentialsProviderBuilderVarExpr.toBuilder().setIsDecl(true).build(),
-                // coreProjectIdProviderVarExpr.toBuilder().setIsDecl(true).build(),
-                propertiesVarExpr.toBuilder().setIsDecl(true).build()))
+        .setArguments(Arrays.asList(propertiesVarExpr.toBuilder().setIsDecl(true).build()))
         .setBody(Arrays.asList(thisPropertiesAssignmentStatement))
-        // credentialIfStatement,
-        // projectIdProviderIfStatement))
-        // .setThrowsExceptions(Arrays.asList(TypeNode.withExceptionClazz(IOException.class)))
         .build();
   }
 
@@ -415,11 +230,8 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     AnnotationNode conditionalOnClassNode =
         AnnotationNode.builder()
             .setType(STATIC_TYPES.get("ConditionalOnClass"))
-            .setDescription(
-                "value = "
-                    + ClassNames.getServiceClientClassName(service)
-                    + ".class") // TODO: change after annotation feature merged. need to produce
-            // XXX.class
+            // TODO: change after annotation feature merged. need to produce XXX.class
+            .setDescription("value = " + ClassNames.getServiceClientClassName(service) + ".class")
             .build();
     AnnotationNode configurationNode =
         AnnotationNode.builder()
@@ -657,8 +469,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(settingsBuilderExpr)
             .setMethodName("setHeaderProvider")
-            // .setArguments() //TODO add augument here to create new obj. Caveat: decide where to
-            // UserAgentHeaderProvider class first.
+            // .setArguments() //TODO: add augument here to create new obj from private class.
             .setReturnType(settingBuilderVariable.type())
             .build();
     AssignmentExpr settingCreateExpr =

--- a/src/main/java/com/google/api/generator/spring/composer/SpringComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringComposer.java
@@ -27,7 +27,6 @@ public class SpringComposer {
   public static List<GapicClass> composeServiceAutoConfigClasses(GapicContext context) {
     List<GapicClass> clazzes = new ArrayList<>();
     clazzes.addAll(generateClientAutoConfig(context));
-    // TODO: from context, explore if any property settings needed.
     return addApacheLicense(clazzes);
   }
 

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -78,9 +78,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     AnnotationNode classAnnotationNode =
         AnnotationNode.builder()
             .setType(STATIC_TYPES.get("ConfigurationProperties"))
-            .setDescription(
-                "google.cloud.spring.autoconfig."
-                    + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name()))
+            .setDescription(Utils.springPropertyPrefix(Utils.getLibName(context), service.name()))
             .build();
 
     ClassDefinition classDef =


### PR DESCRIPTION
Adding Spring related dependencies to build files and use static types instead of vapor references. 
Benefit of this change:
- easier to test
- less code change needed for future changes (e.g. package change of classes).

One caveat is that because `gapic-generator-java` is brought into `googleapis` as `http_archive` code addition to `googleapis` is also needed to include these libraries. Add below code snippet to [WORKSPACE](https://github.com/googleapis/googleapis/blob/38e8b447d173909d3b2fe8fdc3e6cbb3c85442fd/WORKSPACE#L239-L245):
```
SRING_MAVEN_ARTIFACTS = [
    "org.springframework.boot:spring-boot-starter:2.6.9",
    "com.google.cloud:spring-cloud-gcp-core:3.3.0",
]

maven_install(
    artifacts = PROTOBUF_MAVEN_ARTIFACTS + SRING_MAVEN_ARTIFACTS,
    generate_compat_repositories = True,
    repositories = [
        "https://repo.maven.apache.org/maven2/",
    ],
)

```

DO NOT MERGE AND HOLD THIS PR FOR NOW.