### PR TITLE
fix: add name to ConditionalOnMissingBean when creating bean

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -341,7 +341,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         AssignmentExpr.builder()
             .setVariableExpr(
                 VariableExpr.withVariable(
-                    Variable.builder().setName("value").setType(TypeNode.STRING).build()))
+                    Variable.builder().setName("name").setType(TypeNode.STRING).build()))
             .setValueExpr(ValueExpr.withValue(StringObjectValue.withValue(methodName)))
             .build();
     AnnotationNode conditionalOnMissingBean =

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -330,17 +330,24 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
   private static MethodDefinition createTransportChannelProviderBeanMethod(
       String methodName, Map<String, TypeNode> types) {
 
-    //   @Bean
-    //   @ConditionalOnMissingBean
-    //   public TransportChannelProvider defaultLanguageTransportChannelProvider() {
-    //     return LanguageServiceSettings.defaultTransportChannelProvider();
-    //   }
-    // build expressions
     MethodInvocationExpr returnExpr =
         MethodInvocationExpr.builder()
             .setMethodName("defaultTransportChannelProvider")
             .setStaticReferenceType(types.get("ServiceSettings"))
             .setReturnType(STATIC_TYPES.get("TransportChannelProvider"))
+            .build();
+
+    AssignmentExpr nameStringAssignmentExpr =
+        AssignmentExpr.builder()
+            .setVariableExpr(
+                VariableExpr.withVariable(
+                    Variable.builder().setName("value").setType(TypeNode.STRING).build()))
+            .setValueExpr(ValueExpr.withValue(StringObjectValue.withValue(methodName)))
+            .build();
+    AnnotationNode conditionalOnMissingBean =
+        AnnotationNode.builder()
+            .setType(STATIC_TYPES.get("ConditionalOnMissingBean"))
+            .addDescription(nameStringAssignmentExpr)
             .build();
 
     return MethodDefinition.builder()
@@ -351,8 +358,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
         .setReturnType(STATIC_TYPES.get("TransportChannelProvider"))
         .setAnnotations(
             Arrays.asList(
-                AnnotationNode.withType(STATIC_TYPES.get("Bean")),
-                AnnotationNode.withType(STATIC_TYPES.get("ConditionalOnMissingBean"))))
+                AnnotationNode.withType(STATIC_TYPES.get("Bean")), conditionalOnMissingBean))
         .setReturnExpr(returnExpr)
         .build();
   }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -86,7 +86,7 @@ public class EchoSpringAutoConfiguration {
    * useRest option is provided to use HTTP transport instead
    */
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(value = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     return EchoSettings.defaultTransportChannelProvider();
   }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -86,7 +86,7 @@ public class EchoSpringAutoConfiguration {
    * useRest option is provided to use HTTP transport instead
    */
   @Bean
-  @ConditionalOnMissingBean(value = "defaultEchoTransportChannelProvider")
+  @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     return EchoSettings.defaultTransportChannelProvider();
   }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -66,7 +66,7 @@ public class EchoSpringAutoConfiguration {
    * useRest option is provided to use HTTP transport instead
    */
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(value = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     return EchoSettings.defaultTransportChannelProvider();
   }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -66,7 +66,7 @@ public class EchoSpringAutoConfiguration {
    * useRest option is provided to use HTTP transport instead
    */
   @Bean
-  @ConditionalOnMissingBean(value = "defaultEchoTransportChannelProvider")
+  @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     return EchoSettings.defaultTransportChannelProvider();
   }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -67,7 +67,7 @@ public class EchoSpringAutoConfiguration {
    * useRest option is provided to use HTTP transport instead
    */
   @Bean
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(value = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     return EchoSettings.defaultTransportChannelProvider();
   }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -67,7 +67,7 @@ public class EchoSpringAutoConfiguration {
    * useRest option is provided to use HTTP transport instead
    */
   @Bean
-  @ConditionalOnMissingBean(value = "defaultEchoTransportChannelProvider")
+  @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     return EchoSettings.defaultTransportChannelProvider();
   }


### PR DESCRIPTION
Add name to `@ConditionalOnMissingBean` annotation when creating `TransportChannelProvider` bean so that it can be picked up with Qualifier in serviceSettings bean creation that follows.
This was missed in original [commit](https://github.com/googleapis/gapic-generator-java/commit/0643085e8e837f23d11b3bc18bded7e1551233ba) adding this bean and should fix error seen in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1407#issuecomment-1370058527