### PR TITLE
feat: service settings as a bean

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -877,22 +877,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     String methodName =
         CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name()) + "Settings";
-    String conditionalOnMissingBeanNameArgument = methodName;
-
-    // @ConditionalOnMissingBean(name = "[service]Settings")
-    AnnotationNode conditionalOnMissingBeanAnnotation =
-        AnnotationNode.builder()
-            .setType(STATIC_TYPES.get("ConditionalOnMissingBean"))
-            .addDescription(
-                AssignmentExpr.builder()
-                    .setVariableExpr(
-                        VariableExpr.withVariable(
-                            Variable.builder().setName("name").setType(TypeNode.STRING).build()))
-                    .setValueExpr(
-                        ValueExpr.withValue(
-                            StringObjectValue.withValue(conditionalOnMissingBeanNameArgument)))
-                    .build())
-            .build();
 
     return MethodDefinition.builder()
         .setHeaderCommentStatements(
@@ -907,7 +891,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         .setAnnotations(
             Arrays.asList(
                 AnnotationNode.withType(STATIC_TYPES.get("Bean")),
-                conditionalOnMissingBeanAnnotation))
+                AnnotationNode.withType(STATIC_TYPES.get("ConditionalOnMissingBean"))))
         .setThrowsExceptions(Arrays.asList(TypeNode.withExceptionClazz(IOException.class)))
         .setReturnExpr(returnExpr)
         .setBody(bodyStatements)

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -125,7 +125,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
                         service, className, credentialsProviderName, dynamicTypes, thisExpr),
                     createTransportChannelProviderBeanMethod(
                         transportChannelProviderName, dynamicTypes),
-                    createServiceSettingsBeanMethod(
+                    createSettingsBeanMethod(
                         service,
                         credentialsProviderName,
                         transportChannelProviderName,
@@ -529,7 +529,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     return ExprStatement.withExpr(clientSettingBuilderChain);
   }
 
-  private static MethodDefinition createServiceSettingsBeanMethod(
+  private static MethodDefinition createSettingsBeanMethod(
       Service service,
       String credentialsProviderName,
       String transportChannelProviderName,

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -114,7 +114,7 @@ public class EchoSpringAutoConfiguration {
    * default retry settings when they are not specified in EchoSpringProperties.
    */
   @Bean
-  @ConditionalOnMissingBean(name = "echoSettings")
+  @ConditionalOnMissingBean
   public EchoSettings echoSettings(
       @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -114,8 +114,8 @@ public class EchoSpringAutoConfiguration {
    * default retry settings when they are not specified in EchoSpringProperties.
    */
   @Bean
-  @ConditionalOnMissingBean
-  public EchoClient echoClient(
+  @ConditionalOnMissingBean(name = "echoSettings")
+  public EchoSettings echoSettings(
       @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
@@ -576,7 +576,13 @@ public class EchoSpringAutoConfiguration {
     clientSettingsBuilder
         .collideNameSettings()
         .setRetrySettings(collideNameRetrySettingBuilder.build());
-    return EchoClient.create(clientSettingsBuilder.build());
+    return clientSettingsBuilder.build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public EchoClient echoClient(EchoSettings echoSettings) throws IOException {
+    return EchoClient.create(echoSettings);
   }
 
   private HeaderProvider userAgentHeaderProvider() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -94,8 +94,8 @@ public class EchoSpringAutoConfiguration {
    * default retry settings when they are not specified in EchoSpringProperties.
    */
   @Bean
-  @ConditionalOnMissingBean
-  public EchoClient echoClient(
+  @ConditionalOnMissingBean(name = "echoSettings")
+  public EchoSettings echoSettings(
       @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
@@ -556,7 +556,13 @@ public class EchoSpringAutoConfiguration {
     clientSettingsBuilder
         .collideNameSettings()
         .setRetrySettings(collideNameRetrySettingBuilder.build());
-    return EchoClient.create(clientSettingsBuilder.build());
+    return clientSettingsBuilder.build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public EchoClient echoClient(EchoSettings echoSettings) throws IOException {
+    return EchoClient.create(echoSettings);
   }
 
   private HeaderProvider userAgentHeaderProvider() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -94,7 +94,7 @@ public class EchoSpringAutoConfiguration {
    * default retry settings when they are not specified in EchoSpringProperties.
    */
   @Bean
-  @ConditionalOnMissingBean(name = "echoSettings")
+  @ConditionalOnMissingBean
   public EchoSettings echoSettings(
       @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -95,8 +95,8 @@ public class EchoSpringAutoConfiguration {
    * default retry settings when they are not specified in EchoSpringProperties.
    */
   @Bean
-  @ConditionalOnMissingBean
-  public EchoClient echoClient(
+  @ConditionalOnMissingBean(name = "echoSettings")
+  public EchoSettings echoSettings(
       @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
@@ -564,7 +564,13 @@ public class EchoSpringAutoConfiguration {
     clientSettingsBuilder
         .collideNameSettings()
         .setRetrySettings(collideNameRetrySettingBuilder.build());
-    return EchoClient.create(clientSettingsBuilder.build());
+    return clientSettingsBuilder.build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public EchoClient echoClient(EchoSettings echoSettings) throws IOException {
+    return EchoClient.create(echoSettings);
   }
 
   private HeaderProvider userAgentHeaderProvider() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -95,7 +95,7 @@ public class EchoSpringAutoConfiguration {
    * default retry settings when they are not specified in EchoSpringProperties.
    */
   @Bean
-  @ConditionalOnMissingBean(name = "echoSettings")
+  @ConditionalOnMissingBean
   public EchoSettings echoSettings(
       @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")


### PR DESCRIPTION
Enables usage of `[Service]Settings` as a separate bean, as suggested in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1364#discussion_r1036178245

Changes were based on [POC](https://github.com/zhumin8/language_poc1/pull/4) by @zhumin8 and [POC fixes](https://github.com/zhumin8/language_poc1/pull/5) by @emmileaf 