### PR TITLE
fix: Support testing nested argument method signatures and 'double' field assertions

### DIFF
--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -82,6 +82,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public abstract class AbstractServiceClientTestClassComposer implements ClassComposer {
+
   protected static final Statement EMPTY_LINE_STATEMENT = EmptyLineStatement.create();
 
   protected static final String CLIENT_VAR_NAME = "client";
@@ -303,19 +304,23 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
   /**
    * Creates a test method for a given RPC, e.g. createAssetTest.
    *
-   * @param method the RPC for which this test method is created.
-   * @param apiService the host service under test.
-   * @param rpcService the service that {@code method} belongs to. This is not equal to {@code
-   *     apiService} only when {@code method} is a mixin, in which case {@code rpcService} is the
-   *     mixed-in service. If {@code apiService} and {@code rpcService} are different, they will be
-   *     used only for pagination. Otherwise, {@code rpcService} subsumes {@code apiService}.
-   * @param methodSignature the method signature of the RPC under test.
-   * @param variantIndex the nth variant of the RPC under test. This applies when we have
-   *     polymorphism due to the presence of several method signature annotations in the proto.
-   * @param isRequestArg whether the RPC variant under test take only the request proto message.
+   * @param method              the RPC for which this test method is created.
+   * @param apiService          the host service under test.
+   * @param rpcService          the service that {@code method} belongs to. This is not equal to
+   *                            {@code apiService} only when {@code method} is a mixin, in which
+   *                            case {@code rpcService} is the mixed-in service. If
+   *                            {@code apiService} and {@code rpcService} are different, they will
+   *                            be used only for pagination. Otherwise, {@code rpcService} subsumes
+   *                            {@code apiService}.
+   * @param methodSignature     the method signature of the RPC under test.
+   * @param variantIndex        the nth variant of the RPC under test. This applies when we have
+   *                            polymorphism due to the presence of several method signature
+   *                            annotations in the proto.
+   * @param isRequestArg        whether the RPC variant under test take only the request proto
+   *                            message.
    * @param classMemberVarExprs the class members in the generated test class.
-   * @param resourceNames the resource names available for use.
-   * @param messageTypes the proto message types available for use.
+   * @param resourceNames       the resource names available for use.
+   * @param messageTypes        the proto message types available for use.
    */
   private MethodDefinition createRpcTestMethod(
       Method method,
@@ -419,7 +424,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
 
     if (method.hasLro()
         && (method.lro().operationServiceStubType() == null
-            || !method.lro().responseType().equals(method.outputType()))) {
+        || !method.lro().responseType().equals(method.outputType()))) {
 
       VariableExpr resultOperationVarExpr =
           VariableExpr.withVariable(
@@ -690,12 +695,9 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
     methodStatements.add(EMPTY_LINE_STATEMENT);
 
     methodStatements.addAll(
-        methodExprs.stream().map(e -> ExprStatement.withExpr(e)).collect(Collectors.toList()));
-    methodExprs.clear();
-
-    methodStatements.addAll(
         constructRpcTestCheckerLogic(
             method,
+            methodSignature,
             rpcService,
             isRequestArg,
             classMemberVarExprs,
@@ -720,6 +722,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
 
   protected abstract List<Statement> constructRpcTestCheckerLogic(
       Method method,
+      List<MethodArgument> methodSignature,
       Service service,
       boolean isRequestArg,
       Map<String, VariableExpr> classMemberVarExprs,
@@ -737,14 +740,15 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
   /**
    * Creates a test method to exercise exceptions for a given RPC, e.g. createAssetTest.
    *
-   * @param method the RPC for which this test method is created.
-   * @param service the service that {@code method} belongs to.
-   * @param methodSignature the method signature of the RPC under test.
-   * @param variantIndex the nth variant of the RPC under test. This applies when we have
-   *     polymorphism due to the presence of several method signature annotations in the proto.
+   * @param method              the RPC for which this test method is created.
+   * @param service             the service that {@code method} belongs to.
+   * @param methodSignature     the method signature of the RPC under test.
+   * @param variantIndex        the nth variant of the RPC under test. This applies when we have
+   *                            polymorphism due to the presence of several method signature
+   *                            annotations in the proto.
    * @param classMemberVarExprs the class members in the generated test class.
-   * @param resourceNames the resource names available for use.
-   * @param messageTypes the proto message types available for use.
+   * @param resourceNames       the resource names available for use.
+   * @param messageTypes        the proto message types available for use.
    */
   protected abstract MethodDefinition createRpcExceptionTestMethod(
       Method method,

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -304,23 +304,19 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
   /**
    * Creates a test method for a given RPC, e.g. createAssetTest.
    *
-   * @param method              the RPC for which this test method is created.
-   * @param apiService          the host service under test.
-   * @param rpcService          the service that {@code method} belongs to. This is not equal to
-   *                            {@code apiService} only when {@code method} is a mixin, in which
-   *                            case {@code rpcService} is the mixed-in service. If
-   *                            {@code apiService} and {@code rpcService} are different, they will
-   *                            be used only for pagination. Otherwise, {@code rpcService} subsumes
-   *                            {@code apiService}.
-   * @param methodSignature     the method signature of the RPC under test.
-   * @param variantIndex        the nth variant of the RPC under test. This applies when we have
-   *                            polymorphism due to the presence of several method signature
-   *                            annotations in the proto.
-   * @param isRequestArg        whether the RPC variant under test take only the request proto
-   *                            message.
+   * @param method the RPC for which this test method is created.
+   * @param apiService the host service under test.
+   * @param rpcService the service that {@code method} belongs to. This is not equal to {@code
+   *     apiService} only when {@code method} is a mixin, in which case {@code rpcService} is the
+   *     mixed-in service. If {@code apiService} and {@code rpcService} are different, they will be
+   *     used only for pagination. Otherwise, {@code rpcService} subsumes {@code apiService}.
+   * @param methodSignature the method signature of the RPC under test.
+   * @param variantIndex the nth variant of the RPC under test. This applies when we have
+   *     polymorphism due to the presence of several method signature annotations in the proto.
+   * @param isRequestArg whether the RPC variant under test take only the request proto message.
    * @param classMemberVarExprs the class members in the generated test class.
-   * @param resourceNames       the resource names available for use.
-   * @param messageTypes        the proto message types available for use.
+   * @param resourceNames the resource names available for use.
+   * @param messageTypes the proto message types available for use.
    */
   private MethodDefinition createRpcTestMethod(
       Method method,
@@ -424,7 +420,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
 
     if (method.hasLro()
         && (method.lro().operationServiceStubType() == null
-        || !method.lro().responseType().equals(method.outputType()))) {
+            || !method.lro().responseType().equals(method.outputType()))) {
 
       VariableExpr resultOperationVarExpr =
           VariableExpr.withVariable(
@@ -740,15 +736,14 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
   /**
    * Creates a test method to exercise exceptions for a given RPC, e.g. createAssetTest.
    *
-   * @param method              the RPC for which this test method is created.
-   * @param service             the service that {@code method} belongs to.
-   * @param methodSignature     the method signature of the RPC under test.
-   * @param variantIndex        the nth variant of the RPC under test. This applies when we have
-   *                            polymorphism due to the presence of several method signature
-   *                            annotations in the proto.
+   * @param method the RPC for which this test method is created.
+   * @param service the service that {@code method} belongs to.
+   * @param methodSignature the method signature of the RPC under test.
+   * @param variantIndex the nth variant of the RPC under test. This applies when we have
+   *     polymorphism due to the presence of several method signature annotations in the proto.
    * @param classMemberVarExprs the class members in the generated test class.
-   * @param resourceNames       the resource names available for use.
-   * @param messageTypes        the proto message types available for use.
+   * @param resourceNames the resource names available for use.
+   * @param messageTypes the proto message types available for use.
    */
   protected abstract MethodDefinition createRpcExceptionTestMethod(
       Method method,

--- a/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientTestClassComposer.java
@@ -698,8 +698,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
             isRequestArg,
             classMemberVarExprs,
             requestVarExpr,
-            requestMessage,
-            argExprs));
+            requestMessage));
 
     String testMethodName =
         String.format(
@@ -723,8 +722,7 @@ public abstract class AbstractServiceClientTestClassComposer implements ClassCom
       boolean isRequestArg,
       Map<String, VariableExpr> classMemberVarExprs,
       VariableExpr requestVarExpr,
-      Message requestMessage,
-      List<VariableExpr> argExprs);
+      Message requestMessage);
 
   protected abstract MethodDefinition createStreamingRpcTestMethod(
       Service service,

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -365,8 +365,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
       boolean isRequestArg,
       Map<String, VariableExpr> classMemberVarExprs,
       VariableExpr requestVarExpr, // Nullable
-      Message requestMessage,
-      List<VariableExpr> argExprs) {
+      Message requestMessage) {
     List<Expr> methodExprs = new ArrayList<>();
     List<Statement> methodStatements = new ArrayList<>();
 

--- a/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/grpc/ServiceClientTestClassComposer.java
@@ -525,8 +525,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
         .setExprReferenceExpr(exprReference)
         .setMethodName(
             String.format(
-                createGetterNamePattern(field.type()),
-                JavaStyle.toUpperCamelCase(field.name())))
+                createGetterNamePattern(field.type()), JavaStyle.toUpperCamelCase(field.name())))
         .build();
   }
 

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
@@ -303,8 +303,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
       boolean isRequestArg,
       Map<String, VariableExpr> classMemberVarExprs,
       VariableExpr requestVarExpr,
-      Message requestMessage,
-      List<VariableExpr> argExprs) {
+      Message requestMessage) {
 
     VariableExpr actualRequestsVarExpr =
         VariableExpr.withVariable(

--- a/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
+++ b/src/main/java/com/google/api/generator/gapic/composer/rest/ServiceClientTestClassComposer.java
@@ -60,6 +60,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ServiceClientTestClassComposer extends AbstractServiceClientTestClassComposer {
+
   private static final String MOCK_SERVICE_VAR_NAME = "mockService";
 
   private static final ServiceClientTestClassComposer INSTANCE =
@@ -297,6 +298,7 @@ public class ServiceClientTestClassComposer extends AbstractServiceClientTestCla
   @Override
   protected List<Statement> constructRpcTestCheckerLogic(
       Method method,
+      List<MethodArgument> methodSignature,
       Service service,
       boolean isRequestArg,
       Map<String, VariableExpr> classMemberVarExprs,


### PR DESCRIPTION
* **Handle [method signatures with nested arguments](https://github.com/googleapis/gapic-showcase/blob/main/schema/google/showcase/v1beta1/identity.proto#L44-L46)**.

  Before:
  ```java
  Assert.assertEquals(displayName, actualRequest.getDisplayName());
  ```
  After:
  ```java
  Assert.assertEquals(displayName, actualRequest.getUser().getDisplayName());
  ```

* **Provide a consistent tolerance value of `0.0001` for `assertEquals` on `double` and `float` values.**

  Before:
  ```java
  Assert.assertEquals(expected, actual);
  ```
  > bazel error: [DoNotCall] This method always throws java.lang.AssertionError. Use assertEquals(expected, actual, delta) to compare floating-point numbers

  After:
  ```java
  Assert.assertEquals(expected, actual, 0.0001);
  ```