### PR TITLE
fix(spring): Separate out client settings bean and client bean comment

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -847,6 +847,8 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     String methodName =
         CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name()) + "Client";
     return MethodDefinition.builder()
+        .setHeaderCommentStatements(
+            SpringAutoconfigCommentComposer.createClientBeanComment(service.name()))
         .setName(methodName)
         .setScope(ScopeNode.PUBLIC)
         .setReturnType(types.get("ServiceClient"))

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -744,7 +744,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     return MethodDefinition.builder()
         .setHeaderCommentStatements(
-            SpringAutoconfigCommentComposer.createClientBeanComment(
+            SpringAutoconfigCommentComposer.createSettingsBeanComment(
                 service.name(),
                 Utils.getServicePropertiesClassName(service),
                 transportChannelProviderName))

--- a/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
@@ -55,6 +55,9 @@ public class SpringAutoconfigCommentComposer {
           + "Method-level properties will take precedence over service-level properties if available, "
           + "and client library defaults will be used if neither are specified.";
 
+  public static final String CLIENT_BEAN_GENERAL_DESCRIPTION =
+      "Provides a %sClient bean configured with %sSettings.";
+
   public SpringAutoconfigCommentComposer() {}
 
   public static List<CommentStatement> createClassHeaderComments(
@@ -101,6 +104,13 @@ public class SpringAutoconfigCommentComposer {
                     channelProviderName))
             .addParagraph(
                 String.format(CLIENT_SETTINGS_BEAN_RETRY_SETTINGS_DESCRIPTION, propertiesClazzName))
+            .build());
+  }
+
+  public static CommentStatement createClientBeanComment(String serviceName) {
+    return CommentStatement.withComment(
+        JavaDocComment.builder()
+            .addParagraph(String.format(CLIENT_BEAN_GENERAL_DESCRIPTION, serviceName, serviceName))
             .build());
   }
 }

--- a/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
@@ -43,14 +43,14 @@ public class SpringAutoconfigCommentComposer {
   public static final String TRANSPORT_CHANNEL_PROVIDER_GENERAL_DESCRIPTION =
       "Returns the default channel provider. The default is gRPC and will default to it unless the "
           + "useRest option is provided to use HTTP transport instead";
-  public static final String CLIENT_BEAN_GENERAL_DESCRIPTION =
-      "Provides a %sClient bean configured to "
+  public static final String CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION =
+      "Provides a %sSettings bean configured to "
           + "use the default credentials provider (obtained with %sCredentials()) and its default "
           + "transport channel provider (%s()). It also configures the quota project ID if provided. It "
           + "will configure an executor provider in case there is more than one thread configured "
           + "in the client ";
 
-  public static final String CLIENT_BEAN_RETRY_SETTINGS_DESCRIPTION =
+  public static final String CLIENT_SETTINGS_BEAN_RETRY_SETTINGS_DESCRIPTION =
       "Retry settings are also configured from service-level and method-level properties specified in %s. "
           + "Method-level properties will take precedence over service-level properties if available, "
           + "and client library defaults will be used if neither are specified.";
@@ -88,19 +88,19 @@ public class SpringAutoconfigCommentComposer {
             .build());
   }
 
-  public static CommentStatement createClientBeanComment(
+  public static CommentStatement createSettingsBeanComment(
       String serviceName, String propertiesClazzName, String channelProviderName) {
     String credentialsBaseName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceName);
     return CommentStatement.withComment(
         JavaDocComment.builder()
             .addParagraph(
                 String.format(
-                    CLIENT_BEAN_GENERAL_DESCRIPTION,
+                    CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION,
                     serviceName,
                     credentialsBaseName,
                     channelProviderName))
             .addParagraph(
-                String.format(CLIENT_BEAN_RETRY_SETTINGS_DESCRIPTION, propertiesClazzName))
+                String.format(CLIENT_SETTINGS_BEAN_RETRY_SETTINGS_DESCRIPTION, propertiesClazzName))
             .build());
   }
 }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -92,7 +92,7 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a EchoClient bean configured to use the default credentials provider (obtained with
+   * Provides a EchoSettings bean configured to use the default credentials provider (obtained with
    * echoCredentials()) and its default transport channel provider
    * (defaultEchoTransportChannelProvider()). It also configures the quota project ID if provided.
    * It will configure an executor provider in case there is more than one thread configured in the

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -299,6 +299,7 @@ public class EchoSpringAutoConfiguration {
     return clientSettingsBuilder.build();
   }
 
+  /** Provides a EchoClient bean configured with EchoSettings. */
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(EchoSettings echoSettings) throws IOException {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -72,7 +72,7 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a EchoClient bean configured to use the default credentials provider (obtained with
+   * Provides a EchoSettings bean configured to use the default credentials provider (obtained with
    * echoCredentials()) and its default transport channel provider
    * (defaultEchoTransportChannelProvider()). It also configures the quota project ID if provided.
    * It will configure an executor provider in case there is more than one thread configured in the

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -279,6 +279,7 @@ public class EchoSpringAutoConfiguration {
     return clientSettingsBuilder.build();
   }
 
+  /** Provides a EchoClient bean configured with EchoSettings. */
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(EchoSettings echoSettings) throws IOException {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -287,6 +287,7 @@ public class EchoSpringAutoConfiguration {
     return clientSettingsBuilder.build();
   }
 
+  /** Provides a EchoClient bean configured with EchoSettings. */
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(EchoSettings echoSettings) throws IOException {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -73,7 +73,7 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a EchoClient bean configured to use the default credentials provider (obtained with
+   * Provides a EchoSettings bean configured to use the default credentials provider (obtained with
    * echoCredentials()) and its default transport channel provider
    * (defaultEchoTransportChannelProvider()). It also configures the quota project ID if provided.
    * It will configure an executor provider in case there is more than one thread configured in the


### PR DESCRIPTION
Addressing: https://github.com/googleapis/gapic-generator-java/pull/1110#issuecomment-1355712280
This was leftover from changes made in #1110