### PR TITLE
fix(spring): Replace global properties with CredentialsProvider bean

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -246,7 +246,7 @@ public class SpringWriter {
                 + "\n"
                 + "  <dependency>\n"
                 + "    <groupId>com.google.cloud</groupId>\n"
-                + "    <artifactId>spring-cloud-gcp-core</artifactId>\n"
+                + "    <artifactId>spring-cloud-gcp-autoconfigure</artifactId>\n"
                 + "  </dependency>\n"
                 + "</dependencies>\n"
                 + "\n"

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -53,7 +53,7 @@ import com.google.api.generator.gapic.model.GapicServiceConfig;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.model.Transport;
 import com.google.api.generator.spring.composer.comment.SpringAutoconfigCommentComposer;
-import com.google.api.generator.spring.utils.GlobalPropertiesUtils;
+import com.google.api.generator.spring.utils.ComposerUtils;
 import com.google.api.generator.spring.utils.LoggerUtils;
 import com.google.api.generator.spring.utils.Utils;
 import com.google.cloud.spring.core.Credentials;
@@ -143,14 +143,14 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     // private final LanguageProperties clientProperties;
     ExprStatement clientPropertiesStatement =
-        GlobalPropertiesUtils.createMemberVarStatement(
+        ComposerUtils.createMemberVarStatement(
             "clientProperties",
             types.get(Utils.getServicePropertiesClassName(service)),
             true,
             null,
             null);
     Statement credentialProvider =
-        GlobalPropertiesUtils.createMemberVarStatement(
+        ComposerUtils.createMemberVarStatement(
             "credentialsProvider", STATIC_TYPES.get("CredentialsProvider"), true, null, null);
 
     Statement loggerStatement =
@@ -957,7 +957,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     typeMap.put("ServiceClient", serviceClient);
     typeMap.put("ServiceSettings", serviceSettings);
     typeMap.put("ServiceSettingsBuilder", serviceSettingsBuilder);
-    typeMap.put("GlobalProperties", GlobalPropertiesUtils.getGlobalPropertiesType());
 
     return typeMap;
   }

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -243,6 +243,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     return MethodDefinition.constructorBuilder()
         .setScope(ScopeNode.PROTECTED)
+        .setThrowsExceptions(Arrays.asList(TypeNode.withExceptionClazz(IOException.class)))
         .setReturnType(types.get(className))
         .setArguments(
             Arrays.asList(

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -22,7 +22,6 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.generator.engine.ast.AnnotationNode;
 import com.google.api.generator.engine.ast.ArithmeticOperationExpr;
-import com.google.api.generator.engine.ast.ArrayExpr;
 import com.google.api.generator.engine.ast.AssignmentExpr;
 import com.google.api.generator.engine.ast.CastExpr;
 import com.google.api.generator.engine.ast.ClassDefinition;
@@ -36,7 +35,6 @@ import com.google.api.generator.engine.ast.MethodInvocationExpr;
 import com.google.api.generator.engine.ast.NewObjectExpr;
 import com.google.api.generator.engine.ast.PrimitiveValue;
 import com.google.api.generator.engine.ast.RelationalOperationExpr;
-import com.google.api.generator.engine.ast.ReturnExpr;
 import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.engine.ast.Statement;
 import com.google.api.generator.engine.ast.StringObjectValue;
@@ -121,16 +119,11 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .setMethods(
                 Arrays.asList(
                     createConstructor(service, className, dynamicTypes, thisExpr),
-                    createCredentialsProviderBeanMethod(
-                        service, className, credentialsProviderName, dynamicTypes, thisExpr),
                     createTransportChannelProviderBeanMethod(
                         transportChannelProviderName, dynamicTypes),
                     createClientBeanMethod(
                         service,
-                        className,
-                        credentialsProviderName,
                         transportChannelProviderName,
-                        clientName,
                         dynamicTypes,
                         gapicServiceConfig,
                         thisExpr,
@@ -148,29 +141,22 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
       Map<String, TypeNode> types,
       GapicServiceConfig serviceConfig) {
 
-    String serviceName = service.name();
-
     // private final LanguageProperties clientProperties;
-    Variable clientPropertiesVar =
-        Variable.builder()
-            .setName("clientProperties")
-            .setType(types.get(Utils.getServicePropertiesClassName(service)))
-            .build();
-    VariableExpr clientPropertiesVarExpr =
-        VariableExpr.builder()
-            .setVariable(clientPropertiesVar)
-            .setScope(ScopeNode.PRIVATE)
-            .setIsFinal(true)
-            .setIsDecl(true)
-            .build();
-    ExprStatement clientPropertiesStatement = ExprStatement.withExpr(clientPropertiesVarExpr);
+    ExprStatement clientPropertiesStatement =
+        GlobalPropertiesUtils.createMemberVarStatement(
+            "clientProperties",
+            types.get(Utils.getServicePropertiesClassName(service)),
+            true,
+            null,
+            null);
+    Statement credentialProvider =
+        GlobalPropertiesUtils.createMemberVarStatement(
+            "credentialsProvider", STATIC_TYPES.get("CredentialsProvider"), true, null, null);
 
     Statement loggerStatement =
         LoggerUtils.getLoggerDeclarationExpr(
             Utils.getServiceAutoConfigurationClassName(service), types);
-    Statement globalPropertiesStatement =
-        GlobalPropertiesUtils.getGlobalPropertiesDeclaration(types);
-    return Arrays.asList(clientPropertiesStatement, globalPropertiesStatement, loggerStatement);
+    return Arrays.asList(clientPropertiesStatement, credentialProvider, loggerStatement);
   }
 
   private static MethodDefinition createConstructor(
@@ -181,47 +167,79 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
                 .setName("clientProperties")
                 .setType(types.get(Utils.getServicePropertiesClassName(service)))
                 .build());
-    VariableExpr globalPropertiesVarExpr =
+    VariableExpr credentialsProviderVarExpr =
         VariableExpr.withVariable(
             Variable.builder()
-                .setName("globalProperties")
-                .setType(types.get("GlobalProperties"))
+                .setName("credentialsProvider")
+                .setType(STATIC_TYPES.get("CredentialsProvider"))
                 .build());
-    Variable clientPropertiesVar =
-        Variable.builder()
-            .setName("clientProperties")
-            .setType(types.get(Utils.getServicePropertiesClassName(service)))
-            .build();
-    Variable globalPropertiesVar =
-        Variable.builder()
-            .setName("globalProperties")
-            .setType(types.get("GlobalProperties"))
-            .build();
 
     // this.clientProperties = clientProperties;
     AssignmentExpr thisClientPropertiesAssignmentExpr =
         AssignmentExpr.builder()
             .setVariableExpr(
-                VariableExpr.withVariable(clientPropertiesVar)
-                    .toBuilder()
-                    .setExprReferenceExpr(thisExpr)
-                    .build())
+                clientPropertiesVarExpr.toBuilder().setExprReferenceExpr(thisExpr).build())
             .setValueExpr(clientPropertiesVarExpr)
             .build();
     ExprStatement thisClientPropertiesAssignmentStatement =
         ExprStatement.withExpr(thisClientPropertiesAssignmentExpr);
 
-    AssignmentExpr thisGlobalPropertiesAssignmentExpr =
+    // if (this.clientProperties.getCredentials().hasKey()) {
+    //    this.credentialsProvider = new DefaultCredentialsProvider(this.clientProperties);
+    //  } else {
+    //    this.credentialsProvider = credentialsProvider;
+    //  }
+    VariableExpr thisClientProperties =
+        clientPropertiesVarExpr.toBuilder().setExprReferenceExpr(thisExpr).build();
+    AssignmentExpr.Builder thisCredentialsProviderAssignmentExprBuilder =
         AssignmentExpr.builder()
             .setVariableExpr(
-                VariableExpr.withVariable(globalPropertiesVar)
-                    .toBuilder()
-                    .setExprReferenceExpr(thisExpr)
+                credentialsProviderVarExpr.toBuilder().setExprReferenceExpr(thisExpr).build());
+    ExprStatement thisCredentialsProviderToGlobalAssignmentStatement =
+        ExprStatement.withExpr(
+            thisCredentialsProviderAssignmentExprBuilder
+                .setValueExpr(credentialsProviderVarExpr)
+                .build());
+
+    CastExpr newCredentialsProviderExpr =
+        CastExpr.builder()
+            .setExpr(
+                NewObjectExpr.builder()
+                    .setType(STATIC_TYPES.get("DefaultCredentialsProvider"))
+                    .setArguments(thisClientProperties)
                     .build())
-            .setValueExpr(globalPropertiesVarExpr)
+            .setType(STATIC_TYPES.get("CredentialsProvider"))
             .build();
-    ExprStatement thisGlobalPropertiesAssignmentStatement =
-        ExprStatement.withExpr(thisGlobalPropertiesAssignmentExpr);
+    ExprStatement thisCredentialsProviderAssignmentExprNewStatement =
+        ExprStatement.withExpr(
+            thisCredentialsProviderAssignmentExprBuilder
+                .setValueExpr(newCredentialsProviderExpr)
+                .build());
+
+    Expr clientPropertiesGetCredentials =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(thisClientProperties)
+            .setMethodName("getCredentials")
+            .setReturnType(STATIC_TYPES.get("Credentials"))
+            .build();
+    Expr clientPropertiesCredentialsHasKey =
+        MethodInvocationExpr.builder()
+            .setExprReferenceExpr(clientPropertiesGetCredentials)
+            .setMethodName("hasKey")
+            .setReturnType(TypeNode.BOOLEAN)
+            .build();
+
+    Statement logClientCredentials =
+        LoggerUtils.createLoggerStatement(
+            ValueExpr.withValue(
+                StringObjectValue.withValue(
+                    "Using credentials from " + service.name() + "-specific configuration")),
+            types);
+    IfStatement thisCredentialsProviderAssignmentStatement =
+        createIfStatement(
+            clientPropertiesCredentialsHasKey,
+            Arrays.asList(logClientCredentials, thisCredentialsProviderAssignmentExprNewStatement),
+            Arrays.asList(thisCredentialsProviderToGlobalAssignmentStatement));
 
     return MethodDefinition.constructorBuilder()
         .setScope(ScopeNode.PROTECTED)
@@ -229,10 +247,11 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         .setArguments(
             Arrays.asList(
                 clientPropertiesVarExpr.toBuilder().setIsDecl(true).build(),
-                globalPropertiesVarExpr.toBuilder().setIsDecl(true).build()))
+                credentialsProviderVarExpr.toBuilder().setIsDecl(true).build()))
         .setBody(
             Arrays.asList(
-                thisClientPropertiesAssignmentStatement, thisGlobalPropertiesAssignmentStatement))
+                thisClientPropertiesAssignmentStatement,
+                thisCredentialsProviderAssignmentStatement))
         .build();
   }
 
@@ -287,27 +306,10 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         AnnotationNode.builder()
             .setType(STATIC_TYPES.get("EnableConfigurationProperties"))
             .setDescription(
-                ArrayExpr.builder()
-                    .setType(TypeNode.createArrayTypeOf(TypeNode.CLASS_OBJECT))
-                    .addExpr(
-                        VariableExpr.builder()
-                            .setVariable(
-                                Variable.builder()
-                                    .setType(TypeNode.CLASS_OBJECT)
-                                    .setName("class")
-                                    .build())
-                            .setStaticReferenceType(
-                                types.get(Utils.getServicePropertiesClassName(service)))
-                            .build())
-                    .addExpr(
-                        VariableExpr.builder()
-                            .setVariable(
-                                Variable.builder()
-                                    .setType(TypeNode.CLASS_OBJECT)
-                                    .setName("class")
-                                    .build())
-                            .setStaticReferenceType(types.get("GlobalProperties"))
-                            .build())
+                VariableExpr.builder()
+                    .setVariable(
+                        Variable.builder().setType(TypeNode.CLASS_OBJECT).setName("class").build())
+                    .setStaticReferenceType(types.get(Utils.getServicePropertiesClassName(service)))
                     .build())
             .build();
 
@@ -316,107 +318,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         conditionalOnClassNode,
         conditionalOnPropertyNode,
         enableConfigurationPropertiesNode);
-  }
-
-  private static MethodDefinition createCredentialsProviderBeanMethod(
-      Service service,
-      String className,
-      String methodName,
-      Map<String, TypeNode> types,
-      Expr thisExpr) {
-    // @Bean
-    // @ConditionalOnMissingBean(name = "[serviceName]ServiceCredentials")
-    // public CredentialsProvider languageServiceCredentials() throws IOException {
-    //    if (this.clientProperties.getCredentials().hasKey()) {
-    //      return new DefaultCredentialsProvider(this.clientProperties);
-    //    }
-    //    return new DefaultCredentialsProvider(this.globalProperties);
-    // }
-    List<Statement> bodyStatements = new ArrayList<>();
-    Variable globalPropertiesVar =
-        Variable.builder()
-            .setName("globalProperties")
-            .setType(types.get("GlobalProperties"))
-            .build();
-    Variable clientPropertiesVar =
-        Variable.builder()
-            .setName("clientProperties")
-            .setType(types.get(Utils.getServicePropertiesClassName(service)))
-            .build();
-
-    VariableExpr thisClientProperties =
-        VariableExpr.withVariable(clientPropertiesVar)
-            .toBuilder()
-            .setExprReferenceExpr(thisExpr)
-            .build();
-    VariableExpr thisGlobalProperties =
-        VariableExpr.withVariable(globalPropertiesVar)
-            .toBuilder()
-            .setExprReferenceExpr(thisExpr)
-            .build();
-    CastExpr clientCastExpr =
-        CastExpr.builder()
-            .setExpr(
-                NewObjectExpr.builder()
-                    .setType(STATIC_TYPES.get("DefaultCredentialsProvider"))
-                    .setArguments(thisClientProperties)
-                    .build())
-            .setType(STATIC_TYPES.get("CredentialsProvider"))
-            .build();
-    CastExpr globalCredentialsCastExpr =
-        CastExpr.builder()
-            .setExpr(
-                NewObjectExpr.builder()
-                    .setType(STATIC_TYPES.get("DefaultCredentialsProvider"))
-                    .setArguments(thisGlobalProperties)
-                    .build())
-            .setType(STATIC_TYPES.get("CredentialsProvider"))
-            .build();
-    ExprStatement clientCredentialsReturnExpr =
-        ExprStatement.withExpr(ReturnExpr.withExpr(clientCastExpr));
-    Expr clientPropertiesGetCredentials =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(thisClientProperties)
-            .setMethodName("getCredentials")
-            .setReturnType(STATIC_TYPES.get("Credentials"))
-            .build();
-    Expr clientPropertiesCredentialsHasKey =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(clientPropertiesGetCredentials)
-            .setMethodName("hasKey")
-            .setReturnType(TypeNode.BOOLEAN)
-            .build();
-    Statement logClientCredentials =
-        LoggerUtils.createLoggerStatement(
-            ValueExpr.withValue(
-                StringObjectValue.withValue(
-                    "Using credentials from " + service.name() + "-specific configuration")),
-            types);
-    IfStatement clientCredentialsIfStatement =
-        createIfStatement(
-            clientPropertiesCredentialsHasKey,
-            Arrays.asList(logClientCredentials, clientCredentialsReturnExpr),
-            null);
-    bodyStatements.add(clientCredentialsIfStatement);
-    bodyStatements.add(
-        LoggerUtils.createLoggerStatement(
-            ValueExpr.withValue(
-                StringObjectValue.withValue("Using credentials from global configuration")),
-            types));
-    return MethodDefinition.builder()
-        .setName(methodName)
-        .setHeaderCommentStatements(
-            SpringAutoconfigCommentComposer.createCredentialsProviderBeanComment())
-        .setScope(ScopeNode.PUBLIC)
-        .setReturnType(STATIC_TYPES.get("CredentialsProvider"))
-        .setAnnotations(
-            Arrays.asList(
-                AnnotationNode.withType(STATIC_TYPES.get("Bean")),
-                AnnotationNode.withType(STATIC_TYPES.get("ConditionalOnMissingBean"))))
-        .setThrowsExceptions(Arrays.asList(TypeNode.withExceptionClazz(IOException.class)))
-        .setBody(bodyStatements)
-        .setReturnExpr(globalCredentialsCastExpr)
-        .build();
   }
 
   private static MethodDefinition createTransportChannelProviderBeanMethod(
@@ -532,10 +433,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
   private static MethodDefinition createClientBeanMethod(
       Service service,
-      String className,
-      String credentialsProviderName,
       String transportChannelProviderName,
-      String clientName,
       Map<String, TypeNode> types,
       GapicServiceConfig gapicServiceConfig,
       Expr thisExpr,
@@ -574,11 +472,20 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .setMethodName("newBuilder")
             .build();
 
+    VariableExpr thisCredentialsProvider =
+        VariableExpr.withVariable(
+                Variable.builder()
+                    .setName("credentialsProvider")
+                    .setType(STATIC_TYPES.get("CredentialsProvider"))
+                    .build())
+            .toBuilder()
+            .setExprReferenceExpr(thisExpr)
+            .build();
     settingsBuilderExpr =
         MethodInvocationExpr.builder()
             .setExprReferenceExpr(settingsBuilderExpr)
             .setMethodName("setCredentialsProvider")
-            .setArguments(credentialsProviderVariableExpr)
+            .setArguments(thisCredentialsProvider)
             .build();
     //           .setTransportChannelProvider(defaultTransportChannelProvider)
     settingsBuilderExpr =
@@ -866,16 +773,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .build();
     List<VariableExpr> argumentsVariableExprs =
         Arrays.asList(
-            credentialsProviderVariableExpr
-                .toBuilder()
-                .setIsDecl(true)
-                .setAnnotations(
-                    Arrays.asList(
-                        AnnotationNode.builder()
-                            .setType(STATIC_TYPES.get("Qualifier"))
-                            .setDescription(credentialsProviderName)
-                            .build()))
-                .build(),
             transportChannelProviderVariableExpr
                 .toBuilder()
                 .setIsDecl(true)

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -43,6 +43,7 @@ import com.google.api.generator.gapic.model.GapicServiceConfig;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.model.Transport;
 import com.google.api.generator.spring.composer.comment.SpringPropertiesCommentComposer;
+import com.google.api.generator.spring.utils.ComposerUtils;
 import com.google.api.generator.spring.utils.Utils;
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.CredentialsSupplier;
@@ -106,35 +107,6 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     // return null;
   }
 
-  private static ExprStatement createMemberVarStatement(
-      String varName,
-      TypeNode varType,
-      boolean isFinal,
-      Expr defaultVal,
-      List<AnnotationNode> annotationNodes) {
-    Variable memberVar = Variable.builder().setName(varName).setType(varType).build();
-    VariableExpr memberVarExpr =
-        VariableExpr.builder()
-            .setVariable(memberVar)
-            .setScope(ScopeNode.PRIVATE)
-            .setAnnotations(annotationNodes == null ? Collections.emptyList() : annotationNodes)
-            .setIsDecl(true)
-            .setIsFinal(isFinal)
-            .build();
-
-    if (defaultVal == null) {
-      return ExprStatement.withExpr(memberVarExpr);
-    }
-    AssignmentExpr assignmentExpr =
-        AssignmentExpr.builder()
-            .setVariableExpr(memberVarExpr.toBuilder().setIsDecl(true).build())
-            .setValueExpr(defaultVal)
-            .build();
-    ExprStatement memberVarStatement = ExprStatement.withExpr(assignmentExpr);
-
-    return memberVarStatement;
-  }
-
   private static List<Statement> createMemberVariables(
       Service service,
       String packageName,
@@ -161,7 +133,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     List<AnnotationNode> credentialsAnnotations =
         Arrays.asList(AnnotationNode.withType(STATIC_TYPES.get("NestedConfigurationProperty")));
     ExprStatement credentialsStatement =
-        createMemberVarStatement(
+        ComposerUtils.createMemberVarStatement(
             "credentials",
             STATIC_TYPES.get("Credentials"),
             true,
@@ -170,15 +142,17 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     statements.add(credentialsStatement);
     //   private String quotaProjectId;
     ExprStatement quotaProjectIdVarStatement =
-        createMemberVarStatement("quotaProjectId", TypeNode.STRING, false, null, null);
+        ComposerUtils.createMemberVarStatement(
+            "quotaProjectId", TypeNode.STRING, false, null, null);
     statements.add(quotaProjectIdVarStatement);
     //   private Integer executorThreadCount;
     ExprStatement executorThreadCountVarStatement =
-        createMemberVarStatement("executorThreadCount", TypeNode.INT_OBJECT, false, null, null);
+        ComposerUtils.createMemberVarStatement(
+            "executorThreadCount", TypeNode.INT_OBJECT, false, null, null);
     statements.add(executorThreadCountVarStatement);
     if (hasRestOption) {
       ExprStatement useRestVarStatement =
-          createMemberVarStatement(
+          ComposerUtils.createMemberVarStatement(
               "useRest",
               TypeNode.BOOLEAN,
               false,
@@ -207,7 +181,8 @@ public class SpringPropertiesClassComposer implements ClassComposer {
               }
               String propertyName = Joiner.on("").join(methodAndPropertyName);
               ExprStatement retrySettingsStatement =
-                  createMemberVarStatement(propertyName, propertyType, false, null, null);
+                  ComposerUtils.createMemberVarStatement(
+                      propertyName, propertyType, false, null, null);
               getterAndSetter.add(retrySettingsStatement);
               return getterAndSetter;
             },

--- a/src/main/java/com/google/api/generator/spring/utils/ComposerUtils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/ComposerUtils.java
@@ -51,8 +51,7 @@ public class ComposerUtils {
             .setVariableExpr(memberVarExpr.toBuilder().setIsDecl(true).build())
             .setValueExpr(defaultVal)
             .build();
-    ExprStatement memberVarStatement = ExprStatement.withExpr(assignmentExpr);
 
-    return memberVarStatement;
+    return ExprStatement.withExpr(assignmentExpr);
   }
 }

--- a/src/main/java/com/google/api/generator/spring/utils/ComposerUtils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/ComposerUtils.java
@@ -19,55 +19,13 @@ import com.google.api.generator.engine.ast.AssignmentExpr;
 import com.google.api.generator.engine.ast.Expr;
 import com.google.api.generator.engine.ast.ExprStatement;
 import com.google.api.generator.engine.ast.ScopeNode;
-import com.google.api.generator.engine.ast.Statement;
 import com.google.api.generator.engine.ast.TypeNode;
-import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-public class GlobalPropertiesUtils {
-  public static final String GLOBAL_PROPERTIES_CLAZZ_NAME = "GlobalProperties";
-  public static final String GLOBAL_PROPERTIES_PAKKAGE_NAME = "com.google.cloud.spring.global";
-
-  public static TypeNode getGlobalPropertiesType() {
-    TypeNode loggerType =
-        TypeNode.withReference(
-            VaporReference.builder()
-                .setName(GLOBAL_PROPERTIES_CLAZZ_NAME)
-                .setPakkage(GLOBAL_PROPERTIES_PAKKAGE_NAME)
-                .build());
-    return loggerType;
-  }
-
-  public static Statement getGlobalPropertiesDeclaration(Map<String, TypeNode> types) {
-    Variable globalPropertiesVar =
-        Variable.builder()
-            .setName("globalProperties")
-            .setType(types.get("GlobalProperties"))
-            .build();
-    return ExprStatement.withExpr(
-        VariableExpr.builder()
-            .setVariable(globalPropertiesVar)
-            .setScope(ScopeNode.PRIVATE)
-            .setIsStatic(false)
-            .setIsFinal(true)
-            .setIsDecl(true)
-            .build());
-  }
-
-  public static Statement getPrivateVarDeclaration(String varName, TypeNode type, boolean isFinal) {
-    Variable variable = Variable.builder().setName(varName).setType(type).build();
-    return ExprStatement.withExpr(
-        VariableExpr.builder()
-            .setVariable(variable)
-            .setScope(ScopeNode.PRIVATE)
-            .setIsFinal(true)
-            .setIsDecl(true)
-            .build());
-  }
+public class ComposerUtils {
 
   public static ExprStatement createMemberVarStatement(
       String varName,

--- a/src/main/java/com/google/api/generator/spring/utils/GlobalPropertiesUtils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/GlobalPropertiesUtils.java
@@ -14,6 +14,9 @@
 
 package com.google.api.generator.spring.utils;
 
+import com.google.api.generator.engine.ast.AnnotationNode;
+import com.google.api.generator.engine.ast.AssignmentExpr;
+import com.google.api.generator.engine.ast.Expr;
 import com.google.api.generator.engine.ast.ExprStatement;
 import com.google.api.generator.engine.ast.ScopeNode;
 import com.google.api.generator.engine.ast.Statement;
@@ -21,6 +24,8 @@ import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class GlobalPropertiesUtils {
@@ -51,5 +56,45 @@ public class GlobalPropertiesUtils {
             .setIsFinal(true)
             .setIsDecl(true)
             .build());
+  }
+
+  public static Statement getPrivateVarDeclaration(String varName, TypeNode type, boolean isFinal) {
+    Variable variable = Variable.builder().setName(varName).setType(type).build();
+    return ExprStatement.withExpr(
+        VariableExpr.builder()
+            .setVariable(variable)
+            .setScope(ScopeNode.PRIVATE)
+            .setIsFinal(true)
+            .setIsDecl(true)
+            .build());
+  }
+
+  public static ExprStatement createMemberVarStatement(
+      String varName,
+      TypeNode varType,
+      boolean isFinal,
+      Expr defaultVal,
+      List<AnnotationNode> annotationNodes) {
+    Variable memberVar = Variable.builder().setName(varName).setType(varType).build();
+    VariableExpr memberVarExpr =
+        VariableExpr.builder()
+            .setVariable(memberVar)
+            .setScope(ScopeNode.PRIVATE)
+            .setAnnotations(annotationNodes == null ? Collections.emptyList() : annotationNodes)
+            .setIsDecl(true)
+            .setIsFinal(isFinal)
+            .build();
+
+    if (defaultVal == null) {
+      return ExprStatement.withExpr(memberVarExpr);
+    }
+    AssignmentExpr assignmentExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(memberVarExpr.toBuilder().setIsDecl(true).build())
+            .setValueExpr(defaultVal)
+            .build();
+    ExprStatement memberVarStatement = ExprStatement.withExpr(assignmentExpr);
+
+    return memberVarStatement;
   }
 }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
-import com.google.cloud.spring.global.GlobalProperties;
 import com.google.showcase.v1beta1.EchoClient;
 import com.google.showcase.v1beta1.EchoSettings;
 import java.io.IOException;
@@ -62,35 +61,24 @@ import org.threeten.bp.Duration;
 @ConditionalOnProperty(
     value = "com.google.showcase.v1beta1.spring.auto.echo.enabled",
     matchIfMissing = true)
-@EnableConfigurationProperties({EchoSpringProperties.class, GlobalProperties.class})
+@EnableConfigurationProperties(EchoSpringProperties.class)
 public class EchoSpringAutoConfiguration {
   private final EchoSpringProperties clientProperties;
-  private final GlobalProperties globalProperties;
+  private final CredentialsProvider credentialsProvider;
   private static final Log LOGGER = LogFactory.getLog(EchoSpringAutoConfiguration.class);
 
   protected EchoSpringAutoConfiguration(
-      EchoSpringProperties clientProperties, GlobalProperties globalProperties) {
+      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider) {
     this.clientProperties = clientProperties;
-    this.globalProperties = globalProperties;
-  }
-
-  /**
-   * Obtains the default credentials provider. The used key will be obtained from Spring Boot
-   * configuration data files.
-   */
-  @Bean
-  @ConditionalOnMissingBean
-  public CredentialsProvider echoCredentials() throws IOException {
     if (this.clientProperties.getCredentials().hasKey()) {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Using credentials from Echo-specific configuration");
       }
-      return ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
+      this.credentialsProvider =
+          ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
+    } else {
+      this.credentialsProvider = credentialsProvider;
     }
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Using credentials from global configuration");
-    }
-    return ((CredentialsProvider) new DefaultCredentialsProvider(this.globalProperties));
   }
 
   /**
@@ -116,13 +104,12 @@ public class EchoSpringAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(
-      @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
     EchoSettings.Builder clientSettingsBuilder =
         EchoSettings.newBuilder()
-            .setCredentialsProvider(credentialsProvider)
+            .setCredentialsProvider(this.credentialsProvider)
             .setTransportChannelProvider(defaultTransportChannelProvider)
             .setHeaderProvider(this.userAgentHeaderProvider());
     if (this.clientProperties.getQuotaProjectId() != null) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -68,7 +68,8 @@ public class EchoSpringAutoConfiguration {
   private static final Log LOGGER = LogFactory.getLog(EchoSpringAutoConfiguration.class);
 
   protected EchoSpringAutoConfiguration(
-      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider) {
+      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider)
+      throws IOException {
     this.clientProperties = clientProperties;
     if (this.clientProperties.getCredentials().hasKey()) {
       if (LOGGER.isTraceEnabled()) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -7,7 +7,6 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
-import com.google.cloud.spring.global.GlobalProperties;
 import com.google.showcase.v1beta1.EchoClient;
 import com.google.showcase.v1beta1.EchoSettings;
 import java.io.IOException;
@@ -42,35 +41,24 @@ import org.threeten.bp.Duration;
 @ConditionalOnProperty(
     value = "com.google.showcase.v1beta1.spring.auto.echo.enabled",
     matchIfMissing = true)
-@EnableConfigurationProperties({EchoSpringProperties.class, GlobalProperties.class})
+@EnableConfigurationProperties(EchoSpringProperties.class)
 public class EchoSpringAutoConfiguration {
   private final EchoSpringProperties clientProperties;
-  private final GlobalProperties globalProperties;
+  private final CredentialsProvider credentialsProvider;
   private static final Log LOGGER = LogFactory.getLog(EchoSpringAutoConfiguration.class);
 
   protected EchoSpringAutoConfiguration(
-      EchoSpringProperties clientProperties, GlobalProperties globalProperties) {
+      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider) {
     this.clientProperties = clientProperties;
-    this.globalProperties = globalProperties;
-  }
-
-  /**
-   * Obtains the default credentials provider. The used key will be obtained from Spring Boot
-   * configuration data files.
-   */
-  @Bean
-  @ConditionalOnMissingBean
-  public CredentialsProvider echoCredentials() throws IOException {
     if (this.clientProperties.getCredentials().hasKey()) {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Using credentials from Echo-specific configuration");
       }
-      return ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
+      this.credentialsProvider =
+          ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
+    } else {
+      this.credentialsProvider = credentialsProvider;
     }
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Using credentials from global configuration");
-    }
-    return ((CredentialsProvider) new DefaultCredentialsProvider(this.globalProperties));
   }
 
   /**
@@ -96,13 +84,12 @@ public class EchoSpringAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(
-      @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
     EchoSettings.Builder clientSettingsBuilder =
         EchoSettings.newBuilder()
-            .setCredentialsProvider(credentialsProvider)
+            .setCredentialsProvider(this.credentialsProvider)
             .setTransportChannelProvider(defaultTransportChannelProvider)
             .setHeaderProvider(this.userAgentHeaderProvider());
     if (this.clientProperties.getQuotaProjectId() != null) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -48,7 +48,8 @@ public class EchoSpringAutoConfiguration {
   private static final Log LOGGER = LogFactory.getLog(EchoSpringAutoConfiguration.class);
 
   protected EchoSpringAutoConfiguration(
-      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider) {
+      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider)
+      throws IOException {
     this.clientProperties = clientProperties;
     if (this.clientProperties.getCredentials().hasKey()) {
       if (LOGGER.isTraceEnabled()) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -49,7 +49,8 @@ public class EchoSpringAutoConfiguration {
   private static final Log LOGGER = LogFactory.getLog(EchoSpringAutoConfiguration.class);
 
   protected EchoSpringAutoConfiguration(
-      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider) {
+      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider)
+      throws IOException {
     this.clientProperties = clientProperties;
     if (this.clientProperties.getCredentials().hasKey()) {
       if (LOGGER.isTraceEnabled()) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -8,7 +8,6 @@ import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
-import com.google.cloud.spring.global.GlobalProperties;
 import com.google.showcase.v1beta1.EchoClient;
 import com.google.showcase.v1beta1.EchoSettings;
 import java.io.IOException;
@@ -43,35 +42,24 @@ import org.threeten.bp.Duration;
 @ConditionalOnProperty(
     value = "com.google.showcase.v1beta1.spring.auto.echo.enabled",
     matchIfMissing = true)
-@EnableConfigurationProperties({EchoSpringProperties.class, GlobalProperties.class})
+@EnableConfigurationProperties(EchoSpringProperties.class)
 public class EchoSpringAutoConfiguration {
   private final EchoSpringProperties clientProperties;
-  private final GlobalProperties globalProperties;
+  private final CredentialsProvider credentialsProvider;
   private static final Log LOGGER = LogFactory.getLog(EchoSpringAutoConfiguration.class);
 
   protected EchoSpringAutoConfiguration(
-      EchoSpringProperties clientProperties, GlobalProperties globalProperties) {
+      EchoSpringProperties clientProperties, CredentialsProvider credentialsProvider) {
     this.clientProperties = clientProperties;
-    this.globalProperties = globalProperties;
-  }
-
-  /**
-   * Obtains the default credentials provider. The used key will be obtained from Spring Boot
-   * configuration data files.
-   */
-  @Bean
-  @ConditionalOnMissingBean
-  public CredentialsProvider echoCredentials() throws IOException {
     if (this.clientProperties.getCredentials().hasKey()) {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Using credentials from Echo-specific configuration");
       }
-      return ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
+      this.credentialsProvider =
+          ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
+    } else {
+      this.credentialsProvider = credentialsProvider;
     }
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Using credentials from global configuration");
-    }
-    return ((CredentialsProvider) new DefaultCredentialsProvider(this.globalProperties));
   }
 
   /**
@@ -97,13 +85,12 @@ public class EchoSpringAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(
-      @Qualifier("echoCredentials") CredentialsProvider credentialsProvider,
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
     EchoSettings.Builder clientSettingsBuilder =
         EchoSettings.newBuilder()
-            .setCredentialsProvider(credentialsProvider)
+            .setCredentialsProvider(this.credentialsProvider)
             .setTransportChannelProvider(defaultTransportChannelProvider)
             .setHeaderProvider(this.userAgentHeaderProvider());
     if (this.clientProperties.getQuotaProjectId() != null) {

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -27,7 +27,7 @@
 
   <dependency>
     <groupId>com.google.cloud</groupId>
-    <artifactId>spring-cloud-gcp-core</artifactId>
+    <artifactId>spring-cloud-gcp-autoconfigure</artifactId>
   </dependency>
 </dependencies>
 


### PR DESCRIPTION
As discussed off-line, instead of depending on a new `global-properties` module, use `CredentialsProvider` bean from `spring-cloud-gcp-autoconfigure` instead.
- Replace dependency from `core` to `autoconfigure` module.
- Revert #1071 and implement changes shown in [poc](https://github.com/zhumin8/language_poc1/pull/7)
- Minor code cleanups and util method extracted from `SpringPropertiesClassComposer.java`. 

Note: #1071 and https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1308 will be obsolete after this change.
Also, conflicts needs to be resolved between this pr and #1110 depending on merging order.