### PR TITLE
chore: expose methods for parsing api short name and version

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/Composer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/Composer.java
@@ -192,39 +192,10 @@ public class Composer {
     return clazzes;
   }
 
-  @VisibleForTesting
-  static List<GapicClass> prepareExecutableSamples(List<GapicClass> clazzes, String protoPackage) {
-    //  parse protoPackage for apiVersion
-    String[] pakkage = protoPackage.split("\\.");
-    String apiVersion;
-    //  e.g. v1, v2, v1beta1
-    if (pakkage[pakkage.length - 1].matches("v[0-9].*")) {
-      apiVersion = pakkage[pakkage.length - 1];
-    } else {
-      apiVersion = "";
-    }
-    // Include license header, apiShortName, and apiVersion
-    List<GapicClass> clazzesWithSamples = new ArrayList<>();
-    clazzes.forEach(
-        gapicClass -> {
-          List<Sample> samples = new ArrayList<>();
-          gapicClass
-              .samples()
-              .forEach(
-                  sample ->
-                      samples.add(
-                          addRegionTagAndHeaderToSample(
-                              sample, parseDefaultHost(gapicClass.defaultHost()), apiVersion)));
-          clazzesWithSamples.add(gapicClass.withSamples(samples));
-        });
-    return clazzesWithSamples;
-  }
-
   // Parse defaultHost for apiShortName for the RegionTag. Need to account for regional default
   // endpoints like
   // "us-east1-pubsub.googleapis.com".
-  @VisibleForTesting
-  protected static String parseDefaultHost(String defaultHost) {
+  public static String parseApiShortName(String defaultHost) {
     // If the defaultHost is of the format "**.googleapis.com", take the name before the first
     // period.
     String apiShortName = Iterables.getFirst(Splitter.on(".").split(defaultHost), defaultHost);
@@ -237,6 +208,40 @@ public class Composer {
       apiShortName = "iam";
     }
     return apiShortName;
+  }
+
+  public static String parseApiVersion(String protoPackage) {
+    //  parse protoPackage for apiVersion
+    String[] pakkage = protoPackage.split("\\.");
+    String apiVersion;
+    //  e.g. v1, v2, v1beta1
+    if (pakkage[pakkage.length - 1].matches("v[0-9].*")) {
+      apiVersion = pakkage[pakkage.length - 1];
+    } else {
+      apiVersion = "";
+    }
+    return apiVersion;
+  }
+
+  @VisibleForTesting
+  static List<GapicClass> prepareExecutableSamples(List<GapicClass> clazzes, String protoPackage) {
+    // Include license header, apiShortName, and apiVersion
+    List<GapicClass> clazzesWithSamples = new ArrayList<>();
+    clazzes.forEach(
+        gapicClass -> {
+          List<Sample> samples = new ArrayList<>();
+          gapicClass
+              .samples()
+              .forEach(
+                  sample ->
+                      samples.add(
+                          addRegionTagAndHeaderToSample(
+                              sample,
+                              parseApiShortName(gapicClass.defaultHost()),
+                              parseApiVersion(protoPackage))));
+          clazzesWithSamples.add(gapicClass.withSamples(samples));
+        });
+    return clazzesWithSamples;
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -89,31 +89,45 @@ public class ComposerTest {
   }
 
   @Test
-  public void parseDefaultHost_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
+  public void parseApiShortName_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
     String defaultHost = "us-east1-pubsub.googleapis.com";
     String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("pubsub", apiShortName);
   }
 
   @Test
-  public void parseDefaultHost_shouldReturnApiShortName() {
+  public void parseApiShortName_shouldReturnApiShortName() {
     String defaultHost = "logging.googleapis.com";
     String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("logging", apiShortName);
   }
 
   @Test
-  public void parseDefaultHost_shouldReturnApiShortNameForIam() {
+  public void parseApiShortName_shouldReturnApiShortNameForIam() {
     String defaultHost = "iam-meta-api.googleapis.com";
     String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("iam", apiShortName);
   }
 
   @Test
-  public void parseDefaultHost_shouldReturnHostIfNoPeriods() {
+  public void parseApiShortName_shouldReturnHostIfNoPeriods() {
     String defaultHost = "logging:7469";
     String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("logging:7469", apiShortName);
+  }
+
+  @Test
+  public void parseApiVersion_shouldReturnApiVersion() {
+    String protoPackage = "google.cloud.accessapproval.v1";
+    String apiVersion = Composer.parseApiVersion(protoPackage);
+    assertEquals("v1", apiVersion);
+  }
+
+  @Test
+  public void parseApiVersion_shouldReturnEmptyIfNoMatch() {
+    String protoPackage = "google.cloud.accessapproval";
+    String apiVersion = Composer.parseApiVersion(protoPackage);
+    assertEquals("", apiVersion);
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -91,28 +91,28 @@ public class ComposerTest {
   @Test
   public void parseDefaultHost_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
     String defaultHost = "us-east1-pubsub.googleapis.com";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
+    String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("pubsub", apiShortName);
   }
 
   @Test
   public void parseDefaultHost_shouldReturnApiShortName() {
     String defaultHost = "logging.googleapis.com";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
+    String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("logging", apiShortName);
   }
 
   @Test
   public void parseDefaultHost_shouldReturnApiShortNameForIam() {
     String defaultHost = "iam-meta-api.googleapis.com";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
+    String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("iam", apiShortName);
   }
 
   @Test
   public void parseDefaultHost_shouldReturnHostIfNoPeriods() {
     String defaultHost = "logging:7469";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
+    String apiShortName = Composer.parseApiShortName(defaultHost);
     assertEquals("logging:7469", apiShortName);
   }
 


### PR DESCRIPTION
This PR exposes `parseApiShortName` (renamed from parseDefaultHost in #1040) and `parseApiVersion` (refactored from parsing proto package in prepareExecutableSamples) as public static methods in `Composer.java`. This change will enable Spring Codegen (when eventually split out from this repo) to reuse this parsing logic in descriptive comments and metadata. 

An alternative refactoring to expose these two values as field accessors in the `Service` class can be found on the [`refactor-parse-defaulthost-2`](https://github.com/googleapis/gapic-generator-java/compare/refactor-parse-defaulthost-2) branch. It moves the parsing logic to earlier in the process, since the source fields (`defaultHost` and `protoPakkage`) are both defined per-service. It’s a more convoluted change compared to this PR, but if the approach is preferred or adds any value from the sample generation perspective, happy to switch and open a PR from that branch instead.