### PR TITLE
ci: fix bazel cache

### DIFF
--- a/.github/workflows/ci-maven.yaml
+++ b/.github/workflows/ci-maven.yaml
@@ -124,7 +124,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
+          key: ${{ runner.os }}-${{ hashFiles('WORKSPACE') }}
+          restore-keys: ${{ runner.os }}-
       - name: Bazel Cache Not Found
         if: steps.cache-bazel.outputs.cache-hit != 'true'
         run: |
@@ -133,12 +134,9 @@ jobs:
         if: steps.cache-bazel.outputs.cache-hit == 'true'
         run: |
           echo -n "Cache found. Cache size: "
-          du -sh ~/.cache/bazel
-          echo "If the cache seems broken, update the CACHE_VERSION secret in"
-          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
-          echo "(use any random string, any GUID will work)"
-          echo "and it will start over with a clean cache."
-          echo "The old one will disappear after 7 days."
+          du -sh ~/.cache/bazel          
+          echo "If the cache seems broken, update the root WORKSPACE file with a trivial change."
+          echo "The old cache will disappear after 7 days."
 
       - name: Install maven modules
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
-
+          key: ${{ runner.os }}-${{ hashFiles('WORKSPACE') }}
+          restore-keys: ${{ runner.os }}-
       - name: Bazel Cache Not Found
         if: steps.cache-bazel.outputs.cache-hit != 'true'
         run: |
@@ -81,11 +81,8 @@ jobs:
         run: |
           echo -n "Cache found. Cache size: "
           du -sh ~/.cache/bazel
-          echo "If the cache seems broken, update the CACHE_VERSION secret in"
-          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
-          echo "(use any random string, any GUID will work)"
-          echo "and it will start over with a clean cache."
-          echo "The old one will disappear after 7 days."
+          echo "If the cache seems broken, update the root WORKSPACE file with a trivial change."
+          echo "The old cache will disappear after 7 days."
 
       - name: Gradle Build Generated Storage Client Library
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
-
+          key: ${{ runner.os }}-${{ hashFiles('WORKSPACE') }}
+          restore-keys: ${{ runner.os }}-
       - name: Bazel Cache Not Found
         if: steps.cache-bazel.outputs.cache-hit != 'true'
         run: |
@@ -35,10 +35,7 @@ jobs:
         run: |
           echo -n "Cache found. Cache size: "
           du -sh ~/.cache/bazel
-          echo "If the cache seems broken, update the CACHE_VERSION secret in"
-          echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
-          echo "(use any random string, any GUID will work)"
-          echo "and it will start over with a clean cache."
+          echo "If the cache seems broken, update the root WORKSPACE file with a trivial change."
           echo "The old one will disappear after 7 days."
 
       - name: Integration Tests


### PR DESCRIPTION
When a cache hit occurs, we don't update the cache.

Existing bazel cache is outdated (requiring refetching most dependencies) but is used often enough to prevent the cache from being replaced with an update. The existing implementation uses the static cache key `Linux-` due to the `secret` no longer existing.

The new implementation uses the dynamic cache key `Linux-${hashFile(WORKSPACE)}` with a fallback to `Linux-` if there's no hit. This will allow the current, outdated `Linux-` cache to eventually be garbage collected and updated.

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#cache-hits-and-misses

From the Showcase 11 CI build of this PR: The `restore-key` is working to provide the existing cache as a backup.
```
Cache restored successfully
Cache restored from key: Linux-
```

Total time to perform showcase golden and integration testing: **08:09 min**

Cache was then saved:
```
Post job cleanup.
/usr/bin/tar --posix --use-compress-program zstdmt -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/gapic-generator-java/gapic-generator-java --files-from manifest.txt
Cache Size: ~1253 MB (1313414745 B)
Cache saved successfully
Cache saved with key: Linux-257b29dc07b793a82926f3efeb9269c10eefafa6bbf96f92a03822bbdbcb4fee
```

Forced second run of CI builds:
```
Cache restored successfully
Cache restored from key: Linux-257b29dc07b793a82926f3efeb9269c10eefafa6bbf96f92a03822bbdbcb4fee
```

Total time to perform showcase golden and integration testing: **02:25 min**

Total time to run the entire Showcase (11) and Showcase (17) builds:
* On latest main commit: 14:12 min and 10:36 min
* On this PR: 5:30 min and 10:49 min

NOTE: No improvement for Java 17 build. We may want to consider keying off the Java version. However, repositories have a cache quota of 10GB that we must share with the Maven cache. After this 10GB limit is reached, our least recently used cache will be dropped, so we should be careful here.
