### PR TITLE
fix: fix REST transport client creation generated javadoc sample

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpcrest/ServiceClientClassComposer.java
@@ -59,7 +59,7 @@ public class ServiceClientClassComposer extends AbstractServiceClientClassCompos
         ServiceClientHeaderSampleComposer.composeSetEndpointSample(clientType, settingsType);
     Sample transportSampleCode =
         ServiceClientHeaderSampleComposer.composeTransportSample(
-            clientType, settingsType, "defaultHttpJsonTransportProviderBuilder");
+            clientType, settingsType, "newHttpJsonBuilder");
     samples.addAll(
         Arrays.asList(
             classMethodSampleCode, credentialsSampleCode, endpointSampleCode, transportSampleCode));

--- a/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/samplecode/ServiceClientHeaderSampleComposer.java
@@ -285,7 +285,7 @@ public class ServiceClientHeaderSampleComposer {
   }
 
   public static Sample composeTransportSample(
-      TypeNode clientType, TypeNode settingsType, String transportProviderMethod) {
+      TypeNode clientType, TypeNode settingsType, String transportBuilderMethod) {
     String settingsName = JavaStyle.toLowerCamelCase(settingsType.reference().name());
     String clientName = JavaStyle.toLowerCamelCase(clientType.reference().name());
     VariableExpr settingsVarExpr =
@@ -294,26 +294,11 @@ public class ServiceClientHeaderSampleComposer {
     MethodInvocationExpr newBuilderMethodExpr =
         MethodInvocationExpr.builder()
             .setStaticReferenceType(settingsType)
-            .setMethodName("newBuilder")
-            .build();
-    MethodInvocationExpr transportChannelProviderArg =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(
-                MethodInvocationExpr.builder()
-                    .setStaticReferenceType(settingsType)
-                    .setMethodName(transportProviderMethod)
-                    .build())
-            .setMethodName("build")
-            .build();
-    MethodInvocationExpr credentialsMethodExpr =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(newBuilderMethodExpr)
-            .setArguments(transportChannelProviderArg)
-            .setMethodName("setTransportChannelProvider")
+            .setMethodName(transportBuilderMethod)
             .build();
     MethodInvocationExpr buildMethodExpr =
         MethodInvocationExpr.builder()
-            .setExprReferenceExpr(credentialsMethodExpr)
+            .setExprReferenceExpr(newBuilderMethodExpr)
             .setReturnType(settingsType)
             .setMethodName("build")
             .build();

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -105,11 +105,7 @@ import javax.annotation.Generated;
  * // - It may require correct/in-range values for request initialization.
  * // - It may require specifying regional endpoints when creating the service client as shown in
  * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
- * EchoSettings echoSettings =
- *     EchoSettings.newBuilder()
- *         .setTransportChannelProvider(
- *             EchoSettings.defaultHttpJsonTransportProviderBuilder().build())
- *         .build();
+ * EchoSettings echoSettings = EchoSettings.newHttpJsonBuilder().build();
  * EchoClient echoClient = EchoClient.create(echoSettings);
  * }</pre>
  *

--- a/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoEmpty.golden
+++ b/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoEmpty.golden
@@ -85,11 +85,7 @@ import javax.annotation.Generated;
  * // - It may require correct/in-range values for request initialization.
  * // - It may require specifying regional endpoints when creating the service client as shown in
  * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
- * EchoEmpySettings echoEmpySettings =
- *     EchoEmpySettings.newBuilder()
- *         .setTransportChannelProvider(
- *             EchoEmpySettings.defaultHttpJsonTransportProviderBuilder().build())
- *         .build();
+ * EchoEmpySettings echoEmpySettings = EchoEmpySettings.newHttpJsonBuilder().build();
  * EchoEmpyClient echoEmpyClient = EchoEmpyClient.create(echoEmpySettings);
  * }</pre>
  *


### PR DESCRIPTION
The old version also worked for the most part, but it is longer and also does not configure proper headers for statistics gathering.