### PR TITLE
fix(spring): pom writer changes to adapt to repo structure changes in hosting repo

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -208,7 +208,6 @@ public class SpringWriter {
     String clientLibraryShortName = Utils.getLibName(context);
     String clientLibraryGroupId = "{{client-library-group-id}}";
     String clientLibraryName = "{{client-library-artifact-id}}";
-    String clientLibraryVersion = "{{client-library-version}}";
 
     String springStarterArtifactId = clientLibraryName + "-spring-starter";
     String springStarterName = "Spring Boot Starter - " + clientLibraryShortName;
@@ -224,10 +223,12 @@ public class SpringWriter {
                 + "\n"
                 + "  <parent>\n"
                 + "    <groupId>com.google.cloud</groupId>\n"
-                + "    <artifactId>generated-parent</artifactId>\n"
+                + "    <artifactId>spring-cloud-gcp-starters</artifactId>\n"
                 + "    <version>%s</version>\n"
+                + "    <relativePath>../../spring-cloud-gcp-starters/pom.xml</relativePath>\n"
                 + "  </parent>\n"
                 + "  <artifactId>%s</artifactId>\n"
+                + "  <version>${project.parent.version}-preview</version>\n"
                 + "  <name>%s</name>\n"
                 + "  <description>Spring Boot Starter with AutoConfiguration for %s</description>\n"
                 + "\n"
@@ -236,7 +237,6 @@ public class SpringWriter {
                 + "    <dependency>\n"
                 + "      <groupId>%s</groupId>\n"
                 + "      <artifactId>%s</artifactId>\n"
-                + "      <version>%s</version>\n"
                 + "    </dependency>\n"
                 + "\n"
                 + "    <dependency>\n"
@@ -256,8 +256,7 @@ public class SpringWriter {
             springStarterName,
             clientLibraryShortName,
             clientLibraryGroupId,
-            clientLibraryName,
-            clientLibraryVersion));
+            clientLibraryName));
 
     return sb.toString();
   }

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -5,10 +5,12 @@
 
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>generated-parent</artifactId>
+    <artifactId>spring-cloud-gcp-starters</artifactId>
     <version>{{parent-version}}</version>
+    <relativePath>../../spring-cloud-gcp-starters/pom.xml</relativePath>
   </parent>
   <artifactId>{{client-library-artifact-id}}-spring-starter</artifactId>
+  <version>${project.parent.version}-preview</version>
   <name>Spring Boot Starter - localhost:7469</name>
   <description>Spring Boot Starter with AutoConfiguration for localhost:7469</description>
 
@@ -17,7 +19,6 @@
     <dependency>
       <groupId>{{client-library-group-id}}</groupId>
       <artifactId>{{client-library-artifact-id}}</artifactId>
-      <version>{{client-library-version}}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This is part 2 of implementation for repo structural changes in [PoC](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1383).
Changes in Pom string:
- changed parent to `spring-cloud-gcp-starters` and version with "-preview" suffix
- removed client library version (should inherit from Libraries BOM).

Corresponding changes in spring-cloud-gcp: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1394