### PR TITLE
fix(spring codegen): use client-library-artifact-id as pom artifactId prefix

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -204,14 +204,12 @@ public class SpringWriter {
 
   @VisibleForTesting
   static String buildPomString(GapicContext context) {
-    String pakkageName = Utils.getPackageName(context);
-    pakkageName = pakkageName.replace('.', '-');
     String clientLibraryShortName = Utils.getLibName(context);
     String clientLibraryGroupId = "{{client-library-group-id}}";
     String clientLibraryName = "{{client-library-artifact-id}}";
     String clientLibraryVersion = "{{client-library-version}}";
 
-    String springStarterArtifactId = pakkageName + "-spring-starter";
+    String springStarterArtifactId = clientLibraryName + "-spring-starter";
     String springStarterVersion = "{{starter-version}}";
     String springStarterName = "Spring Boot Starter - " + clientLibraryShortName;
 

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud</groupId>
-  <artifactId>com-google-showcase-v1beta1-spring-starter</artifactId>
+  <artifactId>{{client-library-artifact-id}}-spring-starter</artifactId>
   <version>{{starter-version}}</version>
   <name>Spring Boot Starter - localhost:7469</name>
   <description>Spring Boot Starter with AutoConfiguration for localhost:7469</description>


### PR DESCRIPTION
Instead of package name, use corresponding client library's artifact-id as artifact id prefix for spring modules.
Reasoning of this change: 
- Generated module artifact name aligned better with corresponding client library's, less confusing for users.
- "client-library-artifact-id" is already needed to substitute in generation script, so no added item there.
- Charging from [monorepo](https://github.com/googleapis/google-cloud-java/blob/main/versions.txt), only one version of client library is published per module. So consider the generation process starts from a client library coordinates, then the risk of not including `-v1beta1`/`-v1` from package name is mininum. 
- It's more direct this way to generate README item in spring-cloud-gcp side. https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1336