### PR TITLE
fix(spring): use parsed api shortname as libname

### DIFF
--- a/src/main/java/com/google/api/generator/spring/utils/Utils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/Utils.java
@@ -64,12 +64,7 @@ public class Utils {
 
     // Option 3: Use parsed apiShortName from service proto's default host
     // (e.g. vision.googleapis.com => vision)
-    String apiShortName = context.services().get(0).apiShortName();
-    // Cover special case with showcase (localhost:7469) for testing
-    if (apiShortName.equals("localhost:7469")) {
-      apiShortName = "showcase";
-    }
-    return apiShortName;
+    return context.services().get(0).apiShortName();
   }
 
   public static String getPackageName(GapicContext context) {

--- a/src/main/java/com/google/api/generator/spring/utils/Utils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/Utils.java
@@ -65,7 +65,7 @@ public class Utils {
     // Option 3: Use parsed apiShortName from service proto's default host
     // (e.g. vision.googleapis.com => vision)
     String apiShortName = context.services().get(0).apiShortName();
-    // For testing with showcase (localhost:7469)
+    // Cover special case with showcase (localhost:7469) for testing
     if (apiShortName.equals("localhost:7469")) {
       apiShortName = "showcase";
     }

--- a/src/main/java/com/google/api/generator/spring/utils/Utils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/Utils.java
@@ -28,7 +28,6 @@ import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import io.grpc.serviceconfig.MethodConfig.RetryPolicy;
@@ -60,12 +59,17 @@ public class Utils {
     // discrepancies
     // eg. for vision proto: "com.google.cloud.vision.v1"
     // https://github.com/googleapis/java-vision/blob/main/proto-google-cloud-vision-v1/src/main/proto/google/cloud/vision/v1/image_annotator.proto#L36
-    List<String> pakkagePhrases = Splitter.on(".").splitToList(getPackageName(context));
-    return pakkagePhrases.get(pakkagePhrases.size() - 2);
+    // List<String> pakkagePhrases = Splitter.on(".").splitToList(getPackageName(context));
+    // return pakkagePhrases.get(pakkagePhrases.size() - 2);
 
-    // Option 3: Parse ApiShortName from service proto's default host (e.g. vision.googleapis.com)
-    // TODO: Replace implementation above to reuse parsing logic from SampleGen:
-    //  https://github.com/googleapis/gapic-generator-java/pull/1040
+    // Option 3: Use parsed apiShortName from service proto's default host
+    // (e.g. vision.googleapis.com => vision)
+    String apiShortName = context.services().get(0).apiShortName();
+    // For testing with showcase (localhost:7469)
+    if (apiShortName.equals("localhost:7469")) {
+      apiShortName = "showcase";
+    }
+    return apiShortName;
   }
 
   public static String getPackageName(GapicContext context) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/SpringPackageInfo.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/SpringPackageInfo.golden
@@ -1,4 +1,4 @@
-/** Spring Boot auto-configurations for showcase. */
+/** Spring Boot auto-configurations for localhost:7469. */
 @Generated("by gapic-generator-java")
 package com.google.showcase.v1beta1.spring;
 

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/SpringPackageInfoFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/SpringPackageInfoFull.golden
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/** Spring Boot auto-configurations for showcase. */
+/** Spring Boot auto-configurations for localhost:7469. */
 @Generated("by gapic-generator-java")
 package com.google.showcase.v1beta1.spring;
 

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringAdditionalMetadataJson.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringAdditionalMetadataJson.golden
@@ -3,7 +3,7 @@
     {
       "name": "com.google.showcase.v1beta1.spring.auto.echo.enabled",
       "type": "java.lang.Boolean",
-      "description": "Auto-configure Google Cloud showcase/Echo components.",
+      "description": "Auto-configure Google Cloud localhost:7469/Echo components.",
       "defaultValue": true
     }
   ]

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -6,8 +6,8 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>
   <version>{{starter-version}}</version>
-  <name>Spring Boot Starter - showcase</name>
-  <description>Spring Boot Starter with AutoConfiguration for showcase</description>
+  <name>Spring Boot Starter - localhost:7469</name>
+  <description>Spring Boot Starter with AutoConfiguration for localhost:7469</description>
 
 
   <dependencies>


### PR DESCRIPTION
Follow-up PR to switch `getLibName()` to use apiShortName parsed from default host.
- ~Added an extra conversion for showcase (which we unit test with), which uses `localhost:7469` and does not parse to a pretty libname. (This means the current spring golden tests don't really cover other cases of `getLibName()`, but the logic itself also lives upstream)~   