### PR TITLE
fix(Spring CodeGen): Update and move naming-related logic into utils

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -163,7 +163,7 @@ public class SpringWriter {
     String path = "src/main/resources/META-INF";
     JarEntry jarEntry =
         new JarEntry(String.format("%s/additional-spring-configuration-metadata.json", path));
-    String libName = Utils.getLibName(context);
+    String packageName = context.services().get(0).pakkage();
     try {
       jos.putNextEntry(jarEntry);
       StringJoiner sb = new StringJoiner(",\n", "\n{\n    \"properties\": [\n", "\n    ]\n" + "}");
@@ -179,8 +179,8 @@ public class SpringWriter {
                               + "            \"description\": \"Auto-configure Google Cloud %s components.\",\n"
                               + "            \"defaultValue\": true\n"
                               + "        }",
-                          Utils.springPropertyPrefix(libName, service.name()),
-                          libName + "/" + service.name())));
+                          Utils.getSpringPropertyPrefix(packageName, service.name()),
+                          Utils.getLibName(context))));
 
       jos.write(sb.toString().getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -79,12 +79,11 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
   @Override
   public GapicClass generate(GapicContext context, Service service) {
-    String packageName = service.pakkage() + ".spring";
+    String packageName = Utils.getSpringPackageName(service.pakkage());
     Map<String, TypeNode> types = createDynamicTypes(service, packageName);
     String serviceName = service.name();
     String serviceNameLowerCamel = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceName);
     String className = getThisClassName(serviceName);
-    String libName = Utils.getLibName(context);
     String credentialsProviderName = serviceNameLowerCamel + "Credentials";
     String transportChannelProviderName = "default" + serviceName + "TransportChannelProvider";
     String clientName = serviceNameLowerCamel + "Client";
@@ -115,7 +114,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
                         clientName,
                         types,
                         gapicServiceConfig)))
-            .setAnnotations(createClassAnnotations(service, types, libName))
+            .setAnnotations(createClassAnnotations(service, types))
             .build();
     return GapicClass.create(kind, classDef);
   }
@@ -219,7 +218,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
   }
 
   private static List<AnnotationNode> createClassAnnotations(
-      Service service, Map<String, TypeNode> types, String libName) {
+      Service service, Map<String, TypeNode> types) {
     // @Generated("by gapic-generator-java")
     // @AutoConfiguration
     // @ConditionalOnClass(LanguageServiceClient.class)
@@ -234,7 +233,8 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .setValueExpr(
                 ValueExpr.withValue(
                     StringObjectValue.withValue(
-                        Utils.springPropertyPrefix(libName, service.name()) + ".enabled")))
+                        Utils.getSpringPropertyPrefix(service.pakkage(), service.name())
+                            + ".enabled")))
             .build();
     AssignmentExpr matchIfMissingAssignmentExpr =
         AssignmentExpr.builder()

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -64,7 +64,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
 
   @Override
   public GapicClass generate(GapicContext context, Service service) {
-    String packageName = service.pakkage() + ".spring";
+    String packageName = Utils.getSpringPackageName(service.pakkage());
     String className = String.format(CLASS_NAME_PATTERN, service.name());
     GapicServiceConfig gapicServiceConfig = context.serviceConfig();
     Map<String, TypeNode> types = createDynamicTypes(service, packageName);
@@ -74,7 +74,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     AnnotationNode classAnnotationNode =
         AnnotationNode.builder()
             .setType(types.get("ConfigurationProperties"))
-            .setDescription(Utils.springPropertyPrefix(Utils.getLibName(context), service.name()))
+            .setDescription(Utils.getSpringPropertyPrefix(service.pakkage(), service.name()))
             .build();
 
     ClassDefinition classDef =

--- a/src/main/java/com/google/api/generator/spring/composer/Utils.java
+++ b/src/main/java/com/google/api/generator/spring/composer/Utils.java
@@ -44,18 +44,46 @@ public class Utils {
   private static final String BRAND_NAME = "spring.cloud.gcp";
 
   public static String getLibName(GapicContext context) {
-    String pakkageName = context.services().get(0).pakkage();
-    List<String> pakkagePhrases = Splitter.on(".").splitToList(pakkageName);
-    // TODO: confirm if this is guaranteed pattern: xx.[...].xx.lib-name.v[version]
+    // Returns parsed name of client library
+    // This should only be used in descriptive context, such as metadata and javadocs
+
+    // Option 1: Use title from service yaml if available (e.g. Client Library Showcase API)
+    // However, service yaml is optionally parsed and not always available
+    //    if (context.hasServiceYamlProto()
+    //        && !Strings.isNullOrEmpty(context.serviceYamlProto().getTitle())) {
+    //      return context.serviceYamlProto().getTitle();
+    //    }
+
+    // Option 2: Parse ApiShortName from service proto's package name (e.g.
+    // com.google.cloud.vision.v1)
+    // This approach assumes pattern of xx.[...].xx.lib-name.v[version], which may have
+    // discrepancies
     // eg. for vision proto: "com.google.cloud.vision.v1"
     // https://github.com/googleapis/java-vision/blob/main/proto-google-cloud-vision-v1/src/main/proto/google/cloud/vision/v1/image_annotator.proto#L36
+    String pakkageName = context.services().get(0).pakkage();
+    List<String> pakkagePhrases = Splitter.on(".").splitToList(pakkageName);
     return pakkagePhrases.get(pakkagePhrases.size() - 2);
+
+    // Option 3: Parse ApiShortName from service proto's default host (e.g. vision.googleapis.com)
+    // TODO: Replace implementation above to reuse parsing logic from SampleGen:
+    //  https://github.com/googleapis/gapic-generator-java/pull/1040
   }
 
-  public static String springPropertyPrefix(String libName, String serviceName) {
-    return "spring.cloud.gcp.autoconfig."
-        + CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_HYPHEN, libName)
-        + "."
+  public static String getSpringPackageName(String packageName) {
+    // Returns package name of generated spring autoconfiguration library
+    // e.g. for vision: com.google.cloud.vision.v1.spring
+    return packageName + ".spring";
+  }
+
+  public static String getSpringPropertyPrefix(String packageName, String serviceName) {
+    // Returns unique prefix for setting properties and enabling autoconfiguration
+    // Pattern: [package-name].spring.auto.[service-name]
+    // e.g. for vision's ImageAnnotator service:
+    // com.google.cloud.vision.v1.spring.auto.image-annotator
+    // Service name is converted to lower hyphen as required by ConfigurationPropertyName
+    // https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/properties/source/ConfigurationPropertyName.html
+    return packageName
+        + ".spring.auto."
         + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, serviceName);
   }
 

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfiguration.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfiguration.golden
@@ -22,7 +22,7 @@ import org.threeten.bp.Duration;
 @AutoConfiguration
 @ConditionalOnClass(EchoClient.class)
 @ConditionalOnProperty(
-    value = "spring.cloud.gcp.autoconfig.showcase.echo.enabled",
+    value = "com.google.showcase.v1beta1.spring.auto.echo.enabled",
     matchIfMissing = false)
 @EnableConfigurationProperties(EchoSpringProperties.class)
 public class EchoSpringAutoConfiguration {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -38,7 +38,7 @@ import org.threeten.bp.Duration;
 @AutoConfiguration
 @ConditionalOnClass(EchoClient.class)
 @ConditionalOnProperty(
-    value = "spring.cloud.gcp.autoconfig.showcase.echo.enabled",
+    value = "com.google.showcase.v1beta1.spring.auto.echo.enabled",
     matchIfMissing = false)
 @EnableConfigurationProperties(EchoSpringProperties.class)
 public class EchoSpringAutoConfiguration {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringProperties.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringProperties.golden
@@ -5,7 +5,7 @@ import com.google.cloud.spring.core.CredentialsSupplier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.threeten.bp.Duration;
 
-@ConfigurationProperties("spring.cloud.gcp.autoconfig.showcase.echo")
+@ConfigurationProperties("com.google.showcase.v1beta1.spring.auto.echo")
 public class EchoSpringProperties implements CredentialsSupplier {
   @NestedConfigurationProperty
   private final Credentials credentials =

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
@@ -21,7 +21,7 @@ import com.google.cloud.spring.core.CredentialsSupplier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.threeten.bp.Duration;
 
-@ConfigurationProperties("spring.cloud.gcp.autoconfig.showcase.echo")
+@ConfigurationProperties("com.google.showcase.v1beta1.spring.auto.echo")
 public class EchoSpringProperties implements CredentialsSupplier {
   @NestedConfigurationProperty
   private final Credentials credentials =


### PR DESCRIPTION
This PR updates and moves three pieces of naming-related logic in spring codegen into util methods:

- getSpringPropertyPrefix (e.g. `com.google.cloud.vision.v1.spring.auto.image-annotator`)
  * Replaced earlier use of libname due to ambiguity (see [comment](https://github.com/googleapis/gapic-generator-java/pull/1030#discussion_r983837987))
  
- getLibName (e.g. `vision`)
  * Intended for descriptive purposes
  * Includes three options considered by design doc - currently this PR implements option 2 (parse from package name) with the intention to switch to option 3 (parse from default host) in alignment with SampleGen 

- getSpringPackageName (e.g. `com.google.cloud.vision.v1.spring`)
  * Since this was also used in a couple of places, extracted to util in case of future need to update

**Dependencies:**
- #1059 should be adjusted to use these util methods (merge order should be after this PR)
- Would we prefer to have this PR wait on the switch to  `parseDefaultHost`, or make the change later in a separate PR?