### PR TITLE
fix(ast): add import generation for annotations on VariableExpr

### DIFF
--- a/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
+++ b/src/main/java/com/google/api/generator/engine/writer/ImportWriterVisitor.java
@@ -183,6 +183,7 @@ public class ImportWriterVisitor implements AstNodeVisitor {
   @Override
   public void visit(VariableExpr variableExpr) {
     variableExpr.variable().type().accept(this);
+    annotations(variableExpr.annotations());
     if (variableExpr.exprReferenceExpr() != null) {
       variableExpr.exprReferenceExpr().accept(this);
     }

--- a/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
+++ b/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
@@ -37,6 +37,7 @@ import com.google.api.generator.engine.ast.MethodDefinition;
 import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.NewObjectExpr;
 import com.google.api.generator.engine.ast.PackageInfoDefinition;
+import com.google.api.generator.engine.ast.PrimitiveValue;
 import com.google.api.generator.engine.ast.Reference;
 import com.google.api.generator.engine.ast.ReferenceConstructorExpr;
 import com.google.api.generator.engine.ast.RelationalOperationExpr;
@@ -360,6 +361,41 @@ public class ImportWriterVisitorTest {
             "import com.google.api.generator.engine.ast.AssignmentExpr;\n",
             "import com.google.api.generator.engine.ast.Expr;\n",
             "import com.google.api.generator.engine.ast.VariableExpr;\n\n"),
+        writerVisitor.write());
+  }
+
+  @Test
+  public void writeVariableExprImports_withAnnotations() {
+    Variable variable =
+        Variable.builder()
+            .setName("expr")
+            .setType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
+            .build();
+
+    TypeNode fakeAnnotationType =
+        TypeNode.withReference(
+            VaporReference.builder().setName("FakeAnnotation").setPakkage("com.foo.bar").build());
+
+    AnnotationNode annotation =
+        AnnotationNode.builder()
+            .setType(fakeAnnotationType)
+            .setDescription(
+                ValueExpr.withValue(
+                    PrimitiveValue.builder().setValue("1").setType(TypeNode.INT).build()))
+            .build();
+
+    VariableExpr variableExpr =
+        VariableExpr.builder()
+            .setVariable(variable)
+            .setIsDecl(true)
+            .setAnnotations(Arrays.asList(annotation))
+            .build();
+
+    variableExpr.accept(writerVisitor);
+    assertEquals(
+        LineFormatter.lines(
+            "import com.foo.bar.FakeAnnotation;\n",
+            "import com.google.api.generator.engine.ast.Expr;\n\n"),
         writerVisitor.write());
   }
 

--- a/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
+++ b/src/test/java/com/google/api/generator/engine/writer/ImportWriterVisitorTest.java
@@ -37,7 +37,6 @@ import com.google.api.generator.engine.ast.MethodDefinition;
 import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.NewObjectExpr;
 import com.google.api.generator.engine.ast.PackageInfoDefinition;
-import com.google.api.generator.engine.ast.PrimitiveValue;
 import com.google.api.generator.engine.ast.Reference;
 import com.google.api.generator.engine.ast.ReferenceConstructorExpr;
 import com.google.api.generator.engine.ast.RelationalOperationExpr;
@@ -372,30 +371,21 @@ public class ImportWriterVisitorTest {
             .setType(TypeNode.withReference(ConcreteReference.withClazz(Expr.class)))
             .build();
 
-    TypeNode fakeAnnotationType =
-        TypeNode.withReference(
-            VaporReference.builder().setName("FakeAnnotation").setPakkage("com.foo.bar").build());
-
-    AnnotationNode annotation =
-        AnnotationNode.builder()
-            .setType(fakeAnnotationType)
-            .setDescription(
-                ValueExpr.withValue(
-                    PrimitiveValue.builder().setValue("1").setType(TypeNode.INT).build()))
-            .build();
-
     VariableExpr variableExpr =
         VariableExpr.builder()
             .setVariable(variable)
             .setIsDecl(true)
-            .setAnnotations(Arrays.asList(annotation))
+            .setAnnotations(
+                Arrays.asList(
+                    AnnotationNode.withType(
+                        TypeNode.withReference(ConcreteReference.withClazz(Generated.class)))))
             .build();
 
     variableExpr.accept(writerVisitor);
     assertEquals(
         LineFormatter.lines(
-            "import com.foo.bar.FakeAnnotation;\n",
-            "import com.google.api.generator.engine.ast.Expr;\n\n"),
+            "import com.google.api.generator.engine.ast.Expr;\n",
+            "import javax.annotation.Generated;\n\n"),
         writerVisitor.write());
   }
 


### PR DESCRIPTION
This PR is a follow-up patch to #1012 which added support for annotations on `VariableExpr`. It updates `ImportWriterVisitor `so that import generation also covers these annotations. 

Note: the Spring CodeGen branch ([autoconfig-gen-draft2](https://github.com/googleapis/gapic-generator-java/tree/autoconfig-gen-draft2)) will need a rebase after this is merged, and have its golden test files updated to reflect this change.