### PR TITLE
feat(pom): optional parent coordinates

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -115,6 +115,12 @@ java_binary(
     runtime_deps = [":gapic_generator_java"] + MAIN_DEPS,
 )
 
+java_binary(
+    name = "protoc-gen-java_gapic_spring",
+    main_class = "com.google.api.generator.spring.Main",
+    runtime_deps = [":gapic_generator_java"] + MAIN_DEPS,
+)
+
 # Request dumper binary, which dumps the CodeGeneratorRequest to a file on disk
 # which will be identical to the one passed to the protoc-gen-java_gapic during
 # normal execution. The dumped file then can be used to run this gapic-generator

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -190,7 +190,6 @@ def _java_gapic_srcjar(
         # possible values are: "grpc", "rest", "grpc+rest"
         transport,
         rest_numeric_enums,
-        spring_parent_coordinates,
         # Can be used to provide a java_library with a customized generator,
         # like the one which dumps descriptor to a file for future debugging.
         java_generator_name = "java_gapic",
@@ -217,9 +216,6 @@ def _java_gapic_srcjar(
 
     if rest_numeric_enums:
         opt_args.append("rest-numeric-enums")
-
-    if spring_parent_coordinates:
-        opt_args.append("spring-parent-coordinates=%s" % spring_parent_coordinates)
 
     # Produces the GAPIC metadata file if this flag is set. to any value.
     # Protoc invocation: --java_gapic_opt=metadata
@@ -249,7 +245,6 @@ def java_gapic_library(
         # possible values are: "grpc", "rest", "grpc+rest"
         transport = None,
         rest_numeric_enums = False,
-        spring_parent_coordinates = None,
         **kwargs):
     srcjar_name = name + "_srcjar"
     raw_srcjar_name = srcjar_name + "_raw"
@@ -262,7 +257,6 @@ def java_gapic_library(
         service_yaml = service_yaml,
         transport = transport,
         rest_numeric_enums = rest_numeric_enums,
-        spring_parent_coordinates = spring_parent_coordinates,
         java_generator_name = "java_gapic",
         **kwargs
     )

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -190,6 +190,7 @@ def _java_gapic_srcjar(
         # possible values are: "grpc", "rest", "grpc+rest"
         transport,
         rest_numeric_enums,
+        spring_parent_coordinates,
         # Can be used to provide a java_library with a customized generator,
         # like the one which dumps descriptor to a file for future debugging.
         java_generator_name = "java_gapic",
@@ -216,6 +217,9 @@ def _java_gapic_srcjar(
 
     if rest_numeric_enums:
         opt_args.append("rest-numeric-enums")
+
+    if spring_parent_coordinates:
+        opt_args.append("spring-parent-coordinates=%s" % spring_parent_coordinates)
 
     # Produces the GAPIC metadata file if this flag is set. to any value.
     # Protoc invocation: --java_gapic_opt=metadata
@@ -245,6 +249,7 @@ def java_gapic_library(
         # possible values are: "grpc", "rest", "grpc+rest"
         transport = None,
         rest_numeric_enums = False,
+        spring_parent_coordinates = None,
         **kwargs):
     srcjar_name = name + "_srcjar"
     raw_srcjar_name = srcjar_name + "_raw"
@@ -257,6 +262,7 @@ def java_gapic_library(
         service_yaml = service_yaml,
         transport = transport,
         rest_numeric_enums = rest_numeric_enums,
+        spring_parent_coordinates = spring_parent_coordinates,
         java_generator_name = "java_gapic",
         **kwargs
     )

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -22,7 +22,6 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
     output_main = ctx.outputs.main
     output_test = ctx.outputs.test
     output_samples = ctx.outputs.samples
-    output_spring = ctx.outputs.spring
     output_resource_name = ctx.outputs.resource_name
     formatter = ctx.executable.formatter
 
@@ -66,21 +65,10 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
 
     cd $WORKING_DIR
 
-    unzip -q temp-codegen-spring.srcjar -d {output_dir_path}/spring
-    # This may fail if there are spaces and/or too many files (exceed max length of command length).
-    {formatter} --replace $(find {output_dir_path}/spring -type f -printf "%p ")
-
-    # Spring source files.
-    cd {output_dir_path}/spring
-    zip -r $WORKING_DIR/{output_srcjar_name}-spring.srcjar ./
-
-    cd $WORKING_DIR
-
     mv {output_srcjar_name}.srcjar {output_main}
     mv {output_srcjar_name}-resource-name.srcjar {output_resource_name}
     mv {output_srcjar_name}-tests.srcjar {output_test}
     mv {output_srcjar_name}-samples.srcjar {output_samples}
-    mv {output_srcjar_name}-spring.srcjar {output_spring}
     """.format(
         gapic_srcjar = gapic_srcjar.path,
         output_srcjar_name = output_srcjar_name,
@@ -91,14 +79,13 @@ def _java_gapic_postprocess_srcjar_impl(ctx):
         output_resource_name = output_resource_name.path,
         output_test = output_test.path,
         output_samples = output_samples.path,
-        output_spring = output_spring.path,
     )
 
     ctx.actions.run_shell(
         inputs = [gapic_srcjar],
         tools = [formatter],
         command = script,
-        outputs = [output_main, output_resource_name, output_test, output_samples, output_spring],
+        outputs = [output_main, output_resource_name, output_test, output_samples],
     )
 
 _java_gapic_postprocess_srcjar = rule(
@@ -115,7 +102,6 @@ _java_gapic_postprocess_srcjar = rule(
         "resource_name": "%{name}-resource-name.srcjar",
         "test": "%{name}-test.srcjar",
         "samples": "%{name}-samples.srcjar",
-        "spring": "%{name}-spring.srcjar",
     },
     implementation = _java_gapic_postprocess_srcjar_impl,
 )
@@ -173,61 +159,6 @@ _java_gapic_samples_srcjar = rule(
         "samples": "%{name}-samples.srcjar",
     },
     implementation = _java_gapic_samples_srcjar_impl,
-)
-
-def _java_gapic_spring_srcjar_impl(ctx):
-    gapic_srcjar = ctx.file.gapic_srcjar
-    output_srcjar_name = ctx.label.name
-    output_spring = ctx.outputs.spring
-    formatter = ctx.executable.formatter
-
-    output_dir_name = ctx.label.name
-    output_dir_path = "%s/%s" % (output_spring.dirname, output_dir_name)
-
-    script = """
-    unzip -q {gapic_srcjar}
-    # Sync'd to the output file name in Writer.java.
-    unzip -q temp-codegen-spring.srcjar -d {output_dir_path}
-    # This may fail if there are spaces and/or too many files (exceed max length of command length).
-    {formatter} --replace $(find {output_dir_path}/spring -type f -printf "%p ")
-    WORKING_DIR=`pwd`
-
-    # Spring source files.
-    cd $WORKING_DIR/{output_dir_path}
-    zip -r $WORKING_DIR/{output_srcjar_name}-spring.srcjar ./
-
-    cd $WORKING_DIR
-
-    mv {output_srcjar_name}-spring.srcjar {output_spring}
-    """.format(
-        gapic_srcjar = gapic_srcjar.path,
-        output_srcjar_name = output_srcjar_name,
-        formatter = formatter,
-        output_dir_name = output_dir_name,
-        output_dir_path = output_dir_path,
-        output_spring = output_spring.path,
-    )
-
-    ctx.actions.run_shell(
-        inputs = [gapic_srcjar],
-        tools = [formatter],
-        command = script,
-        outputs = [output_spring],
-    )
-
-_java_gapic_spring_srcjar = rule(
-    attrs = {
-        "gapic_srcjar": attr.label(mandatory = True, allow_single_file = True),
-        "formatter": attr.label(
-            default = Label("//:google_java_format_binary"),
-            executable = True,
-            cfg = "host",
-        ),
-    },
-    outputs = {
-        "spring": "%{name}-spring.srcjar",
-    },
-    implementation = _java_gapic_spring_srcjar_impl,
 )
 
 def _extract_common_proto_dep(dep):
@@ -338,12 +269,6 @@ def java_gapic_library(
 
     _java_gapic_samples_srcjar(
         name = "%s_samples" % name,
-        gapic_srcjar = "%s.srcjar" % raw_srcjar_name,
-        **kwargs
-    )
-
-    _java_gapic_spring_srcjar(
-        name = "%s_spring" % name,
         gapic_srcjar = "%s.srcjar" % raw_srcjar_name,
         **kwargs
     )

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -175,7 +175,6 @@ _java_gapic_samples_srcjar = rule(
     implementation = _java_gapic_samples_srcjar_impl,
 )
 
-
 def _java_gapic_spring_srcjar_impl(ctx):
     gapic_srcjar = ctx.file.gapic_srcjar
     output_srcjar_name = ctx.label.name

--- a/rules_java_gapic/java_gapic_spring.bzl
+++ b/rules_java_gapic/java_gapic_spring.bzl
@@ -75,8 +75,6 @@ def java_gapic_spring_library(
         grpc_service_config = None,
         gapic_yaml = None,
         service_yaml = None,
-        deps = [],
-        test_deps = [],
         **kwargs):
     srcjar_name = name + "_srcjar"
     raw_srcjar_name = srcjar_name + "_raw"

--- a/rules_java_gapic/java_gapic_spring.bzl
+++ b/rules_java_gapic/java_gapic_spring.bzl
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#load("@rules_gapic//:gapic.bzl", "proto_custom_library")
-
 load("@rules_gapic//:gapic.bzl", "proto_custom_library")
+
 NO_GRPC_CONFIG_ALLOWLIST = ["library"]
 
 def _java_gapic_spring_postprocess_srcjar_impl(ctx):
@@ -78,9 +77,6 @@ def java_gapic_spring_library(
         service_yaml = None,
         deps = [],
         test_deps = [],
-        # possible values are: "grpc", "rest", "grpc+rest"
-        transport = None,
-        rest_numeric_enums = False,
         **kwargs):
     srcjar_name = name + "_srcjar"
     raw_srcjar_name = srcjar_name + "_raw"
@@ -91,8 +87,6 @@ def java_gapic_spring_library(
         grpc_service_config = grpc_service_config,
         gapic_yaml = gapic_yaml,
         service_yaml = service_yaml,
-        transport = transport,
-        rest_numeric_enums = rest_numeric_enums,
         **kwargs
     )
 
@@ -108,21 +102,11 @@ def _java_gapic_spring_srcjar(
         grpc_service_config,
         gapic_yaml,
         service_yaml,
-        # possible values are: "grpc", "rest", "grpc+rest"
-        transport,
-        rest_numeric_enums,
         # Can be used to provide a java_library with a customized generator,
         # like the one which dumps descriptor to a file for future debugging.
         java_generator_name = "java_gapic_spring",
         **kwargs):
     file_args_dict = {}
-
-    if grpc_service_config:
-        file_args_dict[grpc_service_config] = "grpc-service-config"
-    elif not transport or transport == "grpc":
-        for keyword in NO_GRPC_CONFIG_ALLOWLIST:
-            if keyword not in name:
-                fail("Missing a gRPC service config file")
 
     if gapic_yaml:
         file_args_dict[gapic_yaml] = "gapic-config"
@@ -131,12 +115,6 @@ def _java_gapic_spring_srcjar(
         file_args_dict[service_yaml] = "api-service-config"
 
     opt_args = []
-
-    if transport:
-        opt_args.append("transport=%s" % transport)
-
-    if rest_numeric_enums:
-        opt_args.append("rest-numeric-enums")
 
     # Produces the GAPIC metadata file if this flag is set. to any value.
     # Protoc invocation: --java_gapic_opt=metadata

--- a/rules_java_gapic/java_gapic_spring.bzl
+++ b/rules_java_gapic/java_gapic_spring.bzl
@@ -78,6 +78,7 @@ def java_gapic_spring_library(
         grpc_service_config = None,
         gapic_yaml = None,
         service_yaml = None,
+        spring_parent_coordinates = None,
         **kwargs):
     library_name = name + "-spring"
     raw_srcjar_name = name + "_raw"
@@ -88,6 +89,7 @@ def java_gapic_spring_library(
         grpc_service_config = grpc_service_config,
         gapic_yaml = gapic_yaml,
         service_yaml = service_yaml,
+        spring_parent_coordinates = spring_parent_coordinates,
         **kwargs
     )
 
@@ -103,6 +105,7 @@ def _java_gapic_spring_srcjar(
         grpc_service_config,
         gapic_yaml,
         service_yaml,
+        spring_parent_coordinates,
         # Can be used to provide a java_library with a customized generator,
         # like the one which dumps descriptor to a file for future debugging.
         java_generator_name = "java_gapic_spring",
@@ -116,6 +119,9 @@ def _java_gapic_spring_srcjar(
         file_args_dict[service_yaml] = "api-service-config"
 
     opt_args = []
+
+    if spring_parent_coordinates:
+        opt_args.append("spring-parent-coordinates=%s" % spring_parent_coordinates)
 
     # Produces the GAPIC metadata file if this flag is set. to any value.
     # Protoc invocation: --java_gapic_opt=metadata

--- a/rules_java_gapic/java_gapic_spring.bzl
+++ b/rules_java_gapic/java_gapic_spring.bzl
@@ -1,0 +1,156 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#load("@rules_gapic//:gapic.bzl", "proto_custom_library")
+
+load("@rules_gapic//:gapic.bzl", "proto_custom_library")
+NO_GRPC_CONFIG_ALLOWLIST = ["library"]
+
+def _java_gapic_spring_postprocess_srcjar_impl(ctx):
+    gapic_srcjar = ctx.file.gapic_srcjar
+    output_srcjar_name = ctx.label.name
+    output_spring = ctx.outputs.spring
+    formatter = ctx.executable.formatter
+
+    output_dir_name = ctx.label.name
+    output_dir_path = "%s/%s" % (output_spring.dirname, output_dir_name)
+
+    script = """
+    cd $WORKING_DIR
+
+    unzip -q temp-codegen-spring.srcjar -d {output_dir_path}/spring
+    # This may fail if there are spaces and/or too many files (exceed max length of command length).
+    {formatter} --replace $(find {output_dir_path}/spring -type f -printf "%p ")
+
+    # Spring source files.
+    cd {output_dir_path}/spring
+    zip -r $WORKING_DIR/{output_srcjar_name}-spring.srcjar ./
+
+    cd $WORKING_DIR
+
+    mv {output_srcjar_name}-spring.srcjar {output_spring}
+    """.format(
+        output_srcjar_name = output_srcjar_name,
+        formatter = formatter,
+        output_dir_name = output_dir_name,
+        output_dir_path = output_dir_path,
+        output_spring = output_spring.path,
+    )
+
+    ctx.actions.run_shell(
+        inputs = [gapic_srcjar],
+        tools = [formatter],
+        command = script,
+        outputs = [output_spring],
+    )
+
+_java_gapic_spring_postprocess_srcjar = rule(
+    attrs = {
+        "gapic_srcjar": attr.label(mandatory = True, allow_single_file = True),
+        "formatter": attr.label(
+            default = Label("//:google_java_format_binary"),
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    outputs = {
+        "spring": "%{name}-spring.srcjar",
+    },
+    implementation = _java_gapic_spring_postprocess_srcjar_impl,
+)
+
+def java_gapic_spring_library(
+        name,
+        srcs,
+        grpc_service_config = None,
+        gapic_yaml = None,
+        service_yaml = None,
+        deps = [],
+        test_deps = [],
+        # possible values are: "grpc", "rest", "grpc+rest"
+        transport = None,
+        rest_numeric_enums = False,
+        **kwargs):
+    srcjar_name = name + "_srcjar"
+    raw_srcjar_name = srcjar_name + "_raw"
+
+    _java_gapic_spring_srcjar(
+        name = raw_srcjar_name,
+        srcs = srcs,
+        grpc_service_config = grpc_service_config,
+        gapic_yaml = gapic_yaml,
+        service_yaml = service_yaml,
+        transport = transport,
+        rest_numeric_enums = rest_numeric_enums,
+        **kwargs
+    )
+
+    _java_gapic_spring_postprocess_srcjar(
+        name = srcjar_name,
+        gapic_srcjar = "%s.srcjar" % raw_srcjar_name,
+        **kwargs
+    )
+
+def _java_gapic_spring_srcjar(
+        name,
+        srcs,
+        grpc_service_config,
+        gapic_yaml,
+        service_yaml,
+        # possible values are: "grpc", "rest", "grpc+rest"
+        transport,
+        rest_numeric_enums,
+        # Can be used to provide a java_library with a customized generator,
+        # like the one which dumps descriptor to a file for future debugging.
+        java_generator_name = "java_gapic_spring",
+        **kwargs):
+    file_args_dict = {}
+
+    if grpc_service_config:
+        file_args_dict[grpc_service_config] = "grpc-service-config"
+    elif not transport or transport == "grpc":
+        for keyword in NO_GRPC_CONFIG_ALLOWLIST:
+            if keyword not in name:
+                fail("Missing a gRPC service config file")
+
+    if gapic_yaml:
+        file_args_dict[gapic_yaml] = "gapic-config"
+
+    if service_yaml:
+        file_args_dict[service_yaml] = "api-service-config"
+
+    opt_args = []
+
+    if transport:
+        opt_args.append("transport=%s" % transport)
+
+    if rest_numeric_enums:
+        opt_args.append("rest-numeric-enums")
+
+    # Produces the GAPIC metadata file if this flag is set. to any value.
+    # Protoc invocation: --java_gapic_opt=metadata
+    plugin_args = ["metadata"]
+
+    proto_custom_library(
+        name = name,
+        deps = srcs,
+        plugin = Label("@gapic_generator_java//:protoc-gen-%s" % java_generator_name),
+        plugin_args = plugin_args,
+        plugin_file_args = {},
+        opt_file_args = file_args_dict,
+        output_type = java_generator_name,
+        output_suffix = ".srcjar",
+        opt_args = opt_args,
+        **kwargs
+    )

--- a/src/main/java/com/google/api/generator/gapic/model/GapicContext.java
+++ b/src/main/java/com/google/api/generator/gapic/model/GapicContext.java
@@ -49,6 +49,9 @@ public abstract class GapicContext {
 
   public abstract boolean restNumericEnumsEnabled();
 
+  @Nullable
+  public abstract String springParentCoordinates();
+
   public GapicMetadata gapicMetadata() {
     return gapicMetadata;
   }
@@ -112,6 +115,8 @@ public abstract class GapicContext {
     public abstract Builder setGapicMetadataEnabled(boolean gapicMetadataEnabled);
 
     public abstract Builder setRestNumericEnumsEnabled(boolean restNumericEnumsEnabled);
+
+    public abstract Builder setSpringParentCoordinates(String springParentCoordinates);
 
     public abstract Builder setTransport(Transport transport);
 

--- a/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -118,6 +118,7 @@ public class Parser {
     Optional<GapicLanguageSettings> languageSettingsOpt =
         GapicLanguageSettingsParser.parse(gapicYamlConfigPathOpt);
     Optional<String> transportOpt = PluginArgumentParser.parseTransport(request);
+    Optional<String> springParent = PluginArgumentParser.parseSpringParentCoordinates(request);
 
     boolean willGenerateMetadata = PluginArgumentParser.hasMetadataFlag(request);
     boolean willGenerateNumericEnum = PluginArgumentParser.hasNumericEnumFlag(request);
@@ -218,6 +219,7 @@ public class Parser {
         .setServiceYamlProto(serviceYamlProtoOpt.orElse(null))
         .setTransport(transport)
         .setRestNumericEnumsEnabled(willGenerateNumericEnum)
+        .setSpringParentCoordinates(springParent.orElse(null))
         .build();
   }
 

--- a/src/main/java/com/google/api/generator/gapic/protoparser/PluginArgumentParser.java
+++ b/src/main/java/com/google/api/generator/gapic/protoparser/PluginArgumentParser.java
@@ -31,6 +31,7 @@ public class PluginArgumentParser {
   @VisibleForTesting static final String KEY_METADATA = "metadata";
   @VisibleForTesting static final String KEY_NUMERIC_ENUM = "rest-numeric-enums";
   @VisibleForTesting static final String KEY_SERVICE_YAML_CONFIG = "api-service-config";
+  @VisibleForTesting static final String KEY_SPRING_PARENT = "spring-parent-coordinates";
   @VisibleForTesting static final String KEY_TRANSPORT = "transport";
 
   private static final String JSON_FILE_ENDING = "grpc_service_config.json";
@@ -59,6 +60,10 @@ public class PluginArgumentParser {
 
   static boolean hasNumericEnumFlag(CodeGeneratorRequest request) {
     return hasFlag(request.getParameter(), KEY_NUMERIC_ENUM);
+  }
+
+  static Optional<String> parseSpringParentCoordinates(CodeGeneratorRequest request) {
+    return parseConfigArgument(request.getParameter(), KEY_SPRING_PARENT);
   }
 
   /** Expects a comma-separated list of file paths. */

--- a/src/main/java/com/google/api/generator/spring/Main.java
+++ b/src/main/java/com/google/api/generator/spring/Main.java
@@ -1,0 +1,17 @@
+package com.google.api.generator.spring;
+
+import com.google.api.generator.ProtoRegistry;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import java.io.IOException;
+
+public class Main {
+  public static void main(String[] args) throws IOException {
+    ExtensionRegistry registry = ExtensionRegistry.newInstance();
+    ProtoRegistry.registerAllExtensions(registry);
+    CodeGeneratorRequest request = CodeGeneratorRequest.parseFrom(System.in, registry);
+    CodeGeneratorResponse springResponse = SpringGenerator.generateSpring(request);
+    springResponse.writeTo(System.out);
+  }
+}

--- a/src/main/java/com/google/api/generator/spring/Main.java
+++ b/src/main/java/com/google/api/generator/spring/Main.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.api.generator.spring;
 
 import com.google.api.generator.ProtoRegistry;

--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -298,18 +298,17 @@ public class SpringWriter {
     }
     List<String> splitCoords = Splitter.on(':').splitToList(springParentCoordinates);
     Preconditions.checkArgument(
-        splitCoords.size() == 3,
-        "Expected parent coordinates to " + "be 3 elements separated by a colon (:)");
-    String groupId = splitCoords.get(0);
-    String artifactId = splitCoords.get(1);
-    String version = splitCoords.get(2);
-    String template =
-        "  <parent>\n"
-            + "    <artifactId>%s</artifactId>\n"
-            + "    <groupId>%s</groupId>\n"
-            + "    <version>%s</version>\n"
-            + "  </parent>\n";
-    return String.format(template, groupId, artifactId, version);
+        splitCoords.size() >= 2,
+        "Expected parent coordinates to have two or three elements separated by a colon (:)");
+    StringBuilder result = new StringBuilder();
+    result.append("  <parent>\n");
+    result.append(String.format("    <artifactId>%s</artifactId>\n", splitCoords.get(0)));
+    result.append(String.format("    <groupId>%s</groupId>\n", splitCoords.get(1)));
+    if (splitCoords.size() == 3) {
+      result.append(String.format("    <version>%s</version>\n", splitCoords.get(2)));
+    }
+    result.append("  </parent>\n");
+    return result.toString();
   }
 
   private static void writePom(GapicContext context, JarOutputStream jos) {

--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -302,8 +302,8 @@ public class SpringWriter {
         "Expected parent coordinates to have two or three elements separated by a colon (:)");
     StringBuilder result = new StringBuilder();
     result.append("  <parent>\n");
-    result.append(String.format("    <artifactId>%s</artifactId>\n", splitCoords.get(0)));
-    result.append(String.format("    <groupId>%s</groupId>\n", splitCoords.get(1)));
+    result.append(String.format("    <groupId>%s</groupId>\n", splitCoords.get(0)));
+    result.append(String.format("    <artifactId>%s</artifactId>\n", splitCoords.get(1)));
     if (splitCoords.size() == 3) {
       result.append(String.format("    <version>%s</version>\n", splitCoords.get(2)));
     }

--- a/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
+++ b/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class SpringWriterTest {
-  private static final String PARENT_COORDS = "com.google.cloud:generated-parent:3.5.0-SNAPSHOT";
+  private static final String PARENT_COORDS = "com.google.cloud:generated-parent";
   private GapicContext context;
 
   @Before

--- a/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
+++ b/src/test/java/com/google/api/generator/spring/SpringWriterTest.java
@@ -26,11 +26,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class SpringWriterTest {
+  private static final String PARENT_COORDS = "com.google.cloud:generated-parent:3.5.0-SNAPSHOT";
   private GapicContext context;
 
   @Before
   public void setUp() {
-    this.context = TestProtoLoader.instance().parseShowcaseEcho();
+    this.context =
+        TestProtoLoader.instance()
+            .parseShowcaseEcho()
+            .toBuilder()
+            .setSpringParentCoordinates(PARENT_COORDS)
+            .build();
   }
 
   @Test

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -6,7 +6,6 @@
   <parent>
     <artifactId>com.google.cloud</artifactId>
     <groupId>generated-parent</groupId>
-    <version>3.5.0-SNAPSHOT</version>
   </parent>
   <groupId>com.google.cloud</groupId>
   <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>com.google.cloud</artifactId>
-    <groupId>generated-parent</groupId>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>generated-parent</artifactId>
   </parent>
   <groupId>com.google.cloud</groupId>
   <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -3,6 +3,11 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <artifactId>com.google.cloud</artifactId>
+    <groupId>generated-parent</groupId>
+    <version>3.5.0-SNAPSHOT</version>
+  </parent>
   <groupId>com.google.cloud</groupId>
   <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>
   <version>{{starter-version}}</version>


### PR DESCRIPTION
A new option is added in java_gapic_library (soon to be renamed to java_gapic_spring_library) to receive the coordinates of the generated library's pom parent. If it's not provided, the generated pom will not have a parent

Probably pending:
[x] allow ~less than 3~ 2 or 3 colon-separated entries (e.g. `artifactId` + `version`) - may involve a different way of passing an option
[x] validate bazel rule parameter as option input - _update: it is now optional_

update: rebased on [bazel detachment pr](https://github.com/googleapis/gapic-generator-java/pull/1065) - that PR should be merged before reviewing this one