### PR TITLE
refactor: extract and move comment formatting logic to util

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/ClientLibraryPackageInfoComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ClientLibraryPackageInfoComposer.java
@@ -24,15 +24,13 @@ import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.gapic.composer.samplecode.SampleCodeWriter;
 import com.google.api.generator.gapic.composer.samplecode.ServiceClientHeaderSampleComposer;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
+import com.google.api.generator.gapic.composer.utils.CommentFormatter;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.GapicPackageInfo;
 import com.google.api.generator.gapic.model.Sample;
 import com.google.api.generator.gapic.model.Service;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Generated;
 
 public class ClientLibraryPackageInfoComposer {
@@ -80,36 +78,10 @@ public class ClientLibraryPackageInfoComposer {
           javaDocCommentBuilder.addParagraph(
               String.format("%s %s %s", DIVIDER, javaClientName, DIVIDER));
 
-      // TODO(miraleung): Replace this with a comment converter when we support CommonMark.
       if (service.hasDescription()) {
-        String[] descriptionParagraphs = service.description().split("\\n\\n");
-        for (int i = 0; i < descriptionParagraphs.length; i++) {
-          boolean startsWithItemizedList = descriptionParagraphs[i].startsWith(" * ");
-          // Split by listed items, then join newlines.
-          List<String> listItems =
-              Stream.of(descriptionParagraphs[i].split("\\n \\*"))
-                  .map(s -> s.replace("\n", ""))
-                  .collect(Collectors.toList());
-          if (startsWithItemizedList) {
-            // Remove the first asterisk.
-            listItems.set(0, listItems.get(0).substring(2));
-          }
-
-          if (!startsWithItemizedList) {
-            if (i == 0) {
-              javaDocCommentBuilder =
-                  javaDocCommentBuilder.addParagraph(
-                      String.format(SERVICE_DESCRIPTION_HEADER_PATTERN, listItems.get(0)));
-            } else {
-              javaDocCommentBuilder = javaDocCommentBuilder.addParagraph(listItems.get(0));
-            }
-          }
-          if (listItems.size() > 1 || startsWithItemizedList) {
-            javaDocCommentBuilder =
-                javaDocCommentBuilder.addUnorderedList(
-                    listItems.subList(startsWithItemizedList ? 0 : 1, listItems.size()));
-          }
-        }
+        javaDocCommentBuilder =
+            CommentFormatter.formatCommentForJavaDoc(
+                service.description(), javaDocCommentBuilder, SERVICE_DESCRIPTION_HEADER_PATTERN);
       }
 
       javaDocCommentBuilder =

--- a/src/main/java/com/google/api/generator/gapic/composer/ClientLibraryPackageInfoComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/ClientLibraryPackageInfoComposer.java
@@ -80,7 +80,7 @@ public class ClientLibraryPackageInfoComposer {
 
       if (service.hasDescription()) {
         javaDocCommentBuilder =
-            CommentFormatter.formatCommentForJavaDoc(
+            CommentFormatter.formatAndAddToJavaDocComment(
                 service.description(), javaDocCommentBuilder, SERVICE_DESCRIPTION_HEADER_PATTERN);
       }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -18,18 +18,16 @@ import com.google.api.generator.engine.ast.CommentStatement;
 import com.google.api.generator.engine.ast.JavaDocComment;
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
+import com.google.api.generator.gapic.composer.utils.CommentFormatter;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.MethodArgument;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.utils.JavaStyle;
-import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ServiceClientCommentComposer {
   // Tokens.
@@ -121,7 +119,7 @@ public class ServiceClientCommentComposer {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
     if (service.hasDescription()) {
       classHeaderJavadocBuilder =
-          processProtobufComment(
+          CommentFormatter.formatCommentForJavaDoc(
               service.description(),
               classHeaderJavadocBuilder,
               SERVICE_DESCRIPTION_SUMMARY_PATTERN);
@@ -182,7 +180,8 @@ public class ServiceClientCommentComposer {
 
     if (method.hasDescription()) {
       methodJavadocBuilder =
-          processProtobufComment(method.description(), methodJavadocBuilder, null);
+          CommentFormatter.formatCommentForJavaDoc(
+              method.description(), methodJavadocBuilder, null);
     }
 
     if (sampleCodeOpt.isPresent()) {
@@ -240,7 +239,8 @@ public class ServiceClientCommentComposer {
 
     if (method.hasDescription()) {
       methodJavadocBuilder =
-          processProtobufComment(method.description(), methodJavadocBuilder, null);
+          CommentFormatter.formatCommentForJavaDoc(
+              method.description(), methodJavadocBuilder, null);
     }
 
     methodJavadocBuilder.addParagraph(METHOD_DESCRIPTION_SAMPLE_CODE_SUMMARY_STRING);
@@ -259,43 +259,5 @@ public class ServiceClientCommentComposer {
 
   private static CommentStatement toSimpleComment(String comment) {
     return CommentStatement.withComment(JavaDocComment.withComment(comment));
-  }
-
-  // TODO(miraleung): Replace this with a comment converter when we support CommonMark.
-  private static JavaDocComment.Builder processProtobufComment(
-      String rawComment, JavaDocComment.Builder originalCommentBuilder, String firstPattern) {
-    JavaDocComment.Builder commentBuilder = originalCommentBuilder;
-    String[] descriptionParagraphs = rawComment.split("\\n\\n");
-    for (int i = 0; i < descriptionParagraphs.length; i++) {
-      boolean startsWithItemizedList = descriptionParagraphs[i].startsWith(" * ");
-      // Split by listed items, then join newlines.
-      List<String> listItems =
-          Stream.of(descriptionParagraphs[i].split("\\n \\*"))
-              .map(s -> s.replace("\n", ""))
-              .collect(Collectors.toList());
-      if (startsWithItemizedList) {
-        // Remove the first asterisk.
-        listItems.set(0, listItems.get(0).substring(2));
-      }
-      if (!startsWithItemizedList) {
-        if (i == 0) {
-          if (!Strings.isNullOrEmpty(firstPattern)) {
-            commentBuilder =
-                commentBuilder.addParagraph(String.format(firstPattern, listItems.get(0)));
-          } else {
-            commentBuilder = commentBuilder.addParagraph(listItems.get(0));
-          }
-        } else {
-          commentBuilder = commentBuilder.addParagraph(listItems.get(0));
-        }
-      }
-      if (listItems.size() > 1 || startsWithItemizedList) {
-        commentBuilder =
-            commentBuilder.addUnorderedList(
-                listItems.subList(startsWithItemizedList ? 0 : 1, listItems.size()));
-      }
-    }
-
-    return commentBuilder;
   }
 }

--- a/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/comment/ServiceClientCommentComposer.java
@@ -119,7 +119,7 @@ public class ServiceClientCommentComposer {
     JavaDocComment.Builder classHeaderJavadocBuilder = JavaDocComment.builder();
     if (service.hasDescription()) {
       classHeaderJavadocBuilder =
-          CommentFormatter.formatCommentForJavaDoc(
+          CommentFormatter.formatAndAddToJavaDocComment(
               service.description(),
               classHeaderJavadocBuilder,
               SERVICE_DESCRIPTION_SUMMARY_PATTERN);
@@ -180,7 +180,7 @@ public class ServiceClientCommentComposer {
 
     if (method.hasDescription()) {
       methodJavadocBuilder =
-          CommentFormatter.formatCommentForJavaDoc(
+          CommentFormatter.formatAndAddToJavaDocComment(
               method.description(), methodJavadocBuilder, null);
     }
 
@@ -239,7 +239,7 @@ public class ServiceClientCommentComposer {
 
     if (method.hasDescription()) {
       methodJavadocBuilder =
-          CommentFormatter.formatCommentForJavaDoc(
+          CommentFormatter.formatAndAddToJavaDocComment(
               method.description(), methodJavadocBuilder, null);
     }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/utils/CommentFormatter.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/utils/CommentFormatter.java
@@ -1,0 +1,63 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.api.generator.gapic.composer.utils;
+
+import com.google.api.generator.engine.ast.JavaDocComment;
+import com.google.common.base.Strings;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CommentFormatter {
+
+  private CommentFormatter() {};
+
+  // Additional formatting logic for converting protobuf comment to Javadoc
+  public static JavaDocComment.Builder formatCommentForJavaDoc(
+      String comment, JavaDocComment.Builder originalCommentBuilder, String firstPattern) {
+
+    JavaDocComment.Builder javaDocCommentBuilder = originalCommentBuilder;
+
+    String[] descriptionParagraphs = comment.split("\\n\\n");
+    for (int i = 0; i < descriptionParagraphs.length; i++) {
+      boolean startsWithItemizedList = descriptionParagraphs[i].startsWith(" * ");
+      // Split by listed items, then join newlines.
+      List<String> listItems =
+          Stream.of(descriptionParagraphs[i].split("\\n \\*"))
+              .map(s -> s.replace("\n", ""))
+              .collect(Collectors.toList());
+      if (startsWithItemizedList) {
+        // Remove the first asterisk.
+        listItems.set(0, listItems.get(0).substring(2));
+      }
+
+      if (!startsWithItemizedList) {
+        if (i == 0 && !Strings.isNullOrEmpty(firstPattern)) {
+          javaDocCommentBuilder =
+              javaDocCommentBuilder.addParagraph(String.format(firstPattern, listItems.get(0)));
+        } else {
+          javaDocCommentBuilder = javaDocCommentBuilder.addParagraph(listItems.get(0));
+        }
+      }
+      if (listItems.size() > 1 || startsWithItemizedList) {
+        javaDocCommentBuilder =
+            javaDocCommentBuilder.addUnorderedList(
+                listItems.subList(startsWithItemizedList ? 0 : 1, listItems.size()));
+      }
+    }
+
+    return javaDocCommentBuilder;
+  }
+}

--- a/src/main/java/com/google/api/generator/gapic/composer/utils/CommentFormatter.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/utils/CommentFormatter.java
@@ -22,11 +22,11 @@ import java.util.stream.Stream;
 
 public class CommentFormatter {
 
-  private CommentFormatter() {};
+  private CommentFormatter() {}
 
   // Additional formatting logic for converting protobuf comment to Javadoc
-  public static JavaDocComment.Builder formatCommentForJavaDoc(
-      String comment, JavaDocComment.Builder originalCommentBuilder, String firstPattern) {
+  public static JavaDocComment.Builder formatAndAddToJavaDocComment(
+      String comment, JavaDocComment.Builder originalCommentBuilder, String prefixPattern) {
 
     JavaDocComment.Builder javaDocCommentBuilder = originalCommentBuilder;
 
@@ -44,9 +44,9 @@ public class CommentFormatter {
       }
 
       if (!startsWithItemizedList) {
-        if (i == 0 && !Strings.isNullOrEmpty(firstPattern)) {
+        if (i == 0 && !Strings.isNullOrEmpty(prefixPattern)) {
           javaDocCommentBuilder =
-              javaDocCommentBuilder.addParagraph(String.format(firstPattern, listItems.get(0)));
+              javaDocCommentBuilder.addParagraph(String.format(prefixPattern, listItems.get(0)));
         } else {
           javaDocCommentBuilder = javaDocCommentBuilder.addParagraph(listItems.get(0));
         }


### PR DESCRIPTION
Both `ClientLibraryPackageInfoComposer` and `ServiceClientCommentComposer` currently have additional parsing logic to convert protobuf comments to a Javadoc-compatible format. For example, this handles [bulleted list items with asterisks in secret manager service proto](https://github.com/googleapis/googleapis/blob/db1fc8a59aeec7aabfb3dfed4ce9944a312ed55e/google/cloud/secretmanager/v1/service.proto#L44-L45). 

This PR extracts common logic to an util class, and exposes it for reuse by Spring Codegen.