### PR TITLE
refactor: expose parsed api short name and version as fields in Service

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
@@ -164,7 +164,8 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
 
     updateGapicMetadata(context, service, className, grpcRpcsToJavaMethodNames);
     return GapicClass.create(kind, classDef, SampleComposerUtil.handleDuplicateSamples(samples))
-        .withDefaultHost(service.defaultHost());
+        .withApiShortName(service.apiShortName())
+        .withApiVersion(service.apiVersion());
   }
 
   private static List<AnnotationNode> createClassAnnotations(Service service, TypeStore typeStore) {

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
@@ -127,7 +127,8 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
             .setNestedClasses(Arrays.asList(createNestedBuilderClass(service, typeStore)))
             .build();
     return GapicClass.create(kind, classDef, SampleComposerUtil.handleDuplicateSamples(samples))
-        .withDefaultHost(service.defaultHost());
+        .withApiShortName(service.apiShortName())
+        .withApiVersion(service.apiVersion());
   }
 
   private static List<CommentStatement> createClassHeaderComments(

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -202,7 +202,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             .build();
     return GapicClass.create(
             GapicClass.Kind.STUB, classDef, SampleComposerUtil.handleDuplicateSamples(samples))
-        .withDefaultHost(service.defaultHost());
+        .withApiShortName(service.apiShortName())
+        .withApiVersion(service.apiVersion());
   }
 
   protected MethodDefinition createDefaultCredentialsProviderBuilderMethod() {

--- a/src/main/java/com/google/api/generator/gapic/model/GapicClass.java
+++ b/src/main/java/com/google/api/generator/gapic/model/GapicClass.java
@@ -35,9 +35,11 @@ public abstract class GapicClass {
 
   public abstract List<Sample> samples();
 
-  // Represents the host URL for the service. May or may not contain a regional endpoint. Only used
-  // for generating the region tag for samples; therefore only used in select Composers.
-  public abstract String defaultHost();
+  // Only used for generating the region tag for samples; therefore only used in select Composers.
+  public abstract String apiShortName();
+
+  // Only used for generating the region tag for samples; therefore only used in select Composers.
+  public abstract String apiVersion();
 
   public static GapicClass create(Kind kind, ClassDefinition classDefinition) {
     return builder().setKind(kind).setClassDefinition(classDefinition).build();
@@ -51,7 +53,8 @@ public abstract class GapicClass {
   static Builder builder() {
     return new AutoValue_GapicClass.Builder()
         .setSamples(Collections.emptyList())
-        .setDefaultHost("");
+        .setApiShortName("")
+        .setApiVersion("");
   }
 
   abstract Builder toBuilder();
@@ -60,8 +63,12 @@ public abstract class GapicClass {
     return toBuilder().setSamples(samples).build();
   }
 
-  public final GapicClass withDefaultHost(String defaultHost) {
-    return toBuilder().setDefaultHost(defaultHost).build();
+  public final GapicClass withApiShortName(String apiShortName) {
+    return toBuilder().setApiShortName(apiShortName).build();
+  }
+
+  public final GapicClass withApiVersion(String apiVersion) {
+    return toBuilder().setApiVersion(apiVersion).build();
   }
 
   @AutoValue.Builder
@@ -72,7 +79,9 @@ public abstract class GapicClass {
 
     abstract Builder setSamples(List<Sample> samples);
 
-    abstract Builder setDefaultHost(String defaultHost);
+    abstract Builder setApiShortName(String apiShortName);
+
+    abstract Builder setApiVersion(String apiVersion);
 
     abstract GapicClass build();
   }

--- a/src/main/java/com/google/api/generator/gapic/model/Service.java
+++ b/src/main/java/com/google/api/generator/gapic/model/Service.java
@@ -57,14 +57,14 @@ public abstract class Service {
       return parseApiShortName(defaultHost());
     }
     return "";
-  };
+  }
 
   public String apiVersion() {
     if (!Strings.isNullOrEmpty(protoPakkage())) {
       return parseApiVersion(protoPakkage());
     }
     return "";
-  };
+  }
 
   public Method operationPollingMethod() {
     for (Method method : methods()) {

--- a/src/main/java/com/google/api/generator/gapic/model/Service.java
+++ b/src/main/java/com/google/api/generator/gapic/model/Service.java
@@ -16,8 +16,10 @@ package com.google.api.generator.gapic.model;
 
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -49,6 +51,20 @@ public abstract class Service {
   public boolean hasDescription() {
     return !Strings.isNullOrEmpty(description());
   }
+
+  public String apiShortName() {
+    if (!Strings.isNullOrEmpty(defaultHost())) {
+      return parseApiShortName(defaultHost());
+    }
+    return "";
+  };
+
+  public String apiVersion() {
+    if (!Strings.isNullOrEmpty(protoPakkage())) {
+      return parseApiVersion(protoPakkage());
+    }
+    return "";
+  };
 
   public Method operationPollingMethod() {
     for (Method method : methods()) {
@@ -126,5 +142,36 @@ public abstract class Service {
     public abstract Builder setDescription(String description);
 
     public abstract Service build();
+  }
+
+  private static String parseApiVersion(String protoPackage) {
+    //  parse protoPackage for apiVersion
+    String[] pakkage = protoPackage.split("\\.");
+    String apiVersion;
+    //  e.g. v1, v2, v1beta1
+    if (pakkage[pakkage.length - 1].matches("v[0-9].*")) {
+      apiVersion = pakkage[pakkage.length - 1];
+    } else {
+      apiVersion = "";
+    }
+    return apiVersion;
+  }
+
+  // Parse defaultHost for apiShortName for the RegionTag. Need to account for regional default
+  // endpoints like
+  // "us-east1-pubsub.googleapis.com".
+  private static String parseApiShortName(String defaultHost) {
+    // If the defaultHost is of the format "**.googleapis.com", take the name before the first
+    // period.
+    String apiShortName = Iterables.getFirst(Splitter.on(".").split(defaultHost), defaultHost);
+    // If the defaultHost is of the format "**-**-**.googleapis.com", take the section before the
+    // first period and after the last dash to follow CSharp's implementation here:
+    // https://github.com/googleapis/gapic-generator-csharp/blob/main/Google.Api.Generator/Generation/ServiceDetails.cs#L70
+    apiShortName = Iterables.getLast(Splitter.on("-").split(apiShortName), defaultHost);
+    // `iam-meta-api` service is an exceptional case and is handled as a one-off
+    if (defaultHost.contains("iam-meta-api")) {
+      apiShortName = "iam";
+    }
+    return apiShortName;
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -42,14 +42,16 @@ public class ComposerTest {
   private final Service echoProtoService = context.services().get(0);
   private final List<GapicClass> clazzes =
       Arrays.asList(
-          GrpcServiceCallableFactoryClassComposer.instance().generate(context, echoProtoService));
+          GrpcServiceCallableFactoryClassComposer.instance()
+              .generate(context, echoProtoService)
+              .withApiShortName(echoProtoService.apiShortName())
+              .withApiVersion(echoProtoService.apiVersion()));
   private final Sample sample =
       Sample.builder()
           .setRegionTag(
               RegionTag.builder().setServiceName("serviceName").setRpcName("rpcName").build())
           .build();
   private List<Sample> ListofSamples = Arrays.asList(new Sample[] {sample});
-  private final String protoPackage = echoProtoService.protoPakkage();
 
   @Test
   public void gapicClass_addApacheLicense() {
@@ -75,7 +77,7 @@ public class ComposerTest {
     List<GapicClass> testClassList = Arrays.asList(new GapicClass[] {testClass});
 
     List<Sample> composedSamples =
-        Composer.prepareExecutableSamples(testClassList, protoPackage).get(0).samples();
+        Composer.prepareExecutableSamples(testClassList).get(0).samples();
 
     assertFalse(composedSamples.isEmpty());
     for (Sample sample : composedSamples) {
@@ -83,37 +85,42 @@ public class ComposerTest {
           "File header should be APACHE",
           Arrays.asList(CommentComposer.APACHE_LICENSE_COMMENT),
           sample.fileHeader());
-      assertEquals("ApiShortName should be empty", "", sample.regionTag().apiShortName());
+      assertEquals(
+          "ApiShortName should be Localhost7469",
+          "Localhost7469",
+          sample.regionTag().apiShortName());
       assertEquals("ApiVersion should be V1beta1", "V1Beta1", sample.regionTag().apiVersion());
     }
   }
 
+  // TODO (emmwang): these tests now test the Service class - move to ServiceTest.java?
+
   @Test
   public void parseDefaultHost_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
     String defaultHost = "us-east1-pubsub.googleapis.com";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
-    assertEquals("pubsub", apiShortName);
+    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
+    assertEquals("pubsub", testService.apiShortName());
   }
 
   @Test
   public void parseDefaultHost_shouldReturnApiShortName() {
     String defaultHost = "logging.googleapis.com";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
-    assertEquals("logging", apiShortName);
+    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
+    assertEquals("logging", testService.apiShortName());
   }
 
   @Test
   public void parseDefaultHost_shouldReturnApiShortNameForIam() {
     String defaultHost = "iam-meta-api.googleapis.com";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
-    assertEquals("iam", apiShortName);
+    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
+    assertEquals("iam", testService.apiShortName());
   }
 
   @Test
   public void parseDefaultHost_shouldReturnHostIfNoPeriods() {
     String defaultHost = "logging:7469";
-    String apiShortName = Composer.parseDefaultHost(defaultHost);
-    assertEquals("logging:7469", apiShortName);
+    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
+    assertEquals("logging:7469", testService.apiShortName());
   }
 
   @Test
@@ -128,13 +135,13 @@ public class ComposerTest {
   @Test
   public void composeSamples_parseProtoPackage() {
 
-    String defaultHost = "accessapproval.googleapis.com:443";
-    GapicClass testClass = clazzes.get(0).withSamples(ListofSamples).withDefaultHost(defaultHost);
-    List<GapicClass> testClassList = Arrays.asList(new GapicClass[] {testClass});
-    String protoPack = "google.cloud.accessapproval.v1";
+    // TODO (emmwang): clean up / refactor repeated code in this test?
 
-    List<Sample> composedSamples =
-        Composer.prepareExecutableSamples(testClassList, protoPack).get(0).samples();
+    String defaultHost = "accessapproval.googleapis.com:443";
+    String protoPack = "google.cloud.accessapproval.v1";
+    Service testService =
+        echoProtoService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
+    List<Sample> composedSamples = composeSamplesFromService(testService);
 
     // If samples is empty, the test automatically passes without checking.
     assertFalse(composedSamples.isEmpty());
@@ -149,9 +156,9 @@ public class ComposerTest {
 
     protoPack = "google.cloud.vision.v1p1beta1";
     defaultHost = "vision.googleapis.com";
-    testClass = clazzes.get(0).withSamples(ListofSamples).withDefaultHost(defaultHost);
-    testClassList = Arrays.asList(new GapicClass[] {testClass});
-    composedSamples = Composer.prepareExecutableSamples(testClassList, protoPack).get(0).samples();
+    testService =
+        echoProtoService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
+    composedSamples = composeSamplesFromService(testService);
     // If samples is empty, the test automatically passes without checking.
     assertFalse(composedSamples.isEmpty());
 
@@ -161,7 +168,9 @@ public class ComposerTest {
     }
 
     protoPack = "google.cloud.vision";
-    composedSamples = Composer.prepareExecutableSamples(testClassList, protoPack).get(0).samples();
+    testService =
+        echoProtoService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
+    composedSamples = composeSamplesFromService(testService);
     // If samples is empty, the test automatically passes without checking.
     assertFalse(composedSamples.isEmpty());
 
@@ -169,5 +178,17 @@ public class ComposerTest {
       assertEquals("ApiShortName should be Vision", sample.regionTag().apiShortName(), "Vision");
       assertEquals("ApiVersion should be empty", sample.regionTag().apiVersion(), "");
     }
+  }
+
+  private List<Sample> composeSamplesFromService(Service testService) {
+    GapicClass testClass =
+        GrpcServiceCallableFactoryClassComposer.instance()
+            .generate(context, testService)
+            .withSamples(ListofSamples)
+            .withApiShortName(testService.apiShortName())
+            .withApiVersion(testService.apiVersion());
+    List<GapicClass> testClassList = Arrays.asList(new GapicClass[] {testClass});
+    List<Sample> testSamples = Composer.prepareExecutableSamples(testClassList).get(0).samples();
+    return testSamples;
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -93,36 +93,6 @@ public class ComposerTest {
     }
   }
 
-  // TODO (emmwang): these tests now test the Service class - move to ServiceTest.java?
-
-  @Test
-  public void parseDefaultHost_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
-    String defaultHost = "us-east1-pubsub.googleapis.com";
-    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
-    assertEquals("pubsub", testService.apiShortName());
-  }
-
-  @Test
-  public void parseDefaultHost_shouldReturnApiShortName() {
-    String defaultHost = "logging.googleapis.com";
-    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
-    assertEquals("logging", testService.apiShortName());
-  }
-
-  @Test
-  public void parseDefaultHost_shouldReturnApiShortNameForIam() {
-    String defaultHost = "iam-meta-api.googleapis.com";
-    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
-    assertEquals("iam", testService.apiShortName());
-  }
-
-  @Test
-  public void parseDefaultHost_shouldReturnHostIfNoPeriods() {
-    String defaultHost = "logging:7469";
-    Service testService = echoProtoService.toBuilder().setDefaultHost(defaultHost).build();
-    assertEquals("logging:7469", testService.apiShortName());
-  }
-
   @Test
   public void gapicClass_addRegionTagAndHeaderToSample() {
     Sample testSample;
@@ -135,13 +105,13 @@ public class ComposerTest {
   @Test
   public void composeSamples_parseProtoPackage() {
 
-    // TODO (emmwang): clean up / refactor repeated code in this test?
-
     String defaultHost = "accessapproval.googleapis.com:443";
     String protoPack = "google.cloud.accessapproval.v1";
     Service testService =
         echoProtoService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
-    List<Sample> composedSamples = composeSamplesFromService(testService);
+    List<GapicClass> testClassList = getTestClassListFromService(testService);
+    List<Sample> composedSamples =
+        Composer.prepareExecutableSamples(testClassList).get(0).samples();
 
     // If samples is empty, the test automatically passes without checking.
     assertFalse(composedSamples.isEmpty());
@@ -157,8 +127,9 @@ public class ComposerTest {
     protoPack = "google.cloud.vision.v1p1beta1";
     defaultHost = "vision.googleapis.com";
     testService =
-        echoProtoService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
-    composedSamples = composeSamplesFromService(testService);
+        testService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
+    testClassList = getTestClassListFromService(testService);
+    composedSamples = Composer.prepareExecutableSamples(testClassList).get(0).samples();
     // If samples is empty, the test automatically passes without checking.
     assertFalse(composedSamples.isEmpty());
 
@@ -169,8 +140,9 @@ public class ComposerTest {
 
     protoPack = "google.cloud.vision";
     testService =
-        echoProtoService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
-    composedSamples = composeSamplesFromService(testService);
+        testService.toBuilder().setDefaultHost(defaultHost).setProtoPakkage(protoPack).build();
+    testClassList = getTestClassListFromService(testService);
+    composedSamples = Composer.prepareExecutableSamples(testClassList).get(0).samples();
     // If samples is empty, the test automatically passes without checking.
     assertFalse(composedSamples.isEmpty());
 
@@ -180,7 +152,7 @@ public class ComposerTest {
     }
   }
 
-  private List<Sample> composeSamplesFromService(Service testService) {
+  private List<GapicClass> getTestClassListFromService(Service testService) {
     GapicClass testClass =
         GrpcServiceCallableFactoryClassComposer.instance()
             .generate(context, testService)
@@ -188,7 +160,6 @@ public class ComposerTest {
             .withApiShortName(testService.apiShortName())
             .withApiVersion(testService.apiVersion());
     List<GapicClass> testClassList = Arrays.asList(new GapicClass[] {testClass});
-    List<Sample> testSamples = Composer.prepareExecutableSamples(testClassList).get(0).samples();
-    return testSamples;
+    return testClassList;
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/ComposerTest.java
@@ -89,7 +89,7 @@ public class ComposerTest {
           "ApiShortName should be Localhost7469",
           "Localhost7469",
           sample.regionTag().apiShortName());
-      assertEquals("ApiVersion should be V1beta1", "V1Beta1", sample.regionTag().apiVersion());
+      assertEquals("ApiVersion should be V1Beta1", "V1Beta1", sample.regionTag().apiVersion());
     }
   }
 

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientClassComposerTest.java
@@ -29,11 +29,36 @@ public class ServiceClientClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"EchoClient", GrpcTestProtoLoader.instance().parseShowcaseEcho()},
-          {"DeprecatedServiceClient", GrpcTestProtoLoader.instance().parseDeprecatedService()},
-          {"IdentityClient", GrpcTestProtoLoader.instance().parseShowcaseIdentity()},
-          {"BookshopClient", GrpcTestProtoLoader.instance().parseBookshopService()},
-          {"MessagingClient", GrpcTestProtoLoader.instance().parseShowcaseMessaging()},
+          {
+            "EchoClient",
+            GrpcTestProtoLoader.instance().parseShowcaseEcho(),
+            "localhost:7469",
+            "v1beta1"
+          },
+          {
+            "DeprecatedServiceClient",
+            GrpcTestProtoLoader.instance().parseDeprecatedService(),
+            "localhost:7469",
+            "v1"
+          },
+          {
+            "IdentityClient",
+            GrpcTestProtoLoader.instance().parseShowcaseIdentity(),
+            "localhost:7469",
+            "v1beta1"
+          },
+          {
+            "BookshopClient",
+            GrpcTestProtoLoader.instance().parseBookshopService(),
+            "localhost:2665",
+            "v1beta1"
+          },
+          {
+            "MessagingClient",
+            GrpcTestProtoLoader.instance().parseShowcaseMessaging(),
+            "localhost:7469",
+            "v1beta1"
+          },
         });
   }
 
@@ -41,6 +66,12 @@ public class ServiceClientClassComposerTest {
 
   @Parameterized.Parameter(1)
   public GapicContext context;
+
+  @Parameterized.Parameter(2)
+  public String apiShortNameExpected;
+
+  @Parameterized.Parameter(3)
+  public String apiVersionExpected;
 
   @Test
   public void generateServiceClientClasses() {
@@ -50,5 +81,7 @@ public class ServiceClientClassComposerTest {
     Assert.assertGoldenClass(this.getClass(), clazz, name + ".golden");
     Assert.assertGoldenSamples(
         this.getClass(), name, clazz.classDefinition().packageString(), clazz.samples());
+    Assert.assertCodeEquals(clazz.apiShortName(), apiShortNameExpected);
+    Assert.assertCodeEquals(clazz.apiVersion(), apiVersionExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceClientClassComposerTest.java
@@ -29,27 +29,11 @@ public class ServiceClientClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"EchoClient", GrpcTestProtoLoader.instance().parseShowcaseEcho(), "localhost:7469"},
-          {
-            "DeprecatedServiceClient",
-            GrpcTestProtoLoader.instance().parseDeprecatedService(),
-            "localhost:7469"
-          },
-          {
-            "IdentityClient",
-            GrpcTestProtoLoader.instance().parseShowcaseIdentity(),
-            "localhost:7469"
-          },
-          {
-            "BookshopClient",
-            GrpcTestProtoLoader.instance().parseBookshopService(),
-            "localhost:2665"
-          },
-          {
-            "MessagingClient",
-            GrpcTestProtoLoader.instance().parseShowcaseMessaging(),
-            "localhost:7469"
-          },
+          {"EchoClient", GrpcTestProtoLoader.instance().parseShowcaseEcho()},
+          {"DeprecatedServiceClient", GrpcTestProtoLoader.instance().parseDeprecatedService()},
+          {"IdentityClient", GrpcTestProtoLoader.instance().parseShowcaseIdentity()},
+          {"BookshopClient", GrpcTestProtoLoader.instance().parseBookshopService()},
+          {"MessagingClient", GrpcTestProtoLoader.instance().parseShowcaseMessaging()},
         });
   }
 
@@ -57,9 +41,6 @@ public class ServiceClientClassComposerTest {
 
   @Parameterized.Parameter(1)
   public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String defaultHostExpected;
 
   @Test
   public void generateServiceClientClasses() {
@@ -69,6 +50,5 @@ public class ServiceClientClassComposerTest {
     Assert.assertGoldenClass(this.getClass(), clazz, name + ".golden");
     Assert.assertGoldenSamples(
         this.getClass(), name, clazz.classDefinition().packageString(), clazz.samples());
-    Assert.assertCodeEquals(clazz.defaultHost(), defaultHostExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceSettingsClassComposerTest.java
@@ -31,8 +31,18 @@ public class ServiceSettingsClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"EchoSettings", TestProtoLoader.instance().parseShowcaseEcho()},
-          {"DeprecatedServiceSettings", TestProtoLoader.instance().parseDeprecatedService()}
+          {
+            "EchoSettings",
+            TestProtoLoader.instance().parseShowcaseEcho(),
+            "localhost:7469",
+            "v1beta1"
+          },
+          {
+            "DeprecatedServiceSettings",
+            TestProtoLoader.instance().parseDeprecatedService(),
+            "localhost:7469",
+            "v1"
+          }
         });
   }
 
@@ -40,6 +50,12 @@ public class ServiceSettingsClassComposerTest {
 
   @Parameterized.Parameter(1)
   public GapicContext context;
+
+  @Parameterized.Parameter(2)
+  public String apiShortNameExpected;
+
+  @Parameterized.Parameter(3)
+  public String apiVersionExpected;
 
   @Test
   public void generateServiceSettingsClasses() {
@@ -52,5 +68,7 @@ public class ServiceSettingsClassComposerTest {
         "servicesettings",
         clazz.classDefinition().packageString(),
         clazz.samples());
+    Assert.assertCodeEquals(clazz.apiShortName(), apiShortNameExpected);
+    Assert.assertCodeEquals(clazz.apiVersion(), apiVersionExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceSettingsClassComposerTest.java
@@ -31,12 +31,8 @@ public class ServiceSettingsClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"EchoSettings", TestProtoLoader.instance().parseShowcaseEcho(), "localhost:7469"},
-          {
-            "DeprecatedServiceSettings",
-            TestProtoLoader.instance().parseDeprecatedService(),
-            "localhost:7469"
-          }
+          {"EchoSettings", TestProtoLoader.instance().parseShowcaseEcho()},
+          {"DeprecatedServiceSettings", TestProtoLoader.instance().parseDeprecatedService()}
         });
   }
 
@@ -44,9 +40,6 @@ public class ServiceSettingsClassComposerTest {
 
   @Parameterized.Parameter(1)
   public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String defaultHostExpected;
 
   @Test
   public void generateServiceSettingsClasses() {
@@ -59,6 +52,5 @@ public class ServiceSettingsClassComposerTest {
         "servicesettings",
         clazz.classDefinition().packageString(),
         clazz.samples());
-    Assert.assertCodeEquals(clazz.defaultHost(), defaultHostExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubClassComposerTest.java
@@ -31,8 +31,8 @@ public class ServiceStubClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"EchoStub", TestProtoLoader.instance().parseShowcaseEcho(), ""},
-          {"DeprecatedServiceStub", TestProtoLoader.instance().parseDeprecatedService(), ""}
+          {"EchoStub", TestProtoLoader.instance().parseShowcaseEcho()},
+          {"DeprecatedServiceStub", TestProtoLoader.instance().parseDeprecatedService()}
         });
   }
 
@@ -41,9 +41,6 @@ public class ServiceStubClassComposerTest {
   @Parameterized.Parameter(1)
   public GapicContext context;
 
-  @Parameterized.Parameter(2)
-  public String defaultHostExpected;
-
   @Test
   public void generateServiceStubClasses() {
     Service service = context.services().get(0);
@@ -51,6 +48,5 @@ public class ServiceStubClassComposerTest {
 
     Assert.assertGoldenClass(this.getClass(), clazz, name + ".golden");
     Assert.assertEmptySamples(clazz.samples());
-    Assert.assertCodeEquals(clazz.defaultHost(), defaultHostExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubClassComposerTest.java
@@ -31,8 +31,8 @@ public class ServiceStubClassComposerTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"EchoStub", TestProtoLoader.instance().parseShowcaseEcho()},
-          {"DeprecatedServiceStub", TestProtoLoader.instance().parseDeprecatedService()}
+          {"EchoStub", TestProtoLoader.instance().parseShowcaseEcho(), "", ""},
+          {"DeprecatedServiceStub", TestProtoLoader.instance().parseDeprecatedService(), "", ""}
         });
   }
 
@@ -41,6 +41,12 @@ public class ServiceStubClassComposerTest {
   @Parameterized.Parameter(1)
   public GapicContext context;
 
+  @Parameterized.Parameter(2)
+  public String apiShortNameExpected;
+
+  @Parameterized.Parameter(3)
+  public String apiVersionExpected;
+
   @Test
   public void generateServiceStubClasses() {
     Service service = context.services().get(0);
@@ -48,5 +54,7 @@ public class ServiceStubClassComposerTest {
 
     Assert.assertGoldenClass(this.getClass(), clazz, name + ".golden");
     Assert.assertEmptySamples(clazz.samples());
+    Assert.assertCodeEquals(clazz.apiShortName(), apiShortNameExpected);
+    Assert.assertCodeEquals(clazz.apiVersion(), apiVersionExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
@@ -31,17 +31,28 @@ public class ServiceStubSettingsClassComposerTest {
     return Arrays.asList(
         new Object[][] {
           {
-            "LoggingServiceV2StubSettings", GrpcTestProtoLoader.instance().parseLogging(),
+            "LoggingServiceV2StubSettings",
+            GrpcTestProtoLoader.instance().parseLogging(),
+            "logging",
+            "v2"
           },
           {
-            "PublisherStubSettings", GrpcTestProtoLoader.instance().parsePubSubPublisher(),
+            "PublisherStubSettings",
+            GrpcTestProtoLoader.instance().parsePubSubPublisher(),
+            "pubsub",
+            "v1"
           },
           {
-            "EchoStubSettings", GrpcTestProtoLoader.instance().parseShowcaseEcho(),
+            "EchoStubSettings",
+            GrpcTestProtoLoader.instance().parseShowcaseEcho(),
+            "localhost:7469",
+            "v1beta1"
           },
           {
             "DeprecatedServiceStubSettings",
             GrpcTestProtoLoader.instance().parseDeprecatedService(),
+            "localhost:7469",
+            "v1"
           }
         });
   }
@@ -50,6 +61,12 @@ public class ServiceStubSettingsClassComposerTest {
 
   @Parameterized.Parameter(1)
   public GapicContext context;
+
+  @Parameterized.Parameter(2)
+  public String apiShortNameExpected;
+
+  @Parameterized.Parameter(3)
+  public String apiVersionExpected;
 
   @Test
   public void generateServiceStubSettingsClasses() {
@@ -62,5 +79,7 @@ public class ServiceStubSettingsClassComposerTest {
         "servicesettings/stub",
         clazz.classDefinition().packageString(),
         clazz.samples());
+    Assert.assertCodeEquals(clazz.apiShortName(), apiShortNameExpected);
+    Assert.assertCodeEquals(clazz.apiVersion(), apiVersionExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpc/ServiceStubSettingsClassComposerTest.java
@@ -31,22 +31,17 @@ public class ServiceStubSettingsClassComposerTest {
     return Arrays.asList(
         new Object[][] {
           {
-            "LoggingServiceV2StubSettings",
-            GrpcTestProtoLoader.instance().parseLogging(),
-            "logging.googleapis.com:443"
+            "LoggingServiceV2StubSettings", GrpcTestProtoLoader.instance().parseLogging(),
           },
           {
-            "PublisherStubSettings",
-            GrpcTestProtoLoader.instance().parsePubSubPublisher(),
-            "pubsub.googleapis.com:443"
+            "PublisherStubSettings", GrpcTestProtoLoader.instance().parsePubSubPublisher(),
           },
           {
-            "EchoStubSettings", GrpcTestProtoLoader.instance().parseShowcaseEcho(), "localhost:7469"
+            "EchoStubSettings", GrpcTestProtoLoader.instance().parseShowcaseEcho(),
           },
           {
             "DeprecatedServiceStubSettings",
             GrpcTestProtoLoader.instance().parseDeprecatedService(),
-            "localhost:7469"
           }
         });
   }
@@ -55,9 +50,6 @@ public class ServiceStubSettingsClassComposerTest {
 
   @Parameterized.Parameter(1)
   public GapicContext context;
-
-  @Parameterized.Parameter(2)
-  public String defaultHostExpected;
 
   @Test
   public void generateServiceStubSettingsClasses() {
@@ -70,6 +62,5 @@ public class ServiceStubSettingsClassComposerTest {
         "servicesettings/stub",
         clazz.classDefinition().packageString(),
         clazz.samples());
-    Assert.assertCodeEquals(clazz.defaultHost(), defaultHostExpected);
   }
 }

--- a/src/test/java/com/google/api/generator/gapic/model/ServiceTest.java
+++ b/src/test/java/com/google/api/generator/gapic/model/ServiceTest.java
@@ -1,0 +1,75 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class ServiceTest {
+  private static final String SHOWCASE_PACKAGE_NAME = "com.google.showcase.v1beta1";
+  private static final Service.Builder testServiceBuilder =
+      Service.builder()
+          .setName("Echo")
+          .setDefaultHost("localhost:7469")
+          .setOauthScopes(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"))
+          .setPakkage(SHOWCASE_PACKAGE_NAME)
+          .setProtoPakkage(SHOWCASE_PACKAGE_NAME)
+          .setOriginalJavaPackage(SHOWCASE_PACKAGE_NAME)
+          .setOverriddenName("Echo");
+
+  @Test
+  public void apiShortName_shouldReturnApiShortNameIfHostContainsRegionalEndpoint() {
+    String defaultHost = "us-east1-pubsub.googleapis.com";
+    Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
+    assertEquals("pubsub", testService.apiShortName());
+  }
+
+  @Test
+  public void apiShortName_shouldReturnApiShortName() {
+    String defaultHost = "logging.googleapis.com";
+    Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
+    assertEquals("logging", testService.apiShortName());
+  }
+
+  @Test
+  public void apiShortName_shouldReturnApiShortNameForIam() {
+    String defaultHost = "iam-meta-api.googleapis.com";
+    Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
+    assertEquals("iam", testService.apiShortName());
+  }
+
+  @Test
+  public void apiShortName_shouldReturnHostIfNoPeriods() {
+    String defaultHost = "logging:7469";
+    Service testService = testServiceBuilder.setDefaultHost(defaultHost).build();
+    assertEquals("logging:7469", testService.apiShortName());
+  }
+
+  @Test
+  public void apiVersion_shouldReturnVersionIfMatch() {
+    String protoPackage = "com.google.showcase.v1";
+    Service testService = testServiceBuilder.setProtoPakkage(protoPackage).build();
+    assertEquals("v1", testService.apiVersion());
+  }
+
+  @Test
+  public void apiVersion_shouldReturnEmptyIfNoMatch() {
+    String protoPackage = "com.google.showcase";
+    Service testService = testServiceBuilder.setProtoPakkage(protoPackage).build();
+    assertEquals("", testService.apiVersion());
+  }
+}


### PR DESCRIPTION
Follow-up to #1066.

This PR exposes parsed `apiShortName` and `apiVersion` as fields in `Service.java`, since the source fields (defaultHost and protoPakkage) are both defined per-service. It also:

- Adds these two fields correspondingly to GapicClass so that it can be composed from Service given these two upstream fields, then replaces `withDefaultHost` (for building GapicClass) added in #1040 with `withApiShortName` and `withApiVersion`. (Composers and tests where this is currently used for sample generation are updated) 

This change will enable Spring Codegen (when eventually split out from this repo) to reuse this parsing logic in descriptive comments and metadata. It also moves the parsing logic to earlier in the parse-compose process.

