### PR TITLE
ci(showcase): disable snippet-bot for showcase

### DIFF
--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -3,3 +3,4 @@ alwaysCreateStatusCheck: false
 ignoreFiles:
   - src/test/**
   - test/**
+  - showcase/**


### PR DESCRIPTION
This [snippet-bot issue and conversation](https://github.com/googleapis/repo-automation-bots/issues/4697) states that snippet-bot pulls its configuration from the base branch rather than the PR head. This PR sets the base branch configuration to ignore files that will be introduced in https://github.com/googleapis/gapic-generator-java/pull/1100

