### PR TITLE
fix: extract and expose simple util methods from RetrySettingsComposer

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
@@ -14,8 +14,8 @@
 
 package com.google.api.generator.gapic.composer.common;
 
-import static com.google.api.generator.gapic.composer.utils.RetrySettingsUtils.createDurationOfMillisExpr;
-import static com.google.api.generator.gapic.composer.utils.RetrySettingsUtils.toValExpr;
+import static com.google.api.generator.gapic.composer.utils.ConvertToExprUtils.createDurationOfMillisExpr;
+import static com.google.api.generator.gapic.composer.utils.ConvertToExprUtils.toValExpr;
 
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;

--- a/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java
@@ -14,6 +14,9 @@
 
 package com.google.api.generator.gapic.composer.common;
 
+import static com.google.api.generator.gapic.composer.utils.RetrySettingsUtils.createDurationOfMillisExpr;
+import static com.google.api.generator.gapic.composer.utils.RetrySettingsUtils.toValExpr;
+
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -48,8 +51,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.protobuf.Duration;
-import com.google.protobuf.util.Durations;
 import com.google.rpc.Code;
 import io.grpc.serviceconfig.MethodConfig.RetryPolicy;
 import java.util.ArrayList;
@@ -676,38 +677,6 @@ public class RetrySettingsComposer {
 
   private static EnumRefExpr toStatusCodeEnumRefExpr(Code code) {
     return EnumRefExpr.builder().setType(STATUS_CODE_CODE_TYPE).setName(code.name()).build();
-  }
-
-  private static ValueExpr toValExpr(long longValue) {
-    return ValueExpr.withValue(
-        PrimitiveValue.builder()
-            .setType(TypeNode.LONG)
-            .setValue(String.format("%dL", longValue))
-            .build());
-  }
-
-  private static ValueExpr toValExpr(float floatValue) {
-    return toValExpr((double) floatValue);
-  }
-
-  private static ValueExpr toValExpr(double val) {
-    return ValueExpr.withValue(
-        PrimitiveValue.builder()
-            .setType(TypeNode.DOUBLE)
-            .setValue(String.format("%.1f", val))
-            .build());
-  }
-
-  private static ValueExpr toValExpr(Duration duration) {
-    return toValExpr(Durations.toMillis(duration));
-  }
-
-  private static MethodInvocationExpr createDurationOfMillisExpr(ValueExpr valExpr) {
-    return MethodInvocationExpr.builder()
-        .setStaticReferenceType(FIXED_TYPESTORE.get("Duration"))
-        .setMethodName("ofMillis")
-        .setArguments(valExpr)
-        .build();
   }
 
   private static TypeStore createStaticTypes() {

--- a/src/main/java/com/google/api/generator/gapic/composer/utils/ConvertToExprUtils.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/utils/ConvertToExprUtils.java
@@ -24,8 +24,8 @@ import com.google.protobuf.util.Durations;
 import java.util.Arrays;
 import java.util.List;
 
-/** Common utility methods to expose */
-public class RetrySettingsUtils {
+/** Common utility methods to convert to AST Expr */
+public class ConvertToExprUtils {
   private static final TypeStore FIXED_TYPESTORE = createStaticTypes();
 
   public static ValueExpr toValExpr(long longValue) {

--- a/src/main/java/com/google/api/generator/gapic/composer/utils/RetrySettingsUtils.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/utils/RetrySettingsUtils.java
@@ -57,6 +57,7 @@ public class RetrySettingsUtils {
         .setStaticReferenceType(FIXED_TYPESTORE.get("Duration"))
         .setMethodName("ofMillis")
         .setArguments(valExpr)
+        .setReturnType(FIXED_TYPESTORE.get("Duration"))
         .build();
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/utils/RetrySettingsUtils.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/utils/RetrySettingsUtils.java
@@ -1,0 +1,67 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.utils;
+
+import com.google.api.generator.engine.ast.MethodInvocationExpr;
+import com.google.api.generator.engine.ast.PrimitiveValue;
+import com.google.api.generator.engine.ast.TypeNode;
+import com.google.api.generator.engine.ast.ValueExpr;
+import com.google.api.generator.gapic.composer.store.TypeStore;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
+import java.util.Arrays;
+import java.util.List;
+
+/** Common utility methods to expose */
+public class RetrySettingsUtils {
+  private static final TypeStore FIXED_TYPESTORE = createStaticTypes();
+
+  public static ValueExpr toValExpr(long longValue) {
+    return ValueExpr.withValue(
+        PrimitiveValue.builder()
+            .setType(TypeNode.LONG)
+            .setValue(String.format("%dL", longValue))
+            .build());
+  }
+
+  public static ValueExpr toValExpr(float floatValue) {
+    return toValExpr((double) floatValue);
+  }
+
+  public static ValueExpr toValExpr(double val) {
+    return ValueExpr.withValue(
+        PrimitiveValue.builder()
+            .setType(TypeNode.DOUBLE)
+            .setValue(String.format("%.1f", val))
+            .build());
+  }
+
+  public static ValueExpr toValExpr(Duration duration) {
+    return toValExpr(Durations.toMillis(duration));
+  }
+
+  public static MethodInvocationExpr createDurationOfMillisExpr(ValueExpr valExpr) {
+    return MethodInvocationExpr.builder()
+        .setStaticReferenceType(FIXED_TYPESTORE.get("Duration"))
+        .setMethodName("ofMillis")
+        .setArguments(valExpr)
+        .build();
+  }
+
+  private static TypeStore createStaticTypes() {
+    List<Class<?>> concreteClazzes = Arrays.asList(org.threeten.bp.Duration.class);
+    return new TypeStore(concreteClazzes);
+  }
+}


### PR DESCRIPTION
Extract and expose some simple util methods from `RetrySettingsComposer` for use in Spring code.