### PR TITLE
test(spring): add tests for content-building methods in SpringWriter

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -21,6 +21,7 @@ import com.google.api.generator.gapic.model.GapicClass;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.GapicPackageInfo;
 import com.google.api.generator.spring.utils.Utils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
 import java.io.IOException;
@@ -122,7 +123,8 @@ public class SpringWriter {
     return packagePath;
   }
 
-  private static void writeAutoConfigRegistration(GapicContext context, JarOutputStream jos) {
+  @VisibleForTesting
+  static String writeAutoConfigRegistration(GapicContext context, JarOutputStream jos) {
     String path = "src/main/resources/META-INF/spring";
     JarEntry jarEntry =
         new JarEntry(
@@ -140,12 +142,14 @@ public class SpringWriter {
                           "%s.spring.%sSpringAutoConfig", service.pakkage(), service.name())));
 
       jos.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+      return sb.toString();
     } catch (IOException e) {
       throw new GapicWriterException("Could not write spring.factories", e);
     }
   }
 
-  private static void writeSpringAdditionalMetadataJson(GapicContext context, JarOutputStream jos) {
+  @VisibleForTesting
+  static String writeSpringAdditionalMetadataJson(GapicContext context, JarOutputStream jos) {
     String path = "src/main/resources/META-INF";
     JarEntry jarEntry =
         new JarEntry(String.format("%s/additional-spring-configuration-metadata.json", path));
@@ -169,12 +173,14 @@ public class SpringWriter {
                           Utils.getLibName(context) + "/" + service.name())));
 
       jos.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+      return sb.toString();
     } catch (IOException e) {
       throw new GapicWriterException("Could not write spring.factories", e);
     }
   }
 
-  private static void writePom(GapicContext context, JarOutputStream jos) {
+  @VisibleForTesting
+  static String writePom(GapicContext context, JarOutputStream jos) {
     String pakkageName = Utils.getPackageName(context);
     pakkageName = pakkageName.replace('.', '-');
     String clientLibraryShortName = Utils.getLibName(context);
@@ -259,6 +265,7 @@ public class SpringWriter {
               clientLibraryVersion));
 
       jos.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+      return sb.toString();
     } catch (IOException e) {
       throw new GapicWriterException("Could not write pom.xml", e);
     }

--- a/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
+++ b/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
@@ -18,14 +18,11 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.api.generator.gapic.composer.common.TestProtoLoader;
 import com.google.api.generator.gapic.model.GapicContext;
-import com.google.api.generator.spring.SpringWriter.GapicWriterException;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.framework.Utils;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.protobuf.ByteString;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.jar.JarOutputStream;
@@ -39,23 +36,18 @@ public class SpringWriterTest {
   @Before
   public void setUp() {
     this.context = TestProtoLoader.instance().parseShowcaseEcho();
-    try {
-      this.jos = new JarOutputStream(ByteString.newOutput());
-    } catch (IOException e) {
-      throw new GapicWriterException(e.getMessage(), e);
-    }
   }
 
   @Test
-  public void writeAutoConfigRegistrationTest() {
-    String result = SpringWriter.writeAutoConfigRegistration(context, jos);
+  public void buildAutoConfigRegistrationStringTest() {
+    String result = SpringWriter.buildAutoConfigRegistrationString(context);
     String expected = "com.google.showcase.v1beta1.spring.EchoSpringAutoConfig";
     assertEquals(expected, result);
   }
 
   @Test
-  public void writeSpringAdditionalMetadataJsonTest() {
-    String result = SpringWriter.writeSpringAdditionalMetadataJson(context, jos);
+  public void buildSpringAdditionalMetadataJsonStringTest() {
+    String result = SpringWriter.buildSpringAdditionalMetadataJsonString(context);
     JsonObject jsonResult = JsonParser.parseString(result).getAsJsonObject();
 
     JsonObject innerExpected = new JsonObject();
@@ -73,8 +65,8 @@ public class SpringWriterTest {
   }
 
   @Test
-  public void writePomTest() {
-    String result = SpringWriter.writePom(context, jos);
+  public void buildPomStringTest() {
+    String result = SpringWriter.buildPomString(context);
     String fileName = "SpringPackagePom.golden";
     Utils.saveCodegenToFile(this.getClass(), fileName, result);
     Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), fileName);

--- a/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
+++ b/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
@@ -20,18 +20,13 @@ import com.google.api.generator.gapic.composer.common.TestProtoLoader;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.test.framework.Assert;
 import com.google.api.generator.test.framework.Utils;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.jar.JarOutputStream;
 import org.junit.Before;
 import org.junit.Test;
 
 public class SpringWriterTest {
   private GapicContext context;
-  private JarOutputStream jos;
 
   @Before
   public void setUp() {
@@ -48,20 +43,10 @@ public class SpringWriterTest {
   @Test
   public void buildSpringAdditionalMetadataJsonStringTest() {
     String result = SpringWriter.buildSpringAdditionalMetadataJsonString(context);
-    JsonObject jsonResult = JsonParser.parseString(result).getAsJsonObject();
-
-    JsonObject innerExpected = new JsonObject();
-    innerExpected.addProperty("name", "com.google.showcase.v1beta1.spring.auto.echo.enabled");
-    innerExpected.addProperty("type", "java.lang.Boolean");
-    innerExpected.addProperty(
-        "description", "Auto-configure Google Cloud showcase/Echo components.");
-    innerExpected.addProperty("defaultValue", true);
-    JsonArray innerExpectedArray = new JsonArray();
-    innerExpectedArray.add(innerExpected);
-    JsonObject jsonExpected = new JsonObject();
-    jsonExpected.add("properties", innerExpectedArray);
-
-    assertEquals(jsonExpected, jsonResult);
+    String fileName = "SpringAdditionalMetadataJson.golden";
+    Utils.saveCodegenToFile(this.getClass(), fileName, result);
+    Path goldenFilePath = Paths.get(Utils.getGoldenDir(this.getClass()), fileName);
+    Assert.assertCodeEquals(goldenFilePath, result);
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
+++ b/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
@@ -1,0 +1,134 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.spring;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.generator.gapic.composer.common.TestProtoLoader;
+import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.spring.SpringWriter.GapicWriterException;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.jar.JarOutputStream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SpringWriterTest {
+  private GapicContext context;
+  private JarOutputStream jos;
+
+  @Before
+  public void setUp() {
+    this.context = TestProtoLoader.instance().parseShowcaseEcho();
+    try {
+      this.jos = new JarOutputStream(ByteString.newOutput());
+    } catch (IOException e) {
+      throw new GapicWriterException(e.getMessage(), e);
+    }
+  }
+
+  @Test
+  public void writeAutoConfigRegistrationTest() {
+    String result = SpringWriter.writeAutoConfigRegistration(context, jos);
+    String expected = "com.google.showcase.v1beta1.spring.EchoSpringAutoConfig";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void writeSpringAdditionalMetadataJsonTest() {
+    String result = SpringWriter.writeSpringAdditionalMetadataJson(context, jos);
+    // TODO(emmwang): replace with json comparison?
+    String expected =
+        "\n"
+            + "{\n"
+            + "    \"properties\": [\n"
+            + "        {\n"
+            + "            \"name\": \"com.google.showcase.v1beta1.spring.auto.echo.enabled\",\n"
+            + "            \"type\": \"java.lang.Boolean\",\n"
+            + "            \"description\": \"Auto-configure Google Cloud showcase/Echo components.\",\n"
+            + "            \"defaultValue\": true\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void writePomTest() {
+    String result = SpringWriter.writePom(context, jos);
+    // TODO(emmwang): replace with file comparison?
+    String expected =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n"
+            + "  <modelVersion>4.0.0</modelVersion>\n"
+            + "\n"
+            + "  <groupId>com.google.cloud</groupId>\n"
+            + "  <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>\n"
+            + "  <version>{{starter-version}}</version>\n"
+            + "  <name>Spring Boot Starter - showcase</name>\n"
+            + "  <description>Spring Boot Starter with AutoConfiguration for showcase</description>\n"
+            + "\n"
+            + "\n"
+            + "  <dependencies>\n"
+            + "    <dependency>\n"
+            + "      <groupId>{{client-library-group-id}}</groupId>\n"
+            + "      <artifactId>{{client-library-artifact-id}}</artifactId>\n"
+            + "      <version>{{client-library-version}}</version>\n"
+            + "    </dependency>\n"
+            + "\n"
+            + "    <dependency>\n"
+            + "      <groupId>org.springframework.boot</groupId>\n"
+            + "      <artifactId>spring-boot-starter</artifactId>\n"
+            + "      <version>2.6.3</version>\n"
+            + "    </dependency>\n"
+            + "\n"
+            + "  <dependency>\n"
+            + "    <groupId>com.google.cloud</groupId>\n"
+            + "    <artifactId>spring-cloud-gcp-core</artifactId>\n"
+            + "    <version>3.2.1</version>\n"
+            + "  </dependency>\n"
+            + "</dependencies>\n"
+            + "  <build>\n"
+            + "    <pluginManagement>\n"
+            + "      <plugins>\n"
+            + "        <plugin>\n"
+            + "          <groupId>org.apache.maven.plugins</groupId>\n"
+            + "          <artifactId>maven-jar-plugin</artifactId>\n"
+            + "          <version>3.2.2</version>\n"
+            + "        </plugin>\n"
+            + "      </plugins>\n"
+            + "    </pluginManagement>\n"
+            + "\n"
+            + "    <plugins>\n"
+            + "      <plugin>\n"
+            + "        <groupId>org.apache.maven.plugins</groupId>\n"
+            + "        <artifactId>maven-jar-plugin</artifactId>\n"
+            + "        <configuration>\n"
+            + "          <archive>\n"
+            + "            <manifest>\n"
+            + "              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>\n"
+            + "            </manifest>\n"
+            + "          </archive>\n"
+            + "        </configuration>\n"
+            + "      </plugin>\n"
+            + "    </plugins>\n"
+            + "  </build>\n"
+            + "\n"
+            + "</project>";
+
+    assertEquals(expected, result);
+  }
+}

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringAdditionalMetadataJson.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringAdditionalMetadataJson.golden
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "com.google.showcase.v1beta1.spring.auto.echo.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud showcase/Echo components.",
+      "defaultValue": true
+    }
+  ]
+}

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud</groupId>
+  <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>
+  <version>{{starter-version}}</version>
+  <name>Spring Boot Starter - showcase</name>
+  <description>Spring Boot Starter with AutoConfiguration for showcase</description>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>{{client-library-group-id}}</groupId>
+      <artifactId>{{client-library-artifact-id}}</artifactId>
+      <version>{{client-library-version}}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>spring-cloud-gcp-core</artifactId>
+    <version>3.2.1</version>
+  </dependency>
+</dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
**In this PR:**
- Extract content-building logic in `SpringWriter` not covered by composers into own methods with visibility for testing
- Adds unit testing for:
  - Contents of `org.springframework.boot.autoconfigure.AutoConfiguration.imports` (string comparison)
  - Contents of `additional-spring-configuration-metadata.json` ~(json comparison)~ (generates and updates golden file)
  - Contents of `pom.xml` (generates and updates golden file)