### PR TITLE
fix(spring): fix write pom placeholders.

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -212,6 +212,7 @@ public class SpringWriter {
 
     String springStarterArtifactId = clientLibraryName + "-spring-starter";
     String springStarterName = "Spring Boot Starter - " + clientLibraryShortName;
+    String springParentVersion = "{{parent-version}}";
 
     StringJoiner sb = new StringJoiner(",\\\n");
     sb.add(
@@ -224,6 +225,7 @@ public class SpringWriter {
                 + "  <parent>\n"
                 + "    <groupId>com.google.cloud</groupId>\n"
                 + "    <artifactId>generated-parent</artifactId>\n"
+                + "    <version>%s</version>\n"
                 + "  </parent>\n"
                 + "  <artifactId>%s</artifactId>\n"
                 + "  <name>%s</name>\n"
@@ -251,6 +253,7 @@ public class SpringWriter {
                 + "</dependencies>\n"
                 + "\n"
                 + "</project>",
+            springParentVersion,
             springStarterArtifactId,
             springStarterName,
             clientLibraryShortName,

--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -211,7 +211,6 @@ public class SpringWriter {
     String clientLibraryVersion = "{{client-library-version}}";
 
     String springStarterArtifactId = clientLibraryName + "-spring-starter";
-    String springStarterVersion = "{{starter-version}}";
     String springStarterName = "Spring Boot Starter - " + clientLibraryShortName;
 
     StringJoiner sb = new StringJoiner(",\\\n");
@@ -226,9 +225,7 @@ public class SpringWriter {
                 + "    <groupId>com.google.cloud</groupId>\n"
                 + "    <artifactId>generated-parent</artifactId>\n"
                 + "  </parent>\n"
-                + "  <groupId>com.google.cloud</groupId>\n"
                 + "  <artifactId>%s</artifactId>\n"
-                + "  <version>%s</version>\n"
                 + "  <name>%s</name>\n"
                 + "  <description>Spring Boot Starter with AutoConfiguration for %s</description>\n"
                 + "\n"
@@ -255,7 +252,6 @@ public class SpringWriter {
                 + "\n"
                 + "</project>",
             springStarterArtifactId,
-            springStarterVersion,
             springStarterName,
             clientLibraryShortName,
             clientLibraryGroupId,

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -7,9 +7,7 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>generated-parent</artifactId>
   </parent>
-  <groupId>com.google.cloud</groupId>
   <artifactId>{{client-library-artifact-id}}-spring-starter</artifactId>
-  <version>{{starter-version}}</version>
   <name>Spring Boot Starter - localhost:7469</name>
   <description>Spring Boot Starter with AutoConfiguration for localhost:7469</description>
 

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -6,6 +6,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>generated-parent</artifactId>
+    <version>{{parent-version}}</version>
   </parent>
   <artifactId>{{client-library-artifact-id}}-spring-starter</artifactId>
   <name>Spring Boot Starter - localhost:7469</name>


### PR DESCRIPTION
- `{{starter-version}}` are not needed anymore as we inherit version from parent pom.
- add parent version placeholder. Changes on spring-cloud-gcp side needed.
- remove redundant groupid.
- remove versions for `spring-cloud-gcp-core` and `spring-boot-starter`, specified in `genereated-parent` pom