### PR TITLE
fix(spring): update setters for properties of type Duration

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -296,16 +296,16 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     // Common building blocks
     Variable propertyVar = Variable.builder().setName(propertyName).setType(returnType).build();
     Expr thisExpr = ValueExpr.withValue(ThisObjectValue.withType(thisClassType));
-    TypeNode oldDurationType = staticTypes.get("org.threeten.bp.Duration");
-    TypeNode newDurationType = staticTypes.get("java.time.Duration");
+    TypeNode threetenBpDurationType = staticTypes.get("org.threeten.bp.Duration");
+    TypeNode javaTimeDurationType = staticTypes.get("java.time.Duration");
 
     // Default building blocks - may be updated in Duration condition below
     Variable argumentVar = propertyVar;
     Expr propertyValueExpr = VariableExpr.withVariable(argumentVar);
 
     // Setter logic for Duration accepts different type and handles conversion
-    if (returnType.equals(oldDurationType)) {
-      argumentVar = Variable.builder().setName(propertyName).setType(newDurationType).build();
+    if (returnType.equals(threetenBpDurationType)) {
+      argumentVar = Variable.builder().setName(propertyName).setType(javaTimeDurationType).build();
 
       MethodInvocationExpr durationToStringExpr =
           MethodInvocationExpr.builder()
@@ -316,10 +316,10 @@ public class SpringPropertiesClassComposer implements ClassComposer {
 
       propertyValueExpr =
           MethodInvocationExpr.builder()
-              .setStaticReferenceType(oldDurationType)
+              .setStaticReferenceType(threetenBpDurationType)
               .setMethodName("parse")
               .setArguments(durationToStringExpr)
-              .setReturnType(oldDurationType)
+              .setReturnType(threetenBpDurationType)
               .build();
     }
 

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -296,18 +296,16 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     // Common building blocks
     Variable propertyVar = Variable.builder().setName(propertyName).setType(returnType).build();
     Expr thisExpr = ValueExpr.withValue(ThisObjectValue.withType(thisClassType));
+    TypeNode oldDurationType = staticTypes.get("org.threeten.bp.Duration");
+    TypeNode newDurationType = staticTypes.get("java.time.Duration");
 
     // Default building blocks - may be updated in Duration condition below
     Variable argumentVar = propertyVar;
     Expr propertyValueExpr = VariableExpr.withVariable(argumentVar);
 
     // Setter logic for Duration accepts different type and handles conversion
-    if (returnType.equals(staticTypes.get("org.threeten.bp.Duration"))) {
-      argumentVar =
-          Variable.builder()
-              .setName(propertyName)
-              .setType(staticTypes.get("java.time.Duration"))
-              .build();
+    if (returnType.equals(oldDurationType)) {
+      argumentVar = Variable.builder().setName(propertyName).setType(newDurationType).build();
 
       MethodInvocationExpr durationToStringExpr =
           MethodInvocationExpr.builder()
@@ -318,10 +316,10 @@ public class SpringPropertiesClassComposer implements ClassComposer {
 
       propertyValueExpr =
           MethodInvocationExpr.builder()
-              .setStaticReferenceType(staticTypes.get("org.threeten.bp.Duration"))
+              .setStaticReferenceType(oldDurationType)
               .setMethodName("parse")
               .setArguments(durationToStringExpr)
-              .setReturnType(staticTypes.get("org.threeten.bp.Duration"))
+              .setReturnType(oldDurationType)
               .build();
     }
 
@@ -412,6 +410,6 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     return concreteClazzes.stream()
         .collect(
             Collectors.toMap(
-                c -> c.getName(), c -> TypeNode.withReference(ConcreteReference.withClazz(c))));
+                Class::getName, c -> TypeNode.withReference(ConcreteReference.withClazz(c))));
   }
 }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
@@ -111,8 +111,8 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoInitialRetryDelay;
   }
 
-  public void setEchoInitialRetryDelay(Duration echoInitialRetryDelay) {
-    this.echoInitialRetryDelay = echoInitialRetryDelay;
+  public void setEchoInitialRetryDelay(java.time.Duration echoInitialRetryDelay) {
+    this.echoInitialRetryDelay = Duration.parse(echoInitialRetryDelay.toString());
   }
 
   public Double getEchoRetryDelayMultiplier() {
@@ -127,16 +127,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoMaxRetryDelay;
   }
 
-  public void setEchoMaxRetryDelay(Duration echoMaxRetryDelay) {
-    this.echoMaxRetryDelay = echoMaxRetryDelay;
+  public void setEchoMaxRetryDelay(java.time.Duration echoMaxRetryDelay) {
+    this.echoMaxRetryDelay = Duration.parse(echoMaxRetryDelay.toString());
   }
 
   public Duration getEchoInitialRpcTimeout() {
     return this.echoInitialRpcTimeout;
   }
 
-  public void setEchoInitialRpcTimeout(Duration echoInitialRpcTimeout) {
-    this.echoInitialRpcTimeout = echoInitialRpcTimeout;
+  public void setEchoInitialRpcTimeout(java.time.Duration echoInitialRpcTimeout) {
+    this.echoInitialRpcTimeout = Duration.parse(echoInitialRpcTimeout.toString());
   }
 
   public Double getEchoRpcTimeoutMultiplier() {
@@ -151,24 +151,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoMaxRpcTimeout;
   }
 
-  public void setEchoMaxRpcTimeout(Duration echoMaxRpcTimeout) {
-    this.echoMaxRpcTimeout = echoMaxRpcTimeout;
+  public void setEchoMaxRpcTimeout(java.time.Duration echoMaxRpcTimeout) {
+    this.echoMaxRpcTimeout = Duration.parse(echoMaxRpcTimeout.toString());
   }
 
   public Duration getEchoTotalTimeout() {
     return this.echoTotalTimeout;
   }
 
-  public void setEchoTotalTimeout(Duration echoTotalTimeout) {
-    this.echoTotalTimeout = echoTotalTimeout;
+  public void setEchoTotalTimeout(java.time.Duration echoTotalTimeout) {
+    this.echoTotalTimeout = Duration.parse(echoTotalTimeout.toString());
   }
 
   public Duration getExpandInitialRetryDelay() {
     return this.expandInitialRetryDelay;
   }
 
-  public void setExpandInitialRetryDelay(Duration expandInitialRetryDelay) {
-    this.expandInitialRetryDelay = expandInitialRetryDelay;
+  public void setExpandInitialRetryDelay(java.time.Duration expandInitialRetryDelay) {
+    this.expandInitialRetryDelay = Duration.parse(expandInitialRetryDelay.toString());
   }
 
   public Double getExpandRetryDelayMultiplier() {
@@ -183,16 +183,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.expandMaxRetryDelay;
   }
 
-  public void setExpandMaxRetryDelay(Duration expandMaxRetryDelay) {
-    this.expandMaxRetryDelay = expandMaxRetryDelay;
+  public void setExpandMaxRetryDelay(java.time.Duration expandMaxRetryDelay) {
+    this.expandMaxRetryDelay = Duration.parse(expandMaxRetryDelay.toString());
   }
 
   public Duration getExpandInitialRpcTimeout() {
     return this.expandInitialRpcTimeout;
   }
 
-  public void setExpandInitialRpcTimeout(Duration expandInitialRpcTimeout) {
-    this.expandInitialRpcTimeout = expandInitialRpcTimeout;
+  public void setExpandInitialRpcTimeout(java.time.Duration expandInitialRpcTimeout) {
+    this.expandInitialRpcTimeout = Duration.parse(expandInitialRpcTimeout.toString());
   }
 
   public Double getExpandRpcTimeoutMultiplier() {
@@ -207,24 +207,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.expandMaxRpcTimeout;
   }
 
-  public void setExpandMaxRpcTimeout(Duration expandMaxRpcTimeout) {
-    this.expandMaxRpcTimeout = expandMaxRpcTimeout;
+  public void setExpandMaxRpcTimeout(java.time.Duration expandMaxRpcTimeout) {
+    this.expandMaxRpcTimeout = Duration.parse(expandMaxRpcTimeout.toString());
   }
 
   public Duration getExpandTotalTimeout() {
     return this.expandTotalTimeout;
   }
 
-  public void setExpandTotalTimeout(Duration expandTotalTimeout) {
-    this.expandTotalTimeout = expandTotalTimeout;
+  public void setExpandTotalTimeout(java.time.Duration expandTotalTimeout) {
+    this.expandTotalTimeout = Duration.parse(expandTotalTimeout.toString());
   }
 
   public Duration getCollectInitialRpcTimeout() {
     return this.collectInitialRpcTimeout;
   }
 
-  public void setCollectInitialRpcTimeout(Duration collectInitialRpcTimeout) {
-    this.collectInitialRpcTimeout = collectInitialRpcTimeout;
+  public void setCollectInitialRpcTimeout(java.time.Duration collectInitialRpcTimeout) {
+    this.collectInitialRpcTimeout = Duration.parse(collectInitialRpcTimeout.toString());
   }
 
   public Double getCollectRpcTimeoutMultiplier() {
@@ -239,24 +239,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.collectMaxRpcTimeout;
   }
 
-  public void setCollectMaxRpcTimeout(Duration collectMaxRpcTimeout) {
-    this.collectMaxRpcTimeout = collectMaxRpcTimeout;
+  public void setCollectMaxRpcTimeout(java.time.Duration collectMaxRpcTimeout) {
+    this.collectMaxRpcTimeout = Duration.parse(collectMaxRpcTimeout.toString());
   }
 
   public Duration getCollectTotalTimeout() {
     return this.collectTotalTimeout;
   }
 
-  public void setCollectTotalTimeout(Duration collectTotalTimeout) {
-    this.collectTotalTimeout = collectTotalTimeout;
+  public void setCollectTotalTimeout(java.time.Duration collectTotalTimeout) {
+    this.collectTotalTimeout = Duration.parse(collectTotalTimeout.toString());
   }
 
   public Duration getChatInitialRpcTimeout() {
     return this.chatInitialRpcTimeout;
   }
 
-  public void setChatInitialRpcTimeout(Duration chatInitialRpcTimeout) {
-    this.chatInitialRpcTimeout = chatInitialRpcTimeout;
+  public void setChatInitialRpcTimeout(java.time.Duration chatInitialRpcTimeout) {
+    this.chatInitialRpcTimeout = Duration.parse(chatInitialRpcTimeout.toString());
   }
 
   public Double getChatRpcTimeoutMultiplier() {
@@ -271,24 +271,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.chatMaxRpcTimeout;
   }
 
-  public void setChatMaxRpcTimeout(Duration chatMaxRpcTimeout) {
-    this.chatMaxRpcTimeout = chatMaxRpcTimeout;
+  public void setChatMaxRpcTimeout(java.time.Duration chatMaxRpcTimeout) {
+    this.chatMaxRpcTimeout = Duration.parse(chatMaxRpcTimeout.toString());
   }
 
   public Duration getChatTotalTimeout() {
     return this.chatTotalTimeout;
   }
 
-  public void setChatTotalTimeout(Duration chatTotalTimeout) {
-    this.chatTotalTimeout = chatTotalTimeout;
+  public void setChatTotalTimeout(java.time.Duration chatTotalTimeout) {
+    this.chatTotalTimeout = Duration.parse(chatTotalTimeout.toString());
   }
 
   public Duration getChatAgainInitialRpcTimeout() {
     return this.chatAgainInitialRpcTimeout;
   }
 
-  public void setChatAgainInitialRpcTimeout(Duration chatAgainInitialRpcTimeout) {
-    this.chatAgainInitialRpcTimeout = chatAgainInitialRpcTimeout;
+  public void setChatAgainInitialRpcTimeout(java.time.Duration chatAgainInitialRpcTimeout) {
+    this.chatAgainInitialRpcTimeout = Duration.parse(chatAgainInitialRpcTimeout.toString());
   }
 
   public Double getChatAgainRpcTimeoutMultiplier() {
@@ -303,24 +303,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.chatAgainMaxRpcTimeout;
   }
 
-  public void setChatAgainMaxRpcTimeout(Duration chatAgainMaxRpcTimeout) {
-    this.chatAgainMaxRpcTimeout = chatAgainMaxRpcTimeout;
+  public void setChatAgainMaxRpcTimeout(java.time.Duration chatAgainMaxRpcTimeout) {
+    this.chatAgainMaxRpcTimeout = Duration.parse(chatAgainMaxRpcTimeout.toString());
   }
 
   public Duration getChatAgainTotalTimeout() {
     return this.chatAgainTotalTimeout;
   }
 
-  public void setChatAgainTotalTimeout(Duration chatAgainTotalTimeout) {
-    this.chatAgainTotalTimeout = chatAgainTotalTimeout;
+  public void setChatAgainTotalTimeout(java.time.Duration chatAgainTotalTimeout) {
+    this.chatAgainTotalTimeout = Duration.parse(chatAgainTotalTimeout.toString());
   }
 
   public Duration getPagedExpandInitialRetryDelay() {
     return this.pagedExpandInitialRetryDelay;
   }
 
-  public void setPagedExpandInitialRetryDelay(Duration pagedExpandInitialRetryDelay) {
-    this.pagedExpandInitialRetryDelay = pagedExpandInitialRetryDelay;
+  public void setPagedExpandInitialRetryDelay(java.time.Duration pagedExpandInitialRetryDelay) {
+    this.pagedExpandInitialRetryDelay = Duration.parse(pagedExpandInitialRetryDelay.toString());
   }
 
   public Double getPagedExpandRetryDelayMultiplier() {
@@ -335,16 +335,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.pagedExpandMaxRetryDelay;
   }
 
-  public void setPagedExpandMaxRetryDelay(Duration pagedExpandMaxRetryDelay) {
-    this.pagedExpandMaxRetryDelay = pagedExpandMaxRetryDelay;
+  public void setPagedExpandMaxRetryDelay(java.time.Duration pagedExpandMaxRetryDelay) {
+    this.pagedExpandMaxRetryDelay = Duration.parse(pagedExpandMaxRetryDelay.toString());
   }
 
   public Duration getPagedExpandInitialRpcTimeout() {
     return this.pagedExpandInitialRpcTimeout;
   }
 
-  public void setPagedExpandInitialRpcTimeout(Duration pagedExpandInitialRpcTimeout) {
-    this.pagedExpandInitialRpcTimeout = pagedExpandInitialRpcTimeout;
+  public void setPagedExpandInitialRpcTimeout(java.time.Duration pagedExpandInitialRpcTimeout) {
+    this.pagedExpandInitialRpcTimeout = Duration.parse(pagedExpandInitialRpcTimeout.toString());
   }
 
   public Double getPagedExpandRpcTimeoutMultiplier() {
@@ -359,24 +359,26 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.pagedExpandMaxRpcTimeout;
   }
 
-  public void setPagedExpandMaxRpcTimeout(Duration pagedExpandMaxRpcTimeout) {
-    this.pagedExpandMaxRpcTimeout = pagedExpandMaxRpcTimeout;
+  public void setPagedExpandMaxRpcTimeout(java.time.Duration pagedExpandMaxRpcTimeout) {
+    this.pagedExpandMaxRpcTimeout = Duration.parse(pagedExpandMaxRpcTimeout.toString());
   }
 
   public Duration getPagedExpandTotalTimeout() {
     return this.pagedExpandTotalTimeout;
   }
 
-  public void setPagedExpandTotalTimeout(Duration pagedExpandTotalTimeout) {
-    this.pagedExpandTotalTimeout = pagedExpandTotalTimeout;
+  public void setPagedExpandTotalTimeout(java.time.Duration pagedExpandTotalTimeout) {
+    this.pagedExpandTotalTimeout = Duration.parse(pagedExpandTotalTimeout.toString());
   }
 
   public Duration getSimplePagedExpandInitialRpcTimeout() {
     return this.simplePagedExpandInitialRpcTimeout;
   }
 
-  public void setSimplePagedExpandInitialRpcTimeout(Duration simplePagedExpandInitialRpcTimeout) {
-    this.simplePagedExpandInitialRpcTimeout = simplePagedExpandInitialRpcTimeout;
+  public void setSimplePagedExpandInitialRpcTimeout(
+      java.time.Duration simplePagedExpandInitialRpcTimeout) {
+    this.simplePagedExpandInitialRpcTimeout =
+        Duration.parse(simplePagedExpandInitialRpcTimeout.toString());
   }
 
   public Double getSimplePagedExpandRpcTimeoutMultiplier() {
@@ -392,24 +394,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.simplePagedExpandMaxRpcTimeout;
   }
 
-  public void setSimplePagedExpandMaxRpcTimeout(Duration simplePagedExpandMaxRpcTimeout) {
-    this.simplePagedExpandMaxRpcTimeout = simplePagedExpandMaxRpcTimeout;
+  public void setSimplePagedExpandMaxRpcTimeout(java.time.Duration simplePagedExpandMaxRpcTimeout) {
+    this.simplePagedExpandMaxRpcTimeout = Duration.parse(simplePagedExpandMaxRpcTimeout.toString());
   }
 
   public Duration getSimplePagedExpandTotalTimeout() {
     return this.simplePagedExpandTotalTimeout;
   }
 
-  public void setSimplePagedExpandTotalTimeout(Duration simplePagedExpandTotalTimeout) {
-    this.simplePagedExpandTotalTimeout = simplePagedExpandTotalTimeout;
+  public void setSimplePagedExpandTotalTimeout(java.time.Duration simplePagedExpandTotalTimeout) {
+    this.simplePagedExpandTotalTimeout = Duration.parse(simplePagedExpandTotalTimeout.toString());
   }
 
   public Duration getWaitInitialRpcTimeout() {
     return this.waitInitialRpcTimeout;
   }
 
-  public void setWaitInitialRpcTimeout(Duration waitInitialRpcTimeout) {
-    this.waitInitialRpcTimeout = waitInitialRpcTimeout;
+  public void setWaitInitialRpcTimeout(java.time.Duration waitInitialRpcTimeout) {
+    this.waitInitialRpcTimeout = Duration.parse(waitInitialRpcTimeout.toString());
   }
 
   public Double getWaitRpcTimeoutMultiplier() {
@@ -424,24 +426,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.waitMaxRpcTimeout;
   }
 
-  public void setWaitMaxRpcTimeout(Duration waitMaxRpcTimeout) {
-    this.waitMaxRpcTimeout = waitMaxRpcTimeout;
+  public void setWaitMaxRpcTimeout(java.time.Duration waitMaxRpcTimeout) {
+    this.waitMaxRpcTimeout = Duration.parse(waitMaxRpcTimeout.toString());
   }
 
   public Duration getWaitTotalTimeout() {
     return this.waitTotalTimeout;
   }
 
-  public void setWaitTotalTimeout(Duration waitTotalTimeout) {
-    this.waitTotalTimeout = waitTotalTimeout;
+  public void setWaitTotalTimeout(java.time.Duration waitTotalTimeout) {
+    this.waitTotalTimeout = Duration.parse(waitTotalTimeout.toString());
   }
 
   public Duration getBlockInitialRpcTimeout() {
     return this.blockInitialRpcTimeout;
   }
 
-  public void setBlockInitialRpcTimeout(Duration blockInitialRpcTimeout) {
-    this.blockInitialRpcTimeout = blockInitialRpcTimeout;
+  public void setBlockInitialRpcTimeout(java.time.Duration blockInitialRpcTimeout) {
+    this.blockInitialRpcTimeout = Duration.parse(blockInitialRpcTimeout.toString());
   }
 
   public Double getBlockRpcTimeoutMultiplier() {
@@ -456,24 +458,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.blockMaxRpcTimeout;
   }
 
-  public void setBlockMaxRpcTimeout(Duration blockMaxRpcTimeout) {
-    this.blockMaxRpcTimeout = blockMaxRpcTimeout;
+  public void setBlockMaxRpcTimeout(java.time.Duration blockMaxRpcTimeout) {
+    this.blockMaxRpcTimeout = Duration.parse(blockMaxRpcTimeout.toString());
   }
 
   public Duration getBlockTotalTimeout() {
     return this.blockTotalTimeout;
   }
 
-  public void setBlockTotalTimeout(Duration blockTotalTimeout) {
-    this.blockTotalTimeout = blockTotalTimeout;
+  public void setBlockTotalTimeout(java.time.Duration blockTotalTimeout) {
+    this.blockTotalTimeout = Duration.parse(blockTotalTimeout.toString());
   }
 
   public Duration getCollideNameInitialRpcTimeout() {
     return this.collideNameInitialRpcTimeout;
   }
 
-  public void setCollideNameInitialRpcTimeout(Duration collideNameInitialRpcTimeout) {
-    this.collideNameInitialRpcTimeout = collideNameInitialRpcTimeout;
+  public void setCollideNameInitialRpcTimeout(java.time.Duration collideNameInitialRpcTimeout) {
+    this.collideNameInitialRpcTimeout = Duration.parse(collideNameInitialRpcTimeout.toString());
   }
 
   public Double getCollideNameRpcTimeoutMultiplier() {
@@ -488,15 +490,15 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.collideNameMaxRpcTimeout;
   }
 
-  public void setCollideNameMaxRpcTimeout(Duration collideNameMaxRpcTimeout) {
-    this.collideNameMaxRpcTimeout = collideNameMaxRpcTimeout;
+  public void setCollideNameMaxRpcTimeout(java.time.Duration collideNameMaxRpcTimeout) {
+    this.collideNameMaxRpcTimeout = Duration.parse(collideNameMaxRpcTimeout.toString());
   }
 
   public Duration getCollideNameTotalTimeout() {
     return this.collideNameTotalTimeout;
   }
 
-  public void setCollideNameTotalTimeout(Duration collideNameTotalTimeout) {
-    this.collideNameTotalTimeout = collideNameTotalTimeout;
+  public void setCollideNameTotalTimeout(java.time.Duration collideNameTotalTimeout) {
+    this.collideNameTotalTimeout = Duration.parse(collideNameTotalTimeout.toString());
   }
 }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpc.golden
@@ -91,8 +91,8 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoInitialRetryDelay;
   }
 
-  public void setEchoInitialRetryDelay(Duration echoInitialRetryDelay) {
-    this.echoInitialRetryDelay = echoInitialRetryDelay;
+  public void setEchoInitialRetryDelay(java.time.Duration echoInitialRetryDelay) {
+    this.echoInitialRetryDelay = Duration.parse(echoInitialRetryDelay.toString());
   }
 
   public Double getEchoRetryDelayMultiplier() {
@@ -107,16 +107,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoMaxRetryDelay;
   }
 
-  public void setEchoMaxRetryDelay(Duration echoMaxRetryDelay) {
-    this.echoMaxRetryDelay = echoMaxRetryDelay;
+  public void setEchoMaxRetryDelay(java.time.Duration echoMaxRetryDelay) {
+    this.echoMaxRetryDelay = Duration.parse(echoMaxRetryDelay.toString());
   }
 
   public Duration getEchoInitialRpcTimeout() {
     return this.echoInitialRpcTimeout;
   }
 
-  public void setEchoInitialRpcTimeout(Duration echoInitialRpcTimeout) {
-    this.echoInitialRpcTimeout = echoInitialRpcTimeout;
+  public void setEchoInitialRpcTimeout(java.time.Duration echoInitialRpcTimeout) {
+    this.echoInitialRpcTimeout = Duration.parse(echoInitialRpcTimeout.toString());
   }
 
   public Double getEchoRpcTimeoutMultiplier() {
@@ -131,24 +131,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoMaxRpcTimeout;
   }
 
-  public void setEchoMaxRpcTimeout(Duration echoMaxRpcTimeout) {
-    this.echoMaxRpcTimeout = echoMaxRpcTimeout;
+  public void setEchoMaxRpcTimeout(java.time.Duration echoMaxRpcTimeout) {
+    this.echoMaxRpcTimeout = Duration.parse(echoMaxRpcTimeout.toString());
   }
 
   public Duration getEchoTotalTimeout() {
     return this.echoTotalTimeout;
   }
 
-  public void setEchoTotalTimeout(Duration echoTotalTimeout) {
-    this.echoTotalTimeout = echoTotalTimeout;
+  public void setEchoTotalTimeout(java.time.Duration echoTotalTimeout) {
+    this.echoTotalTimeout = Duration.parse(echoTotalTimeout.toString());
   }
 
   public Duration getExpandInitialRetryDelay() {
     return this.expandInitialRetryDelay;
   }
 
-  public void setExpandInitialRetryDelay(Duration expandInitialRetryDelay) {
-    this.expandInitialRetryDelay = expandInitialRetryDelay;
+  public void setExpandInitialRetryDelay(java.time.Duration expandInitialRetryDelay) {
+    this.expandInitialRetryDelay = Duration.parse(expandInitialRetryDelay.toString());
   }
 
   public Double getExpandRetryDelayMultiplier() {
@@ -163,16 +163,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.expandMaxRetryDelay;
   }
 
-  public void setExpandMaxRetryDelay(Duration expandMaxRetryDelay) {
-    this.expandMaxRetryDelay = expandMaxRetryDelay;
+  public void setExpandMaxRetryDelay(java.time.Duration expandMaxRetryDelay) {
+    this.expandMaxRetryDelay = Duration.parse(expandMaxRetryDelay.toString());
   }
 
   public Duration getExpandInitialRpcTimeout() {
     return this.expandInitialRpcTimeout;
   }
 
-  public void setExpandInitialRpcTimeout(Duration expandInitialRpcTimeout) {
-    this.expandInitialRpcTimeout = expandInitialRpcTimeout;
+  public void setExpandInitialRpcTimeout(java.time.Duration expandInitialRpcTimeout) {
+    this.expandInitialRpcTimeout = Duration.parse(expandInitialRpcTimeout.toString());
   }
 
   public Double getExpandRpcTimeoutMultiplier() {
@@ -187,24 +187,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.expandMaxRpcTimeout;
   }
 
-  public void setExpandMaxRpcTimeout(Duration expandMaxRpcTimeout) {
-    this.expandMaxRpcTimeout = expandMaxRpcTimeout;
+  public void setExpandMaxRpcTimeout(java.time.Duration expandMaxRpcTimeout) {
+    this.expandMaxRpcTimeout = Duration.parse(expandMaxRpcTimeout.toString());
   }
 
   public Duration getExpandTotalTimeout() {
     return this.expandTotalTimeout;
   }
 
-  public void setExpandTotalTimeout(Duration expandTotalTimeout) {
-    this.expandTotalTimeout = expandTotalTimeout;
+  public void setExpandTotalTimeout(java.time.Duration expandTotalTimeout) {
+    this.expandTotalTimeout = Duration.parse(expandTotalTimeout.toString());
   }
 
   public Duration getCollectInitialRpcTimeout() {
     return this.collectInitialRpcTimeout;
   }
 
-  public void setCollectInitialRpcTimeout(Duration collectInitialRpcTimeout) {
-    this.collectInitialRpcTimeout = collectInitialRpcTimeout;
+  public void setCollectInitialRpcTimeout(java.time.Duration collectInitialRpcTimeout) {
+    this.collectInitialRpcTimeout = Duration.parse(collectInitialRpcTimeout.toString());
   }
 
   public Double getCollectRpcTimeoutMultiplier() {
@@ -219,24 +219,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.collectMaxRpcTimeout;
   }
 
-  public void setCollectMaxRpcTimeout(Duration collectMaxRpcTimeout) {
-    this.collectMaxRpcTimeout = collectMaxRpcTimeout;
+  public void setCollectMaxRpcTimeout(java.time.Duration collectMaxRpcTimeout) {
+    this.collectMaxRpcTimeout = Duration.parse(collectMaxRpcTimeout.toString());
   }
 
   public Duration getCollectTotalTimeout() {
     return this.collectTotalTimeout;
   }
 
-  public void setCollectTotalTimeout(Duration collectTotalTimeout) {
-    this.collectTotalTimeout = collectTotalTimeout;
+  public void setCollectTotalTimeout(java.time.Duration collectTotalTimeout) {
+    this.collectTotalTimeout = Duration.parse(collectTotalTimeout.toString());
   }
 
   public Duration getChatInitialRpcTimeout() {
     return this.chatInitialRpcTimeout;
   }
 
-  public void setChatInitialRpcTimeout(Duration chatInitialRpcTimeout) {
-    this.chatInitialRpcTimeout = chatInitialRpcTimeout;
+  public void setChatInitialRpcTimeout(java.time.Duration chatInitialRpcTimeout) {
+    this.chatInitialRpcTimeout = Duration.parse(chatInitialRpcTimeout.toString());
   }
 
   public Double getChatRpcTimeoutMultiplier() {
@@ -251,24 +251,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.chatMaxRpcTimeout;
   }
 
-  public void setChatMaxRpcTimeout(Duration chatMaxRpcTimeout) {
-    this.chatMaxRpcTimeout = chatMaxRpcTimeout;
+  public void setChatMaxRpcTimeout(java.time.Duration chatMaxRpcTimeout) {
+    this.chatMaxRpcTimeout = Duration.parse(chatMaxRpcTimeout.toString());
   }
 
   public Duration getChatTotalTimeout() {
     return this.chatTotalTimeout;
   }
 
-  public void setChatTotalTimeout(Duration chatTotalTimeout) {
-    this.chatTotalTimeout = chatTotalTimeout;
+  public void setChatTotalTimeout(java.time.Duration chatTotalTimeout) {
+    this.chatTotalTimeout = Duration.parse(chatTotalTimeout.toString());
   }
 
   public Duration getChatAgainInitialRpcTimeout() {
     return this.chatAgainInitialRpcTimeout;
   }
 
-  public void setChatAgainInitialRpcTimeout(Duration chatAgainInitialRpcTimeout) {
-    this.chatAgainInitialRpcTimeout = chatAgainInitialRpcTimeout;
+  public void setChatAgainInitialRpcTimeout(java.time.Duration chatAgainInitialRpcTimeout) {
+    this.chatAgainInitialRpcTimeout = Duration.parse(chatAgainInitialRpcTimeout.toString());
   }
 
   public Double getChatAgainRpcTimeoutMultiplier() {
@@ -283,24 +283,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.chatAgainMaxRpcTimeout;
   }
 
-  public void setChatAgainMaxRpcTimeout(Duration chatAgainMaxRpcTimeout) {
-    this.chatAgainMaxRpcTimeout = chatAgainMaxRpcTimeout;
+  public void setChatAgainMaxRpcTimeout(java.time.Duration chatAgainMaxRpcTimeout) {
+    this.chatAgainMaxRpcTimeout = Duration.parse(chatAgainMaxRpcTimeout.toString());
   }
 
   public Duration getChatAgainTotalTimeout() {
     return this.chatAgainTotalTimeout;
   }
 
-  public void setChatAgainTotalTimeout(Duration chatAgainTotalTimeout) {
-    this.chatAgainTotalTimeout = chatAgainTotalTimeout;
+  public void setChatAgainTotalTimeout(java.time.Duration chatAgainTotalTimeout) {
+    this.chatAgainTotalTimeout = Duration.parse(chatAgainTotalTimeout.toString());
   }
 
   public Duration getPagedExpandInitialRetryDelay() {
     return this.pagedExpandInitialRetryDelay;
   }
 
-  public void setPagedExpandInitialRetryDelay(Duration pagedExpandInitialRetryDelay) {
-    this.pagedExpandInitialRetryDelay = pagedExpandInitialRetryDelay;
+  public void setPagedExpandInitialRetryDelay(java.time.Duration pagedExpandInitialRetryDelay) {
+    this.pagedExpandInitialRetryDelay = Duration.parse(pagedExpandInitialRetryDelay.toString());
   }
 
   public Double getPagedExpandRetryDelayMultiplier() {
@@ -315,16 +315,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.pagedExpandMaxRetryDelay;
   }
 
-  public void setPagedExpandMaxRetryDelay(Duration pagedExpandMaxRetryDelay) {
-    this.pagedExpandMaxRetryDelay = pagedExpandMaxRetryDelay;
+  public void setPagedExpandMaxRetryDelay(java.time.Duration pagedExpandMaxRetryDelay) {
+    this.pagedExpandMaxRetryDelay = Duration.parse(pagedExpandMaxRetryDelay.toString());
   }
 
   public Duration getPagedExpandInitialRpcTimeout() {
     return this.pagedExpandInitialRpcTimeout;
   }
 
-  public void setPagedExpandInitialRpcTimeout(Duration pagedExpandInitialRpcTimeout) {
-    this.pagedExpandInitialRpcTimeout = pagedExpandInitialRpcTimeout;
+  public void setPagedExpandInitialRpcTimeout(java.time.Duration pagedExpandInitialRpcTimeout) {
+    this.pagedExpandInitialRpcTimeout = Duration.parse(pagedExpandInitialRpcTimeout.toString());
   }
 
   public Double getPagedExpandRpcTimeoutMultiplier() {
@@ -339,24 +339,26 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.pagedExpandMaxRpcTimeout;
   }
 
-  public void setPagedExpandMaxRpcTimeout(Duration pagedExpandMaxRpcTimeout) {
-    this.pagedExpandMaxRpcTimeout = pagedExpandMaxRpcTimeout;
+  public void setPagedExpandMaxRpcTimeout(java.time.Duration pagedExpandMaxRpcTimeout) {
+    this.pagedExpandMaxRpcTimeout = Duration.parse(pagedExpandMaxRpcTimeout.toString());
   }
 
   public Duration getPagedExpandTotalTimeout() {
     return this.pagedExpandTotalTimeout;
   }
 
-  public void setPagedExpandTotalTimeout(Duration pagedExpandTotalTimeout) {
-    this.pagedExpandTotalTimeout = pagedExpandTotalTimeout;
+  public void setPagedExpandTotalTimeout(java.time.Duration pagedExpandTotalTimeout) {
+    this.pagedExpandTotalTimeout = Duration.parse(pagedExpandTotalTimeout.toString());
   }
 
   public Duration getSimplePagedExpandInitialRpcTimeout() {
     return this.simplePagedExpandInitialRpcTimeout;
   }
 
-  public void setSimplePagedExpandInitialRpcTimeout(Duration simplePagedExpandInitialRpcTimeout) {
-    this.simplePagedExpandInitialRpcTimeout = simplePagedExpandInitialRpcTimeout;
+  public void setSimplePagedExpandInitialRpcTimeout(
+      java.time.Duration simplePagedExpandInitialRpcTimeout) {
+    this.simplePagedExpandInitialRpcTimeout =
+        Duration.parse(simplePagedExpandInitialRpcTimeout.toString());
   }
 
   public Double getSimplePagedExpandRpcTimeoutMultiplier() {
@@ -372,24 +374,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.simplePagedExpandMaxRpcTimeout;
   }
 
-  public void setSimplePagedExpandMaxRpcTimeout(Duration simplePagedExpandMaxRpcTimeout) {
-    this.simplePagedExpandMaxRpcTimeout = simplePagedExpandMaxRpcTimeout;
+  public void setSimplePagedExpandMaxRpcTimeout(java.time.Duration simplePagedExpandMaxRpcTimeout) {
+    this.simplePagedExpandMaxRpcTimeout = Duration.parse(simplePagedExpandMaxRpcTimeout.toString());
   }
 
   public Duration getSimplePagedExpandTotalTimeout() {
     return this.simplePagedExpandTotalTimeout;
   }
 
-  public void setSimplePagedExpandTotalTimeout(Duration simplePagedExpandTotalTimeout) {
-    this.simplePagedExpandTotalTimeout = simplePagedExpandTotalTimeout;
+  public void setSimplePagedExpandTotalTimeout(java.time.Duration simplePagedExpandTotalTimeout) {
+    this.simplePagedExpandTotalTimeout = Duration.parse(simplePagedExpandTotalTimeout.toString());
   }
 
   public Duration getWaitInitialRpcTimeout() {
     return this.waitInitialRpcTimeout;
   }
 
-  public void setWaitInitialRpcTimeout(Duration waitInitialRpcTimeout) {
-    this.waitInitialRpcTimeout = waitInitialRpcTimeout;
+  public void setWaitInitialRpcTimeout(java.time.Duration waitInitialRpcTimeout) {
+    this.waitInitialRpcTimeout = Duration.parse(waitInitialRpcTimeout.toString());
   }
 
   public Double getWaitRpcTimeoutMultiplier() {
@@ -404,24 +406,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.waitMaxRpcTimeout;
   }
 
-  public void setWaitMaxRpcTimeout(Duration waitMaxRpcTimeout) {
-    this.waitMaxRpcTimeout = waitMaxRpcTimeout;
+  public void setWaitMaxRpcTimeout(java.time.Duration waitMaxRpcTimeout) {
+    this.waitMaxRpcTimeout = Duration.parse(waitMaxRpcTimeout.toString());
   }
 
   public Duration getWaitTotalTimeout() {
     return this.waitTotalTimeout;
   }
 
-  public void setWaitTotalTimeout(Duration waitTotalTimeout) {
-    this.waitTotalTimeout = waitTotalTimeout;
+  public void setWaitTotalTimeout(java.time.Duration waitTotalTimeout) {
+    this.waitTotalTimeout = Duration.parse(waitTotalTimeout.toString());
   }
 
   public Duration getBlockInitialRpcTimeout() {
     return this.blockInitialRpcTimeout;
   }
 
-  public void setBlockInitialRpcTimeout(Duration blockInitialRpcTimeout) {
-    this.blockInitialRpcTimeout = blockInitialRpcTimeout;
+  public void setBlockInitialRpcTimeout(java.time.Duration blockInitialRpcTimeout) {
+    this.blockInitialRpcTimeout = Duration.parse(blockInitialRpcTimeout.toString());
   }
 
   public Double getBlockRpcTimeoutMultiplier() {
@@ -436,24 +438,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.blockMaxRpcTimeout;
   }
 
-  public void setBlockMaxRpcTimeout(Duration blockMaxRpcTimeout) {
-    this.blockMaxRpcTimeout = blockMaxRpcTimeout;
+  public void setBlockMaxRpcTimeout(java.time.Duration blockMaxRpcTimeout) {
+    this.blockMaxRpcTimeout = Duration.parse(blockMaxRpcTimeout.toString());
   }
 
   public Duration getBlockTotalTimeout() {
     return this.blockTotalTimeout;
   }
 
-  public void setBlockTotalTimeout(Duration blockTotalTimeout) {
-    this.blockTotalTimeout = blockTotalTimeout;
+  public void setBlockTotalTimeout(java.time.Duration blockTotalTimeout) {
+    this.blockTotalTimeout = Duration.parse(blockTotalTimeout.toString());
   }
 
   public Duration getCollideNameInitialRpcTimeout() {
     return this.collideNameInitialRpcTimeout;
   }
 
-  public void setCollideNameInitialRpcTimeout(Duration collideNameInitialRpcTimeout) {
-    this.collideNameInitialRpcTimeout = collideNameInitialRpcTimeout;
+  public void setCollideNameInitialRpcTimeout(java.time.Duration collideNameInitialRpcTimeout) {
+    this.collideNameInitialRpcTimeout = Duration.parse(collideNameInitialRpcTimeout.toString());
   }
 
   public Double getCollideNameRpcTimeoutMultiplier() {
@@ -468,15 +470,15 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.collideNameMaxRpcTimeout;
   }
 
-  public void setCollideNameMaxRpcTimeout(Duration collideNameMaxRpcTimeout) {
-    this.collideNameMaxRpcTimeout = collideNameMaxRpcTimeout;
+  public void setCollideNameMaxRpcTimeout(java.time.Duration collideNameMaxRpcTimeout) {
+    this.collideNameMaxRpcTimeout = Duration.parse(collideNameMaxRpcTimeout.toString());
   }
 
   public Duration getCollideNameTotalTimeout() {
     return this.collideNameTotalTimeout;
   }
 
-  public void setCollideNameTotalTimeout(Duration collideNameTotalTimeout) {
-    this.collideNameTotalTimeout = collideNameTotalTimeout;
+  public void setCollideNameTotalTimeout(java.time.Duration collideNameTotalTimeout) {
+    this.collideNameTotalTimeout = Duration.parse(collideNameTotalTimeout.toString());
   }
 }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpcRest.golden
@@ -100,8 +100,8 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoInitialRetryDelay;
   }
 
-  public void setEchoInitialRetryDelay(Duration echoInitialRetryDelay) {
-    this.echoInitialRetryDelay = echoInitialRetryDelay;
+  public void setEchoInitialRetryDelay(java.time.Duration echoInitialRetryDelay) {
+    this.echoInitialRetryDelay = Duration.parse(echoInitialRetryDelay.toString());
   }
 
   public Double getEchoRetryDelayMultiplier() {
@@ -116,16 +116,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoMaxRetryDelay;
   }
 
-  public void setEchoMaxRetryDelay(Duration echoMaxRetryDelay) {
-    this.echoMaxRetryDelay = echoMaxRetryDelay;
+  public void setEchoMaxRetryDelay(java.time.Duration echoMaxRetryDelay) {
+    this.echoMaxRetryDelay = Duration.parse(echoMaxRetryDelay.toString());
   }
 
   public Duration getEchoInitialRpcTimeout() {
     return this.echoInitialRpcTimeout;
   }
 
-  public void setEchoInitialRpcTimeout(Duration echoInitialRpcTimeout) {
-    this.echoInitialRpcTimeout = echoInitialRpcTimeout;
+  public void setEchoInitialRpcTimeout(java.time.Duration echoInitialRpcTimeout) {
+    this.echoInitialRpcTimeout = Duration.parse(echoInitialRpcTimeout.toString());
   }
 
   public Double getEchoRpcTimeoutMultiplier() {
@@ -140,24 +140,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.echoMaxRpcTimeout;
   }
 
-  public void setEchoMaxRpcTimeout(Duration echoMaxRpcTimeout) {
-    this.echoMaxRpcTimeout = echoMaxRpcTimeout;
+  public void setEchoMaxRpcTimeout(java.time.Duration echoMaxRpcTimeout) {
+    this.echoMaxRpcTimeout = Duration.parse(echoMaxRpcTimeout.toString());
   }
 
   public Duration getEchoTotalTimeout() {
     return this.echoTotalTimeout;
   }
 
-  public void setEchoTotalTimeout(Duration echoTotalTimeout) {
-    this.echoTotalTimeout = echoTotalTimeout;
+  public void setEchoTotalTimeout(java.time.Duration echoTotalTimeout) {
+    this.echoTotalTimeout = Duration.parse(echoTotalTimeout.toString());
   }
 
   public Duration getExpandInitialRetryDelay() {
     return this.expandInitialRetryDelay;
   }
 
-  public void setExpandInitialRetryDelay(Duration expandInitialRetryDelay) {
-    this.expandInitialRetryDelay = expandInitialRetryDelay;
+  public void setExpandInitialRetryDelay(java.time.Duration expandInitialRetryDelay) {
+    this.expandInitialRetryDelay = Duration.parse(expandInitialRetryDelay.toString());
   }
 
   public Double getExpandRetryDelayMultiplier() {
@@ -172,16 +172,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.expandMaxRetryDelay;
   }
 
-  public void setExpandMaxRetryDelay(Duration expandMaxRetryDelay) {
-    this.expandMaxRetryDelay = expandMaxRetryDelay;
+  public void setExpandMaxRetryDelay(java.time.Duration expandMaxRetryDelay) {
+    this.expandMaxRetryDelay = Duration.parse(expandMaxRetryDelay.toString());
   }
 
   public Duration getExpandInitialRpcTimeout() {
     return this.expandInitialRpcTimeout;
   }
 
-  public void setExpandInitialRpcTimeout(Duration expandInitialRpcTimeout) {
-    this.expandInitialRpcTimeout = expandInitialRpcTimeout;
+  public void setExpandInitialRpcTimeout(java.time.Duration expandInitialRpcTimeout) {
+    this.expandInitialRpcTimeout = Duration.parse(expandInitialRpcTimeout.toString());
   }
 
   public Double getExpandRpcTimeoutMultiplier() {
@@ -196,24 +196,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.expandMaxRpcTimeout;
   }
 
-  public void setExpandMaxRpcTimeout(Duration expandMaxRpcTimeout) {
-    this.expandMaxRpcTimeout = expandMaxRpcTimeout;
+  public void setExpandMaxRpcTimeout(java.time.Duration expandMaxRpcTimeout) {
+    this.expandMaxRpcTimeout = Duration.parse(expandMaxRpcTimeout.toString());
   }
 
   public Duration getExpandTotalTimeout() {
     return this.expandTotalTimeout;
   }
 
-  public void setExpandTotalTimeout(Duration expandTotalTimeout) {
-    this.expandTotalTimeout = expandTotalTimeout;
+  public void setExpandTotalTimeout(java.time.Duration expandTotalTimeout) {
+    this.expandTotalTimeout = Duration.parse(expandTotalTimeout.toString());
   }
 
   public Duration getCollectInitialRpcTimeout() {
     return this.collectInitialRpcTimeout;
   }
 
-  public void setCollectInitialRpcTimeout(Duration collectInitialRpcTimeout) {
-    this.collectInitialRpcTimeout = collectInitialRpcTimeout;
+  public void setCollectInitialRpcTimeout(java.time.Duration collectInitialRpcTimeout) {
+    this.collectInitialRpcTimeout = Duration.parse(collectInitialRpcTimeout.toString());
   }
 
   public Double getCollectRpcTimeoutMultiplier() {
@@ -228,24 +228,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.collectMaxRpcTimeout;
   }
 
-  public void setCollectMaxRpcTimeout(Duration collectMaxRpcTimeout) {
-    this.collectMaxRpcTimeout = collectMaxRpcTimeout;
+  public void setCollectMaxRpcTimeout(java.time.Duration collectMaxRpcTimeout) {
+    this.collectMaxRpcTimeout = Duration.parse(collectMaxRpcTimeout.toString());
   }
 
   public Duration getCollectTotalTimeout() {
     return this.collectTotalTimeout;
   }
 
-  public void setCollectTotalTimeout(Duration collectTotalTimeout) {
-    this.collectTotalTimeout = collectTotalTimeout;
+  public void setCollectTotalTimeout(java.time.Duration collectTotalTimeout) {
+    this.collectTotalTimeout = Duration.parse(collectTotalTimeout.toString());
   }
 
   public Duration getChatInitialRpcTimeout() {
     return this.chatInitialRpcTimeout;
   }
 
-  public void setChatInitialRpcTimeout(Duration chatInitialRpcTimeout) {
-    this.chatInitialRpcTimeout = chatInitialRpcTimeout;
+  public void setChatInitialRpcTimeout(java.time.Duration chatInitialRpcTimeout) {
+    this.chatInitialRpcTimeout = Duration.parse(chatInitialRpcTimeout.toString());
   }
 
   public Double getChatRpcTimeoutMultiplier() {
@@ -260,24 +260,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.chatMaxRpcTimeout;
   }
 
-  public void setChatMaxRpcTimeout(Duration chatMaxRpcTimeout) {
-    this.chatMaxRpcTimeout = chatMaxRpcTimeout;
+  public void setChatMaxRpcTimeout(java.time.Duration chatMaxRpcTimeout) {
+    this.chatMaxRpcTimeout = Duration.parse(chatMaxRpcTimeout.toString());
   }
 
   public Duration getChatTotalTimeout() {
     return this.chatTotalTimeout;
   }
 
-  public void setChatTotalTimeout(Duration chatTotalTimeout) {
-    this.chatTotalTimeout = chatTotalTimeout;
+  public void setChatTotalTimeout(java.time.Duration chatTotalTimeout) {
+    this.chatTotalTimeout = Duration.parse(chatTotalTimeout.toString());
   }
 
   public Duration getChatAgainInitialRpcTimeout() {
     return this.chatAgainInitialRpcTimeout;
   }
 
-  public void setChatAgainInitialRpcTimeout(Duration chatAgainInitialRpcTimeout) {
-    this.chatAgainInitialRpcTimeout = chatAgainInitialRpcTimeout;
+  public void setChatAgainInitialRpcTimeout(java.time.Duration chatAgainInitialRpcTimeout) {
+    this.chatAgainInitialRpcTimeout = Duration.parse(chatAgainInitialRpcTimeout.toString());
   }
 
   public Double getChatAgainRpcTimeoutMultiplier() {
@@ -292,24 +292,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.chatAgainMaxRpcTimeout;
   }
 
-  public void setChatAgainMaxRpcTimeout(Duration chatAgainMaxRpcTimeout) {
-    this.chatAgainMaxRpcTimeout = chatAgainMaxRpcTimeout;
+  public void setChatAgainMaxRpcTimeout(java.time.Duration chatAgainMaxRpcTimeout) {
+    this.chatAgainMaxRpcTimeout = Duration.parse(chatAgainMaxRpcTimeout.toString());
   }
 
   public Duration getChatAgainTotalTimeout() {
     return this.chatAgainTotalTimeout;
   }
 
-  public void setChatAgainTotalTimeout(Duration chatAgainTotalTimeout) {
-    this.chatAgainTotalTimeout = chatAgainTotalTimeout;
+  public void setChatAgainTotalTimeout(java.time.Duration chatAgainTotalTimeout) {
+    this.chatAgainTotalTimeout = Duration.parse(chatAgainTotalTimeout.toString());
   }
 
   public Duration getPagedExpandInitialRetryDelay() {
     return this.pagedExpandInitialRetryDelay;
   }
 
-  public void setPagedExpandInitialRetryDelay(Duration pagedExpandInitialRetryDelay) {
-    this.pagedExpandInitialRetryDelay = pagedExpandInitialRetryDelay;
+  public void setPagedExpandInitialRetryDelay(java.time.Duration pagedExpandInitialRetryDelay) {
+    this.pagedExpandInitialRetryDelay = Duration.parse(pagedExpandInitialRetryDelay.toString());
   }
 
   public Double getPagedExpandRetryDelayMultiplier() {
@@ -324,16 +324,16 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.pagedExpandMaxRetryDelay;
   }
 
-  public void setPagedExpandMaxRetryDelay(Duration pagedExpandMaxRetryDelay) {
-    this.pagedExpandMaxRetryDelay = pagedExpandMaxRetryDelay;
+  public void setPagedExpandMaxRetryDelay(java.time.Duration pagedExpandMaxRetryDelay) {
+    this.pagedExpandMaxRetryDelay = Duration.parse(pagedExpandMaxRetryDelay.toString());
   }
 
   public Duration getPagedExpandInitialRpcTimeout() {
     return this.pagedExpandInitialRpcTimeout;
   }
 
-  public void setPagedExpandInitialRpcTimeout(Duration pagedExpandInitialRpcTimeout) {
-    this.pagedExpandInitialRpcTimeout = pagedExpandInitialRpcTimeout;
+  public void setPagedExpandInitialRpcTimeout(java.time.Duration pagedExpandInitialRpcTimeout) {
+    this.pagedExpandInitialRpcTimeout = Duration.parse(pagedExpandInitialRpcTimeout.toString());
   }
 
   public Double getPagedExpandRpcTimeoutMultiplier() {
@@ -348,24 +348,26 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.pagedExpandMaxRpcTimeout;
   }
 
-  public void setPagedExpandMaxRpcTimeout(Duration pagedExpandMaxRpcTimeout) {
-    this.pagedExpandMaxRpcTimeout = pagedExpandMaxRpcTimeout;
+  public void setPagedExpandMaxRpcTimeout(java.time.Duration pagedExpandMaxRpcTimeout) {
+    this.pagedExpandMaxRpcTimeout = Duration.parse(pagedExpandMaxRpcTimeout.toString());
   }
 
   public Duration getPagedExpandTotalTimeout() {
     return this.pagedExpandTotalTimeout;
   }
 
-  public void setPagedExpandTotalTimeout(Duration pagedExpandTotalTimeout) {
-    this.pagedExpandTotalTimeout = pagedExpandTotalTimeout;
+  public void setPagedExpandTotalTimeout(java.time.Duration pagedExpandTotalTimeout) {
+    this.pagedExpandTotalTimeout = Duration.parse(pagedExpandTotalTimeout.toString());
   }
 
   public Duration getSimplePagedExpandInitialRpcTimeout() {
     return this.simplePagedExpandInitialRpcTimeout;
   }
 
-  public void setSimplePagedExpandInitialRpcTimeout(Duration simplePagedExpandInitialRpcTimeout) {
-    this.simplePagedExpandInitialRpcTimeout = simplePagedExpandInitialRpcTimeout;
+  public void setSimplePagedExpandInitialRpcTimeout(
+      java.time.Duration simplePagedExpandInitialRpcTimeout) {
+    this.simplePagedExpandInitialRpcTimeout =
+        Duration.parse(simplePagedExpandInitialRpcTimeout.toString());
   }
 
   public Double getSimplePagedExpandRpcTimeoutMultiplier() {
@@ -381,24 +383,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.simplePagedExpandMaxRpcTimeout;
   }
 
-  public void setSimplePagedExpandMaxRpcTimeout(Duration simplePagedExpandMaxRpcTimeout) {
-    this.simplePagedExpandMaxRpcTimeout = simplePagedExpandMaxRpcTimeout;
+  public void setSimplePagedExpandMaxRpcTimeout(java.time.Duration simplePagedExpandMaxRpcTimeout) {
+    this.simplePagedExpandMaxRpcTimeout = Duration.parse(simplePagedExpandMaxRpcTimeout.toString());
   }
 
   public Duration getSimplePagedExpandTotalTimeout() {
     return this.simplePagedExpandTotalTimeout;
   }
 
-  public void setSimplePagedExpandTotalTimeout(Duration simplePagedExpandTotalTimeout) {
-    this.simplePagedExpandTotalTimeout = simplePagedExpandTotalTimeout;
+  public void setSimplePagedExpandTotalTimeout(java.time.Duration simplePagedExpandTotalTimeout) {
+    this.simplePagedExpandTotalTimeout = Duration.parse(simplePagedExpandTotalTimeout.toString());
   }
 
   public Duration getWaitInitialRpcTimeout() {
     return this.waitInitialRpcTimeout;
   }
 
-  public void setWaitInitialRpcTimeout(Duration waitInitialRpcTimeout) {
-    this.waitInitialRpcTimeout = waitInitialRpcTimeout;
+  public void setWaitInitialRpcTimeout(java.time.Duration waitInitialRpcTimeout) {
+    this.waitInitialRpcTimeout = Duration.parse(waitInitialRpcTimeout.toString());
   }
 
   public Double getWaitRpcTimeoutMultiplier() {
@@ -413,24 +415,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.waitMaxRpcTimeout;
   }
 
-  public void setWaitMaxRpcTimeout(Duration waitMaxRpcTimeout) {
-    this.waitMaxRpcTimeout = waitMaxRpcTimeout;
+  public void setWaitMaxRpcTimeout(java.time.Duration waitMaxRpcTimeout) {
+    this.waitMaxRpcTimeout = Duration.parse(waitMaxRpcTimeout.toString());
   }
 
   public Duration getWaitTotalTimeout() {
     return this.waitTotalTimeout;
   }
 
-  public void setWaitTotalTimeout(Duration waitTotalTimeout) {
-    this.waitTotalTimeout = waitTotalTimeout;
+  public void setWaitTotalTimeout(java.time.Duration waitTotalTimeout) {
+    this.waitTotalTimeout = Duration.parse(waitTotalTimeout.toString());
   }
 
   public Duration getBlockInitialRpcTimeout() {
     return this.blockInitialRpcTimeout;
   }
 
-  public void setBlockInitialRpcTimeout(Duration blockInitialRpcTimeout) {
-    this.blockInitialRpcTimeout = blockInitialRpcTimeout;
+  public void setBlockInitialRpcTimeout(java.time.Duration blockInitialRpcTimeout) {
+    this.blockInitialRpcTimeout = Duration.parse(blockInitialRpcTimeout.toString());
   }
 
   public Double getBlockRpcTimeoutMultiplier() {
@@ -445,24 +447,24 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.blockMaxRpcTimeout;
   }
 
-  public void setBlockMaxRpcTimeout(Duration blockMaxRpcTimeout) {
-    this.blockMaxRpcTimeout = blockMaxRpcTimeout;
+  public void setBlockMaxRpcTimeout(java.time.Duration blockMaxRpcTimeout) {
+    this.blockMaxRpcTimeout = Duration.parse(blockMaxRpcTimeout.toString());
   }
 
   public Duration getBlockTotalTimeout() {
     return this.blockTotalTimeout;
   }
 
-  public void setBlockTotalTimeout(Duration blockTotalTimeout) {
-    this.blockTotalTimeout = blockTotalTimeout;
+  public void setBlockTotalTimeout(java.time.Duration blockTotalTimeout) {
+    this.blockTotalTimeout = Duration.parse(blockTotalTimeout.toString());
   }
 
   public Duration getCollideNameInitialRpcTimeout() {
     return this.collideNameInitialRpcTimeout;
   }
 
-  public void setCollideNameInitialRpcTimeout(Duration collideNameInitialRpcTimeout) {
-    this.collideNameInitialRpcTimeout = collideNameInitialRpcTimeout;
+  public void setCollideNameInitialRpcTimeout(java.time.Duration collideNameInitialRpcTimeout) {
+    this.collideNameInitialRpcTimeout = Duration.parse(collideNameInitialRpcTimeout.toString());
   }
 
   public Double getCollideNameRpcTimeoutMultiplier() {
@@ -477,15 +479,15 @@ public class EchoSpringProperties implements CredentialsSupplier {
     return this.collideNameMaxRpcTimeout;
   }
 
-  public void setCollideNameMaxRpcTimeout(Duration collideNameMaxRpcTimeout) {
-    this.collideNameMaxRpcTimeout = collideNameMaxRpcTimeout;
+  public void setCollideNameMaxRpcTimeout(java.time.Duration collideNameMaxRpcTimeout) {
+    this.collideNameMaxRpcTimeout = Duration.parse(collideNameMaxRpcTimeout.toString());
   }
 
   public Duration getCollideNameTotalTimeout() {
     return this.collideNameTotalTimeout;
   }
 
-  public void setCollideNameTotalTimeout(Duration collideNameTotalTimeout) {
-    this.collideNameTotalTimeout = collideNameTotalTimeout;
+  public void setCollideNameTotalTimeout(java.time.Duration collideNameTotalTimeout) {
+    this.collideNameTotalTimeout = Duration.parse(collideNameTotalTimeout.toString());
   }
 }


### PR DESCRIPTION
**This PR:** updates setters for Spring properties of type `org.threeten.bp.Duration` to accept argument of type `java.time.Duration` instead, and parse to `org.threeten.bp.Duration` in the setter body. 
- Converting between the two types: `parse()` and `toString()` methods for both will accept or return ISO-8601 seconds based representation, such as `PT8H6M12.345S`.

This addresses the issue that properties of type `org.threeten.bp.Duration` cannot be set from strings (e.g. specified in Spring property files) because the implicit conversion is unsupported. Spring boot has [dedicated support](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion.durations) for properties of type `java.time.Duration`.

**Note for review:** would appreciate any feedback or thoughts on the conversion approach here! Some alternative approaches explored were:
- The property type itself can be changed to `java.time.Duration`, but have getters modified to convert to `org.threeten.bp.Duration` ([poc](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/df71cb64ebc9e3355a4f688f137d49c1761ed6c8/generated/language/src/main/java/com/google/cloud/language/v1/spring/LanguageServiceSpringProperties.java#L138-L149))
- Adding custom converter for String to `org.threeten.bp.Duration` through `@ConfigurationPropertiesBinding` ([poc](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/df71cb64ebc9e3355a4f688f137d49c1761ed6c8/generated/language/src/main/java/com/google/cloud/language/v1/spring/StringToBackportDurationConverter.java))