### PR TITLE
build: use bazelisk avoid unexpected Bazel version upgrades

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,2 @@
+# See https://github.com/bazelbuild/bazelisk
+USE_BAZEL_VERSION=4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,19 +110,6 @@ jobs:
         ./gradlew clean build publishToMavenLocal sourcesJar allJars
         popd
 
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
-        with:
-          java-version: 8
-      - run: java -version
-
-      - name: Generate Code Coverage Report
-        # Run only test targets, and not golden_update targets.
-        run: bazelisk coverage //:units --combined_report=lcov
-
   license-header:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,11 @@ jobs:
           echo "and it will start over with a clean cache."
           echo "The old one will disappear after 7 days."
 
-      - name: Unit Tests
-        run: bazel --batch test //:units --noshow_progress --test_output=errors
-
-      - name: Integration Tests
-        run: bazel --batch test //test/integration/...
+#      - name: Unit Tests
+#        run: bazel --batch test //:units --noshow_progress --test_output=errors
+#
+#      - name: Integration Tests
+#        run: bazel --batch test //test/integration/...
 
       - name: Gradle Build Generated Storage Client Library
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis:20220711
     strategy:
+      fail-fast: false
       matrix:
         java: [ 8, 11 ]
     steps:
@@ -18,54 +19,31 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - run: java -version
+      - run: bazel version
+      - name: Bazel File Cache Setup
+        id: cache-bazel
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
 
-#      - name: Bazel File Cache Setup
-#        id: cache-bazel
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.cache/bazel
-#          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
-#
-#      - name: Bazel Cache Not Found
-#        if: steps.cache-bazel.outputs.cache-hit != 'true'
-#        run: |
-#          echo "No cache found."
-#      - name: Bazel Cache Found
-#        if: steps.cache-bazel.outputs.cache-hit == 'true'
-#        run: |
-#          echo -n "Cache found. Cache size: "
-#          du -sh ~/.cache/bazel
-#          echo "If the cache seems broken, update the CACHE_VERSION secret in"
-#          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
-#          echo "(use any random string, any GUID will work)"
-#          echo "and it will start over with a clean cache."
-#          echo "The old one will disappear after 7 days."
-#
-#      - name: Unit Tests
-#        run: bazel --batch test //:units --noshow_progress --test_output=errors
-#
-#      - name: Integration Tests
-#        run: bazel --batch test //test/integration/...
-
-      - name: Gradle Build Generated Storage Client Library
+      - name: Bazel Cache Not Found
+        if: steps.cache-bazel.outputs.cache-hit != 'true'
         run: |
-          echo "Building Storage lib from generated source..."
-          mkdir /tmp/java-storage
-          bazel --batch build @com_google_googleapis//google/storage/v2:google-cloud-storage-v2-java
-          tar zxvf bazel-bin/external/com_google_googleapis/google/storage/v2/google-cloud-storage-v2-java.tar.gz -C /tmp/java-storage
-          pushd /tmp/java-storage/google-cloud-storage-v2-java
-          ./gradlew clean build publishToMavenLocal sourcesJar allJars
-          popd
-
-      - name: Gradle Build Generated Compute Client Library
+          echo "No cache found."
+      - name: Bazel Cache Found
+        if: steps.cache-bazel.outputs.cache-hit == 'true'
         run: |
-          echo "Building Compute lib from generated source..."
-          mkdir /tmp/java-compute
-          bazel --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
-          tar zxvf bazel-bin/external/com_google_googleapis/google/cloud/compute/v1small/google-cloud-compute-small-v1-java.tar.gz -C /tmp/java-compute
-          pushd /tmp/java-compute/google-cloud-compute-small-v1-java
-          ./gradlew clean build publishToMavenLocal sourcesJar allJars
-          popd
+          echo -n "Cache found. Cache size: "
+          du -sh ~/.cache/bazel
+          echo "If the cache seems broken, update the CACHE_VERSION secret in"
+          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
+          echo "(use any random string, any GUID will work)"
+          echo "and it will start over with a clean cache."
+          echo "The old one will disappear after 7 days."
+
+      - name: Integration Tests
+        run: bazel --batch test //test/integration/...
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
@@ -76,6 +54,63 @@ jobs:
 
       - name: Java Linter
         run: bazel --batch run //:google_java_format_verification
+
+  generate-client-libraries:
+    runs-on: ubuntu-latest
+    container: gcr.io/gapic-images/googleapis:20220711
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8, 11 ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: temurin
+    - run: java -version
+    - run: bazel version
+    - name: Bazel File Cache Setup
+      id: cache-bazel
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
+
+    - name: Bazel Cache Not Found
+      if: steps.cache-bazel.outputs.cache-hit != 'true'
+      run: |
+        echo "No cache found."
+    - name: Bazel Cache Found
+      if: steps.cache-bazel.outputs.cache-hit == 'true'
+      run: |
+        echo -n "Cache found. Cache size: "
+        du -sh ~/.cache/bazel
+        echo "If the cache seems broken, update the CACHE_VERSION secret in"
+        echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
+        echo "(use any random string, any GUID will work)"
+        echo "and it will start over with a clean cache."
+        echo "The old one will disappear after 7 days."
+
+    - name: Gradle Build Generated Storage Client Library
+      run: |
+        echo "Building Storage lib from generated source..."
+        mkdir /tmp/java-storage
+        bazel --batch build @com_google_googleapis//google/storage/v2:google-cloud-storage-v2-java
+        tar zxvf bazel-bin/external/com_google_googleapis/google/storage/v2/google-cloud-storage-v2-java.tar.gz -C /tmp/java-storage
+        pushd /tmp/java-storage/google-cloud-storage-v2-java
+        ./gradlew clean build publishToMavenLocal sourcesJar allJars
+        popd
+
+    - name: Gradle Build Generated Compute Client Library
+      run: |
+        echo "Building Compute lib from generated source..."
+        mkdir /tmp/java-compute
+        bazel --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
+        tar zxvf bazel-bin/external/com_google_googleapis/google/cloud/compute/v1small/google-cloud-compute-small-v1-java.tar.gz -C /tmp/java-compute
+        pushd /tmp/java-compute/google-cloud-compute-small-v1-java
+        ./gradlew clean build publishToMavenLocal sourcesJar allJars
+        popd
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,6 @@ jobs:
 
   generate-client-libraries:
     runs-on: ubuntu-latest
-    container: gcr.io/gapic-images/googleapis:20220711
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,9 +51,6 @@ jobs:
           path: ~/.cache/bazel/*/*/*/gapic_generator_java/bazel-out/*/testlogs/*
           retention-days: 5
 
-      - name: Java Linter
-        run: bazelisk --batch run //:google_java_format_verification
-
   generate-client-libraries:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: ci
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    container: gcr.io/gapic-images/googleapis:20220711
     strategy:
       matrix:
         java: [ 8, 11 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,28 +19,28 @@ jobs:
           distribution: temurin
       - run: java -version
 
-      - name: Bazel File Cache Setup
-        id: cache-bazel
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/bazel
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
-
-      - name: Bazel Cache Not Found
-        if: steps.cache-bazel.outputs.cache-hit != 'true'
-        run: |
-          echo "No cache found."
-      - name: Bazel Cache Found
-        if: steps.cache-bazel.outputs.cache-hit == 'true'
-        run: |
-          echo -n "Cache found. Cache size: "
-          du -sh ~/.cache/bazel
-          echo "If the cache seems broken, update the CACHE_VERSION secret in"
-          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
-          echo "(use any random string, any GUID will work)"
-          echo "and it will start over with a clean cache."
-          echo "The old one will disappear after 7 days."
-
+#      - name: Bazel File Cache Setup
+#        id: cache-bazel
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.cache/bazel
+#          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
+#
+#      - name: Bazel Cache Not Found
+#        if: steps.cache-bazel.outputs.cache-hit != 'true'
+#        run: |
+#          echo "No cache found."
+#      - name: Bazel Cache Found
+#        if: steps.cache-bazel.outputs.cache-hit == 'true'
+#        run: |
+#          echo -n "Cache found. Cache size: "
+#          du -sh ~/.cache/bazel
+#          echo "If the cache seems broken, update the CACHE_VERSION secret in"
+#          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
+#          echo "(use any random string, any GUID will work)"
+#          echo "and it will start over with a clean cache."
+#          echo "The old one will disappear after 7 days."
+#
 #      - name: Unit Tests
 #        run: bazel --batch test //:units --noshow_progress --test_output=errors
 #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,6 @@ name: ci
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Using the same container as googleapis/googleapis repository ensures that
-    # we use the same Bazel version. The ubuntu-latest's Bazel version is
-    # occasionally upgraded automatically without a notice.
-    # https://github.com/googleapis/googleapis/blob/master/.github/workflows/diregapic.yaml#L11
-    container: gcr.io/gapic-images/googleapis:20220711
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +18,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - run: java -version
-      - run: bazel version
+      - run: bazelisk version
       - name: Bazel File Cache Setup
         id: cache-bazel
         uses: actions/cache@v3
@@ -47,7 +42,7 @@ jobs:
           echo "The old one will disappear after 7 days."
 
       - name: Integration Tests
-        run: bazel --batch test //test/integration/...
+        run: bazelisk --batch test //test/integration/...
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
@@ -57,7 +52,7 @@ jobs:
           retention-days: 5
 
       - name: Java Linter
-        run: bazel --batch run //:google_java_format_verification
+        run: bazelisk --batch run //:google_java_format_verification
 
   generate-client-libraries:
     runs-on: ubuntu-latest
@@ -73,7 +68,7 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: temurin
     - run: java -version
-    - run: bazel version
+    - run: bazelisk version
     - name: Bazel File Cache Setup
       id: cache-bazel
       uses: actions/cache@v3
@@ -100,7 +95,7 @@ jobs:
       run: |
         echo "Building Storage lib from generated source..."
         mkdir /tmp/java-storage
-        bazel --batch build @com_google_googleapis//google/storage/v2:google-cloud-storage-v2-java
+        bazelisk --batch build @com_google_googleapis//google/storage/v2:google-cloud-storage-v2-java
         tar zxvf bazel-bin/external/com_google_googleapis/google/storage/v2/google-cloud-storage-v2-java.tar.gz -C /tmp/java-storage
         pushd /tmp/java-storage/google-cloud-storage-v2-java
         ./gradlew clean build publishToMavenLocal sourcesJar allJars
@@ -110,7 +105,7 @@ jobs:
       run: |
         echo "Building Compute lib from generated source..."
         mkdir /tmp/java-compute
-        bazel --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
+        bazelisk --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
         tar zxvf bazel-bin/external/com_google_googleapis/google/cloud/compute/v1small/google-cloud-compute-small-v1-java.tar.gz -C /tmp/java-compute
         pushd /tmp/java-compute/google-cloud-compute-small-v1-java
         ./gradlew clean build publishToMavenLocal sourcesJar allJars
@@ -127,7 +122,7 @@ jobs:
 
       - name: Generate Code Coverage Report
         # Run only test targets, and not golden_update targets.
-        run: bazel coverage //:units --combined_report=lcov
+        run: bazelisk coverage //:units --combined_report=lcov
 
   license-header:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ name: ci
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Using the same container as googleapis/googleapis repository ensures that
+    # we use the same Bazel version. The ubuntu-latest's Bazel version is
+    # occasionally upgraded automatically without a notice.
+    # https://github.com/googleapis/googleapis/blob/master/.github/workflows/diregapic.yaml#L11
     container: gcr.io/gapic-images/googleapis:20220711
     strategy:
       fail-fast: false


### PR DESCRIPTION
" ci / build (8) " has been failing in https://github.com/googleapis/gapic-generator-java/pull/1156. Creating an empty pull request to see the build failures.

This PR changes:

- The unit tests in Bazel and "coverage" on it have been removed. @blakeli0 intends to remove it in another PR anyway.
- GitHub Actions to use bazelisk command that keeps the Bazel version stable.
- The client library generation job is separated from the build job.

As per https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md, ubuntu-latest has bazelisk installed.
