### PR TITLE
build(spring): update spring branch with Bazel CI fix from main

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,2 @@
+# See https://github.com/bazelbuild/bazelisk
+USE_BAZEL_VERSION=4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ name: ci
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
         java: [8, 11]
     steps:
@@ -18,7 +18,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - run: java -version
-
+      - run: bazelisk version
       - name: Bazel File Cache Setup
         id: cache-bazel
         uses: actions/cache@v3
@@ -41,31 +41,8 @@ jobs:
           echo "and it will start over with a clean cache."
           echo "The old one will disappear after 7 days."
 
-      - name: Unit Tests
-        run: bazel --batch test //:units --noshow_progress --test_output=errors
-
       - name: Integration Tests
-        run: bazel --batch test //test/integration/...
-
-      - name: Gradle Build Generated Storage Client Library
-        run: |
-          echo "Building Storage lib from generated source..."
-          mkdir /tmp/java-storage
-          bazel --batch build @com_google_googleapis//google/storage/v2:google-cloud-storage-v2-java
-          tar zxvf bazel-bin/external/com_google_googleapis/google/storage/v2/google-cloud-storage-v2-java.tar.gz -C /tmp/java-storage
-          pushd /tmp/java-storage/google-cloud-storage-v2-java
-          ./gradlew clean build publishToMavenLocal sourcesJar allJars
-          popd
-
-      - name: Gradle Build Generated Compute Client Library
-        run: |
-          echo "Building Compute lib from generated source..."
-          mkdir /tmp/java-compute
-          bazel --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
-          tar zxvf bazel-bin/external/com_google_googleapis/google/cloud/compute/v1small/google-cloud-compute-small-v1-java.tar.gz -C /tmp/java-compute
-          pushd /tmp/java-compute/google-cloud-compute-small-v1-java
-          ./gradlew clean build publishToMavenLocal sourcesJar allJars
-          popd
+        run: bazelisk --batch test //test/integration/...
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
@@ -74,21 +51,61 @@ jobs:
           path: ~/.cache/bazel/*/*/*/gapic_generator_java/bazel-out/*/testlogs/*
           retention-days: 5
 
-      - name: Java Linter
-        run: bazel --batch run //:google_java_format_verification
-
-  coverage:
+  generate-client-libraries:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8, 11 ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
-        with:
-          java-version: 8
-      - run: java -version
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: temurin
+    - run: java -version
+    - run: bazelisk version
+    - name: Bazel File Cache Setup
+      id: cache-bazel
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
 
-      - name: Generate Code Coverage Report
-        # Run only test targets, and not golden_update targets.
-        run: bazel coverage //:units --combined_report=lcov
+    - name: Bazel Cache Not Found
+      if: steps.cache-bazel.outputs.cache-hit != 'true'
+      run: |
+        echo "No cache found."
+    - name: Bazel Cache Found
+      if: steps.cache-bazel.outputs.cache-hit == 'true'
+      run: |
+        echo -n "Cache found. Cache size: "
+        du -sh ~/.cache/bazel
+        echo "If the cache seems broken, update the CACHE_VERSION secret in"
+        echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
+        echo "(use any random string, any GUID will work)"
+        echo "and it will start over with a clean cache."
+        echo "The old one will disappear after 7 days."
+
+    - name: Gradle Build Generated Storage Client Library
+      run: |
+        echo "Building Storage lib from generated source..."
+        mkdir /tmp/java-storage
+        bazelisk --batch build @com_google_googleapis//google/storage/v2:google-cloud-storage-v2-java
+        tar zxvf bazel-bin/external/com_google_googleapis/google/storage/v2/google-cloud-storage-v2-java.tar.gz -C /tmp/java-storage
+        pushd /tmp/java-storage/google-cloud-storage-v2-java
+        ./gradlew clean build publishToMavenLocal sourcesJar allJars
+        popd
+
+    - name: Gradle Build Generated Compute Client Library
+      run: |
+        echo "Building Compute lib from generated source..."
+        mkdir /tmp/java-compute
+        bazelisk --batch build @com_google_googleapis//google/cloud/compute/v1small:google-cloud-compute-small-v1-java
+        tar zxvf bazel-bin/external/com_google_googleapis/google/cloud/compute/v1small/google-cloud-compute-small-v1-java.tar.gz -C /tmp/java-compute
+        pushd /tmp/java-compute/google-cloud-compute-small-v1-java
+        ./gradlew clean build publishToMavenLocal sourcesJar allJars
+        popd
 
   license-header:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Brings in #1163 to spring codegen branch to fix Bazel 6.0.0 breaking changes in CI
- Cherry-picked commit instead of updating against main given repo restructure changes