### PR TITLE
feat: Add callable getters for non-eligible or non-enabled REST methods

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -228,7 +228,9 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     return String.format("Not implemented: %s()", callableName);
   }
 
-  protected abstract boolean isSupportedMethod(Method method);
+  protected boolean isSupportedMethod(Method method) {
+    return true;
+  }
 
   protected abstract Statement createMethodDescriptorVariableDecl(
       Service service,

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -83,18 +83,18 @@ import javax.annotation.Nullable;
 public abstract class AbstractTransportServiceStubClassComposer implements ClassComposer {
   private static final Statement EMPTY_LINE_STATEMENT = EmptyLineStatement.create();
 
-  protected static final String METHOD_DESCRIPTOR_NAME_PATTERN = "%sMethodDescriptor";
-  protected static final String PAGED_RESPONSE_TYPE_NAME_PATTERN = "%sPagedResponse";
-  protected static final String PAGED_CALLABLE_CLASS_MEMBER_PATTERN = "%sPagedCallable";
+  private static final String METHOD_DESCRIPTOR_NAME_PATTERN = "%sMethodDescriptor";
+  private static final String PAGED_RESPONSE_TYPE_NAME_PATTERN = "%sPagedResponse";
+  private static final String PAGED_CALLABLE_CLASS_MEMBER_PATTERN = "%sPagedCallable";
 
-  protected static final String BACKGROUND_RESOURCES_MEMBER_NAME = "backgroundResources";
-  protected static final String CALLABLE_NAME = "Callable";
-  protected static final String CALLABLE_FACTORY_MEMBER_NAME = "callableFactory";
+  private static final String BACKGROUND_RESOURCES_MEMBER_NAME = "backgroundResources";
+  private static final String CALLABLE_NAME = "Callable";
+  private static final String CALLABLE_FACTORY_MEMBER_NAME = "callableFactory";
   protected static final String CALLABLE_CLASS_MEMBER_PATTERN = "%sCallable";
-  protected static final String OPERATION_CALLABLE_CLASS_MEMBER_PATTERN = "%sOperationCallable";
-  protected static final String OPERATION_CALLABLE_NAME = "OperationCallable";
+  private static final String OPERATION_CALLABLE_CLASS_MEMBER_PATTERN = "%sOperationCallable";
+  private static final String OPERATION_CALLABLE_NAME = "OperationCallable";
   // private static final String OPERATIONS_STUB_MEMBER_NAME = "operationsStub";
-  protected static final String PAGED_CALLABLE_NAME = "PagedCallable";
+  private static final String PAGED_CALLABLE_NAME = "PagedCallable";
 
   protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
 

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -228,9 +228,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     return String.format("Not implemented: %s()", callableName);
   }
 
-  protected boolean isSupportedMethod(Method method) {
-    return true;
-  }
+  protected abstract boolean isSupportedMethod(Method method);
 
   protected abstract Statement createMethodDescriptorVariableDecl(
       Service service,

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -225,10 +225,6 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     return GapicClass.create(kind, classDef);
   }
 
-  protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
-    return String.format("Not implemented: %s()", callableName);
-  }
-
   protected Transport getTransport() {
     return Transport.GRPC;
   }

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -59,7 +59,6 @@ import com.google.api.generator.gapic.model.GapicServiceConfig;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
-import com.google.api.generator.gapic.model.Transport;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -226,18 +225,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     return GapicClass.create(kind, classDef);
   }
 
-  private String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
-    if (protoMethod.stream() == Method.Stream.BIDI
-        || protoMethod.stream() == Method.Stream.CLIENT) {
-      return String.format(
-          "Not implemented: %s(). %s is not implemented for %s",
-          callableName, protoMethod.stream(), Transport.REST);
-    } else if (protoMethod.httpBindings() == null) {
-      return String.format(
-          "Not implemented: %s(). RPC is not enabled for %s", callableName, Transport.REST);
-    } else {
-      return String.format("Not implemented: %s()", callableName);
-    }
+  protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
+    return String.format("Not implemented: %s()", callableName);
   }
 
   private List<MethodDefinition> createInvalidClassMethods(Service service) {

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -82,18 +82,18 @@ import javax.annotation.Nullable;
 public abstract class AbstractTransportServiceStubClassComposer implements ClassComposer {
   private static final Statement EMPTY_LINE_STATEMENT = EmptyLineStatement.create();
 
-  private static final String METHOD_DESCRIPTOR_NAME_PATTERN = "%sMethodDescriptor";
-  private static final String PAGED_RESPONSE_TYPE_NAME_PATTERN = "%sPagedResponse";
-  private static final String PAGED_CALLABLE_CLASS_MEMBER_PATTERN = "%sPagedCallable";
+  protected static final String METHOD_DESCRIPTOR_NAME_PATTERN = "%sMethodDescriptor";
+  protected static final String PAGED_RESPONSE_TYPE_NAME_PATTERN = "%sPagedResponse";
+  protected static final String PAGED_CALLABLE_CLASS_MEMBER_PATTERN = "%sPagedCallable";
 
-  private static final String BACKGROUND_RESOURCES_MEMBER_NAME = "backgroundResources";
-  private static final String CALLABLE_NAME = "Callable";
-  private static final String CALLABLE_FACTORY_MEMBER_NAME = "callableFactory";
-  private static final String CALLABLE_CLASS_MEMBER_PATTERN = "%sCallable";
-  private static final String OPERATION_CALLABLE_CLASS_MEMBER_PATTERN = "%sOperationCallable";
-  private static final String OPERATION_CALLABLE_NAME = "OperationCallable";
+  protected static final String BACKGROUND_RESOURCES_MEMBER_NAME = "backgroundResources";
+  protected static final String CALLABLE_NAME = "Callable";
+  protected static final String CALLABLE_FACTORY_MEMBER_NAME = "callableFactory";
+  protected static final String CALLABLE_CLASS_MEMBER_PATTERN = "%sCallable";
+  protected static final String OPERATION_CALLABLE_CLASS_MEMBER_PATTERN = "%sOperationCallable";
+  protected static final String OPERATION_CALLABLE_NAME = "OperationCallable";
   // private static final String OPERATIONS_STUB_MEMBER_NAME = "operationsStub";
-  private static final String PAGED_CALLABLE_NAME = "PagedCallable";
+  protected static final String PAGED_CALLABLE_NAME = "PagedCallable";
 
   protected static final TypeStore FIXED_TYPESTORE = createStaticTypes();
 
@@ -200,7 +200,6 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
             callableClassMemberVarExprs,
             protoMethodNameToDescriptorVarExprs,
             classStatements);
-    methodDefinitions.addAll(createInvalidClassMethods(service));
     methodDefinitions.addAll(
         createStubOverrideMethods(
             classMemberVarExprs.get(BACKGROUND_RESOURCES_MEMBER_NAME), service));
@@ -227,34 +226,6 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
     return String.format("Not implemented: %s()", callableName);
-  }
-
-  private List<MethodDefinition> createInvalidClassMethods(Service service) {
-    List<MethodDefinition> methodDefinitions = new ArrayList<>();
-    for (Method protoMethod : service.methods()) {
-      if (!isSupportedMethod(protoMethod)) {
-        String javaStyleProtoMethodName = JavaStyle.toLowerCamelCase(protoMethod.name());
-        String callableName =
-            String.format(CALLABLE_CLASS_MEMBER_PATTERN, javaStyleProtoMethodName);
-        methodDefinitions.add(
-            MethodDefinition.builder()
-                .setIsOverride(true)
-                .setScope(ScopeNode.PUBLIC)
-                .setName(callableName)
-                .setReturnType(getCallableType(protoMethod))
-                .setBody(
-                    Arrays.asList(
-                        ExprStatement.withExpr(
-                            ThrowExpr.builder()
-                                .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
-                                .setMessageExpr(
-                                    getUnsupportedOperationExceptionReason(
-                                        callableName, protoMethod))
-                                .build())))
-                .build());
-      }
-    }
-    return methodDefinitions;
   }
 
   protected boolean isSupportedMethod(Method method) {
@@ -1139,7 +1110,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
     return typeStore;
   }
 
-  private static TypeNode getCallableType(Method protoMethod) {
+  protected static TypeNode getCallableType(Method protoMethod) {
     TypeNode callableType = FIXED_TYPESTORE.get("UnaryCallable");
     switch (protoMethod.stream()) {
       case CLIENT:

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -91,10 +91,6 @@ public class GrpcServiceStubClassComposer extends AbstractTransportServiceStubCl
     return new TypeStore(concreteClazzes);
   }
 
-  protected boolean isSupportedMethod(Method method) {
-    return method.isMethodSupportedByTransport(Transport.GRPC);
-  }
-
   @Override
   protected Statement createMethodDescriptorVariableDecl(
       Service service,

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -41,6 +41,7 @@ import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.RoutingHeaderRule.RoutingHeaderParam;
 import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.model.Transport;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Splitter;
@@ -88,6 +89,10 @@ public class GrpcServiceStubClassComposer extends AbstractTransportServiceStubCl
             MethodDescriptor.class,
             ProtoUtils.class);
     return new TypeStore(concreteClazzes);
+  }
+
+  protected boolean isSupportedMethod(Method method) {
+    return method.isMethodSupportedByTransport(Transport.GRPC);
   }
 
   @Override

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/grpc/GrpcServiceStubClassComposer.java
@@ -41,7 +41,6 @@ import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.RoutingHeaderRule.RoutingHeaderParam;
 import com.google.api.generator.gapic.model.Service;
-import com.google.api.generator.gapic.model.Transport;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Splitter;

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -122,19 +122,6 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
     return Transport.REST;
   }
 
-  private String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
-    if (protoMethod.stream() == Method.Stream.BIDI
-        || protoMethod.stream() == Method.Stream.CLIENT) {
-      return String.format(
-          "Not supported: %s(). %s streaming is not supported for %s",
-          callableName, protoMethod.stream(), Transport.REST);
-    } else {
-      return String.format(
-          "Not implemented: %s(). %s transport is not implemented for this method yet",
-          callableName, Transport.REST);
-    }
-  }
-
   @Override
   protected boolean generateOperationsStubLogic(Service service) {
     return service.hasLroMethods();
@@ -1305,8 +1292,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                             ThrowExpr.builder()
                                 .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
                                 .setMessageExpr(
-                                    getUnsupportedOperationExceptionReason(
-                                        callableName, protoMethod))
+                                        String.format("Not implemented: %s(). %s transport is not implemented for this method yet", callableName, getTransport()))
                                 .build())))
                 .build());
       }

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -1276,28 +1276,28 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
   private List<MethodDefinition> createInvalidClassMethods(Service service) {
     List<MethodDefinition> methodDefinitions = new ArrayList<>();
     for (Method protoMethod : service.methods()) {
-      if (!protoMethod.isSupportedByTransport(getTransport())) {
-        String javaStyleProtoMethodName = JavaStyle.toLowerCamelCase(protoMethod.name());
-        String callableName =
-            String.format(CALLABLE_CLASS_MEMBER_PATTERN, javaStyleProtoMethodName);
-        methodDefinitions.add(
-            MethodDefinition.builder()
-                .setIsOverride(true)
-                .setScope(ScopeNode.PUBLIC)
-                .setName(callableName)
-                .setReturnType(getCallableType(protoMethod))
-                .setBody(
-                    Arrays.asList(
-                        ExprStatement.withExpr(
-                            ThrowExpr.builder()
-                                .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
-                                .setMessageExpr(
-                                    String.format(
-                                        "Not implemented: %s(). %s transport is not implemented for this method yet",
-                                        callableName, getTransport()))
-                                .build())))
-                .build());
+      if (protoMethod.isSupportedByTransport(getTransport())) {
+        continue;
       }
+      String javaStyleProtoMethodName = JavaStyle.toLowerCamelCase(protoMethod.name());
+      String callableName = String.format(CALLABLE_CLASS_MEMBER_PATTERN, javaStyleProtoMethodName);
+      methodDefinitions.add(
+          MethodDefinition.builder()
+              .setIsOverride(true)
+              .setScope(ScopeNode.PUBLIC)
+              .setName(callableName)
+              .setReturnType(getCallableType(protoMethod))
+              .setBody(
+                  Arrays.asList(
+                      ExprStatement.withExpr(
+                          ThrowExpr.builder()
+                              .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
+                              .setMessageExpr(
+                                  String.format(
+                                      "Not implemented: %s(). %s transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)",
+                                      callableName, getTransport()))
+                              .build())))
+              .build());
     }
     return methodDefinitions;
   }

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -57,7 +57,6 @@ import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
 import com.google.api.generator.gapic.model.Message;
 import com.google.api.generator.gapic.model.Method;
-import com.google.api.generator.gapic.model.Method.Stream;
 import com.google.api.generator.gapic.model.OperationResponse;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.model.Transport;
@@ -119,7 +118,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
   }
 
   protected boolean isSupportedMethod(Method method) {
-    return method.isMethodSupportedByTransport(Transport.REST);
+    return method.isSupportedByTransport(Transport.REST);
   }
 
   protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -1263,6 +1263,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                 .build()));
   }
 
+  @Override
   protected List<MethodDefinition> createClassMethods(
       GapicContext context,
       Service service,

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -117,8 +117,9 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
             TypeRegistry.class));
   }
 
-  protected boolean isSupportedMethod(Method method) {
-    return method.isSupportedByTransport(Transport.REST);
+  @Override
+  protected Transport getTransport() {
+    return Transport.REST;
   }
 
   protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
@@ -1287,7 +1288,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
   private List<MethodDefinition> createInvalidClassMethods(Service service) {
     List<MethodDefinition> methodDefinitions = new ArrayList<>();
     for (Method protoMethod : service.methods()) {
-      if (!isSupportedMethod(protoMethod)) {
+      if (!protoMethod.isSupportedByTransport(getTransport())) {
         String javaStyleProtoMethodName = JavaStyle.toLowerCamelCase(protoMethod.name());
         String callableName =
             String.format(CALLABLE_CLASS_MEMBER_PATTERN, javaStyleProtoMethodName);

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -1263,15 +1263,23 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
   }
 
   protected List<MethodDefinition> createClassMethods(
-          GapicContext context,
-          Service service,
-          TypeStore typeStore,
-          Map<String, VariableExpr> classMemberVarExprs,
-          Map<String, VariableExpr> callableClassMemberVarExprs,
-          Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs,
-          List<Statement> classStatements) {
+      GapicContext context,
+      Service service,
+      TypeStore typeStore,
+      Map<String, VariableExpr> classMemberVarExprs,
+      Map<String, VariableExpr> callableClassMemberVarExprs,
+      Map<String, VariableExpr> protoMethodNameToDescriptorVarExprs,
+      List<Statement> classStatements) {
     List<MethodDefinition> javaMethods = new ArrayList<>();
-    javaMethods.addAll(super.createClassMethods(context, service, typeStore, classMemberVarExprs, callableClassMemberVarExprs, protoMethodNameToDescriptorVarExprs, classStatements));
+    javaMethods.addAll(
+        super.createClassMethods(
+            context,
+            service,
+            typeStore,
+            classMemberVarExprs,
+            callableClassMemberVarExprs,
+            protoMethodNameToDescriptorVarExprs,
+            classStatements));
     javaMethods.addAll(createInvalidClassMethods(service));
     return javaMethods;
   }
@@ -1282,23 +1290,23 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
       if (!isSupportedMethod(protoMethod)) {
         String javaStyleProtoMethodName = JavaStyle.toLowerCamelCase(protoMethod.name());
         String callableName =
-                String.format(CALLABLE_CLASS_MEMBER_PATTERN, javaStyleProtoMethodName);
+            String.format(CALLABLE_CLASS_MEMBER_PATTERN, javaStyleProtoMethodName);
         methodDefinitions.add(
-                MethodDefinition.builder()
-                        .setIsOverride(true)
-                        .setScope(ScopeNode.PUBLIC)
-                        .setName(callableName)
-                        .setReturnType(getCallableType(protoMethod))
-                        .setBody(
-                                Arrays.asList(
-                                        ExprStatement.withExpr(
-                                                ThrowExpr.builder()
-                                                        .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
-                                                        .setMessageExpr(
-                                                                getUnsupportedOperationExceptionReason(
-                                                                        callableName, protoMethod))
-                                                        .build())))
-                        .build());
+            MethodDefinition.builder()
+                .setIsOverride(true)
+                .setScope(ScopeNode.PUBLIC)
+                .setName(callableName)
+                .setReturnType(getCallableType(protoMethod))
+                .setBody(
+                    Arrays.asList(
+                        ExprStatement.withExpr(
+                            ThrowExpr.builder()
+                                .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
+                                .setMessageExpr(
+                                    getUnsupportedOperationExceptionReason(
+                                        callableName, protoMethod))
+                                .build())))
+                .build());
       }
     }
     return methodDefinitions;

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -119,23 +119,19 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
   }
 
   protected boolean isSupportedMethod(Method method) {
-    return method.httpBindings() != null
-        && method.stream() != Stream.BIDI
-        && method.stream() != Stream.CLIENT;
+    return method.isMethodSupportedByTransport(Transport.REST);
   }
 
   protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
     if (protoMethod.stream() == Method.Stream.BIDI
         || protoMethod.stream() == Method.Stream.CLIENT) {
       return String.format(
-          "Not supported: %s(). %s streaming is not implemented for %s",
+          "Not supported: %s(). %s streaming is not supported for %s",
           callableName, protoMethod.stream(), Transport.REST);
-    } else if (protoMethod.httpBindings() == null) {
-      return String.format(
-          "Not implemented: %s(). %s transport is not supported for this method yet",
-          callableName, Transport.REST);
     } else {
-      return String.format("Not implemented: %s()", callableName);
+      return String.format(
+          "Not implemented: %s(). %s transport is not implemented for this method yet",
+          callableName, Transport.REST);
     }
   }
 

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -1294,7 +1294,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                               .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
                               .setMessageExpr(
                                   String.format(
-                                      "Not implemented: %s(). %s transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)",
+                                      "Not implemented: %s(). %s transport is not implemented for this method yet.",
                                       callableName, getTransport()))
                               .build())))
               .build());

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -122,7 +122,7 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
     return Transport.REST;
   }
 
-  protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
+  private String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
     if (protoMethod.stream() == Method.Stream.BIDI
         || protoMethod.stream() == Method.Stream.CLIENT) {
       return String.format(

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -58,6 +58,7 @@ import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Method.Stream;
 import com.google.api.generator.gapic.model.OperationResponse;
 import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.model.Transport;
 import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BiMap;
@@ -119,6 +120,21 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
     return method.httpBindings() != null
         && method.stream() != Stream.BIDI
         && method.stream() != Stream.CLIENT;
+  }
+
+  protected String getUnsupportedOperationExceptionReason(String callableName, Method protoMethod) {
+    if (protoMethod.stream() == Method.Stream.BIDI
+        || protoMethod.stream() == Method.Stream.CLIENT) {
+      return String.format(
+          "Not supported: %s(). %s streaming is not implemented for %s",
+          callableName, protoMethod.stream(), Transport.REST);
+    } else if (protoMethod.httpBindings() == null) {
+      return String.format(
+          "Not implemented: %s(). %s transport is not supported for this method yet",
+          callableName, Transport.REST);
+    } else {
+      return String.format("Not implemented: %s()", callableName);
+    }
   }
 
   @Override

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/rest/HttpJsonServiceStubClassComposer.java
@@ -1292,7 +1292,9 @@ public class HttpJsonServiceStubClassComposer extends AbstractTransportServiceSt
                             ThrowExpr.builder()
                                 .setType(FIXED_TYPESTORE.get("UnsupportedOperationException"))
                                 .setMessageExpr(
-                                        String.format("Not implemented: %s(). %s transport is not implemented for this method yet", callableName, getTransport()))
+                                    String.format(
+                                        "Not implemented: %s(). %s transport is not implemented for this method yet",
+                                        callableName, getTransport()))
                                 .build())))
                 .build());
       }

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -105,7 +105,7 @@ public abstract class Method {
    * (GRPC or REST)
    *
    * @param transport Expects either GRPC or REST Transport
-   * @return boolean is method should be generated for the transport
+   * @return boolean if method should be generated for the transport
    */
   public boolean isSupportedByTransport(Transport transport) {
     if (transport == Transport.REST) {

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -99,13 +99,9 @@ public abstract class Method {
     return operationPollingMethod();
   }
 
-  private boolean isRESTEnabled() {
-    return httpBindings() != null && stream() != Stream.BIDI && stream() != Stream.CLIENT;
-  }
-
   public boolean isSupportedByTransport(Transport transport) {
     if (transport == Transport.REST) {
-      return isRESTEnabled();
+      return httpBindings() != null && stream() != Stream.BIDI && stream() != Stream.CLIENT;
     } else {
       return true;
     }

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -99,17 +99,15 @@ public abstract class Method {
     return operationPollingMethod();
   }
 
-  public boolean isRESTEnabled() {
+  private boolean isRESTEnabled() {
     return httpBindings() != null && stream() != Stream.BIDI && stream() != Stream.CLIENT;
   }
 
-  public boolean isMethodSupportedByTransport(Transport transport) {
+  public boolean isSupportedByTransport(Transport transport) {
     if (transport == Transport.REST) {
       return isRESTEnabled();
-    } else if (transport == Transport.GRPC) {
-      return true;
     } else {
-      throw new IllegalArgumentException("GRPC+REST Transport is not allowed.");
+      return true;
     }
   }
 

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -99,6 +99,20 @@ public abstract class Method {
     return operationPollingMethod();
   }
 
+  public boolean isRESTEnabled() {
+    return httpBindings() != null && stream() != Stream.BIDI && stream() != Stream.CLIENT;
+  }
+
+  public boolean isMethodSupportedByTransport(Transport transport) {
+    if (transport == Transport.REST) {
+      return isRESTEnabled();
+    } else if (transport == Transport.GRPC) {
+      return true;
+    } else {
+      throw new IllegalArgumentException("GRPC+REST Transport is not allowed.");
+    }
+  }
+
   public abstract Builder toBuilder();
 
   public static Builder builder() {

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -99,11 +99,22 @@ public abstract class Method {
     return operationPollingMethod();
   }
 
+  /**
+   * Determines if method is both eligible and enabled for the Transport. GRPC+REST Transport is not
+   * supported as each transport's sub composers will invoke this method the specific transport
+   * (GRPC or REST)
+   *
+   * @param transport Expects either GRPC or REST Transport
+   * @return boolean is method should be generated for the transport
+   */
   public boolean isSupportedByTransport(Transport transport) {
     if (transport == Transport.REST) {
       return httpBindings() != null && stream() != Stream.BIDI && stream() != Stream.CLIENT;
-    } else {
+    } else if (transport == Transport.GRPC) {
       return true;
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Invalid Transport: %s. Expecting GRPC or REST", transport.name()));
     }
   }
 

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -548,13 +548,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: chatCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
+        "Not implemented: chatCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override
   public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: noBindingCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
+        "Not implemented: noBindingCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -548,13 +548,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: chatCallable(). REST transport is not implemented for this method yet");
+        "Not implemented: chatCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
   }
 
   @Override
   public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: noBindingCallable(). REST transport is not implemented for this method yet");
+        "Not implemented: noBindingCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -548,7 +548,7 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: chatCallable(). BIDI streaming is not supported for REST");
+        "Not implemented: chatCallable(). REST transport is not implemented for this method yet");
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -548,13 +548,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: chatCallable(). BIDI is not implemented for REST");
+        "Not supported: chatCallable(). BIDI streaming is not implemented for REST");
   }
 
   @Override
   public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: noBindingCallable(). RPC is not enabled for REST");
+        "Not implemented: noBindingCallable(). REST transport is not supported for this method yet");
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -16,6 +16,7 @@ import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
 import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
 import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.ServerStreamingCallable;
@@ -542,6 +543,18 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public UnaryCallable<EchoRequest, Object> nestedBindingCallable() {
     return nestedBindingCallable;
+  }
+
+  @Override
+  public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: chatCallable(). BIDI is not implemented for REST");
+  }
+
+  @Override
+  public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: noBindingCallable(). RPC is not enabled for REST");
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -548,13 +548,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: chatCallable(). BIDI streaming is not implemented for REST");
+        "Not supported: chatCallable(). BIDI streaming is not supported for REST");
   }
 
   @Override
   public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: noBindingCallable(). REST transport is not supported for this method yet");
+        "Not implemented: noBindingCallable(). REST transport is not implemented for this method yet");
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
@@ -112,4 +112,59 @@ public class MethodTest {
     Method method = METHOD.toBuilder().setHttpBindings(null).setRoutingHeaderRule(null).build();
     assertThat(method.shouldSetParamsExtractor()).isFalse();
   }
+
+  @Test
+  public void
+      isSupportedByTransport_shouldReturnTrueIfHasHttpBindingsAndIsRESTEligibleForRESTTransport() {
+    Method methodNoStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.NONE).build();
+    assertThat(methodNoStreaming.isSupportedByTransport(Transport.REST)).isTrue();
+    Method methodServerSideStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.SERVER).build();
+    assertThat(methodServerSideStreaming.isSupportedByTransport(Transport.REST)).isTrue();
+  }
+
+  @Test
+  public void isSupportedByTransport_shouldReturnFalseIfNoHttpBindingsForRESTTransport() {
+    Method methodNoStreaming =
+        METHOD.toBuilder().setHttpBindings(null).setStream(Method.Stream.NONE).build();
+    assertThat(methodNoStreaming.isSupportedByTransport(Transport.REST)).isFalse();
+    Method methodServerSideStreaming =
+        METHOD.toBuilder().setHttpBindings(null).setStream(Method.Stream.SERVER).build();
+    assertThat(methodServerSideStreaming.isSupportedByTransport(Transport.REST)).isFalse();
+  }
+
+  @Test
+  public void
+      isSupportedByTransport_shouldReturnFalseIfHasHttpBindingsAndIsNotRESTEligibleForRESTTransport() {
+    Method methodClientSideStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.CLIENT).build();
+    assertThat(methodClientSideStreaming.isSupportedByTransport(Transport.REST)).isFalse();
+    Method methodBiDiStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.BIDI).build();
+    assertThat(methodBiDiStreaming.isSupportedByTransport(Transport.REST)).isFalse();
+  }
+
+  @Test
+  public void isSupportedByTransport_shouldReturnTrueForGRPCTransport() {
+    Method methodNoStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.NONE).build();
+    assertThat(methodNoStreaming.isSupportedByTransport(Transport.GRPC)).isTrue();
+    Method methodBiDiStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.BIDI).build();
+    assertThat(methodBiDiStreaming.isSupportedByTransport(Transport.GRPC)).isTrue();
+    Method methodNoStreamingNoHttpBindings =
+        METHOD.toBuilder().setStream(Method.Stream.NONE).build();
+    assertThat(methodNoStreamingNoHttpBindings.isSupportedByTransport(Transport.GRPC)).isTrue();
+    Method methodBiDiStreamingNoHttpBindings =
+        METHOD.toBuilder().setStream(Method.Stream.BIDI).build();
+    assertThat(methodBiDiStreamingNoHttpBindings.isSupportedByTransport(Transport.GRPC)).isTrue();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void isSupportedByTransport_shouldThrowExceptionIfPassedGRPCRESTTransport() {
+    Method methodClientStreaming =
+        METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.CLIENT).build();
+    methodClientStreaming.isSupportedByTransport(Transport.GRPC_REST);
+  }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/model/MethodTest.java
@@ -15,6 +15,7 @@
 package com.google.api.generator.gapic.model;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.api.generator.engine.ast.TypeNode;
 import com.google.api.generator.gapic.model.HttpBindings.HttpBinding;
@@ -161,10 +162,12 @@ public class MethodTest {
     assertThat(methodBiDiStreamingNoHttpBindings.isSupportedByTransport(Transport.GRPC)).isTrue();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void isSupportedByTransport_shouldThrowExceptionIfPassedGRPCRESTTransport() {
     Method methodClientStreaming =
         METHOD.toBuilder().setHttpBindings(HTTP_BINDINGS).setStream(Method.Stream.CLIENT).build();
-    methodClientStreaming.isSupportedByTransport(Transport.GRPC_REST);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> methodClientStreaming.isSupportedByTransport(Transport.GRPC_REST));
   }
 }

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -529,13 +529,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public ClientStreamingCallable<EchoRequest, EchoResponse> collectCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: collectCallable(). CLIENT streaming is not supported for REST");
+        "Not implemented: collectCallable(). REST transport is not implemented for this method yet");
   }
 
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: chatCallable(). BIDI streaming is not supported for REST");
+        "Not implemented: chatCallable(). REST transport is not implemented for this method yet");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -529,13 +529,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public ClientStreamingCallable<EchoRequest, EchoResponse> collectCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: collectCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
+        "Not implemented: collectCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: chatCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
+        "Not implemented: chatCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -529,13 +529,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public ClientStreamingCallable<EchoRequest, EchoResponse> collectCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: collectCallable(). CLIENT streaming is not implemented for REST");
+        "Not supported: collectCallable(). CLIENT streaming is not supported for REST");
   }
 
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: chatCallable(). BIDI streaming is not implemented for REST");
+        "Not supported: chatCallable(). BIDI streaming is not supported for REST");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -32,7 +32,9 @@ import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
 import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
 import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
@@ -522,6 +524,18 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public UnaryCallable<BlockRequest, BlockResponse> blockCallable() {
     return blockCallable;
+  }
+
+  @Override
+  public ClientStreamingCallable<EchoRequest, EchoResponse> collectCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: collectCallable(). CLIENT is not implemented for REST");
+  }
+
+  @Override
+  public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: chatCallable(). BIDI is not implemented for REST");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -529,13 +529,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public ClientStreamingCallable<EchoRequest, EchoResponse> collectCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: collectCallable(). CLIENT is not implemented for REST");
+        "Not supported: collectCallable(). CLIENT streaming is not implemented for REST");
   }
 
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: chatCallable(). BIDI is not implemented for REST");
+        "Not supported: chatCallable(). BIDI streaming is not implemented for REST");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -529,13 +529,13 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public ClientStreamingCallable<EchoRequest, EchoResponse> collectCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: collectCallable(). REST transport is not implemented for this method yet");
+        "Not implemented: collectCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
   }
 
   @Override
   public BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: chatCallable(). REST transport is not implemented for this method yet");
+        "Not implemented: chatCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -792,13 +792,13 @@ public class HttpJsonMessagingStub extends MessagingStub {
   @Override
   public ClientStreamingCallable<CreateBlurbRequest, SendBlurbsResponse> sendBlurbsCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: sendBlurbsCallable(). CLIENT streaming is not implemented for REST");
+        "Not supported: sendBlurbsCallable(). CLIENT streaming is not supported for REST");
   }
 
   @Override
   public BidiStreamingCallable<ConnectRequest, StreamBlurbsResponse> connectCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: connectCallable(). BIDI streaming is not implemented for REST");
+        "Not supported: connectCallable(). BIDI streaming is not supported for REST");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -792,13 +792,13 @@ public class HttpJsonMessagingStub extends MessagingStub {
   @Override
   public ClientStreamingCallable<CreateBlurbRequest, SendBlurbsResponse> sendBlurbsCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: sendBlurbsCallable(). REST transport is not implemented for this method yet");
+        "Not implemented: sendBlurbsCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
   }
 
   @Override
   public BidiStreamingCallable<ConnectRequest, StreamBlurbsResponse> connectCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: connectCallable(). REST transport is not implemented for this method yet");
+        "Not implemented: connectCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -792,13 +792,13 @@ public class HttpJsonMessagingStub extends MessagingStub {
   @Override
   public ClientStreamingCallable<CreateBlurbRequest, SendBlurbsResponse> sendBlurbsCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: sendBlurbsCallable(). CLIENT is not implemented for REST");
+        "Not supported: sendBlurbsCallable(). CLIENT streaming is not implemented for REST");
   }
 
   @Override
   public BidiStreamingCallable<ConnectRequest, StreamBlurbsResponse> connectCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: connectCallable(). BIDI is not implemented for REST");
+        "Not supported: connectCallable(). BIDI streaming is not implemented for REST");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -32,7 +32,9 @@ import com.google.api.gax.httpjson.ProtoMessageResponseParser;
 import com.google.api.gax.httpjson.ProtoRestSerializer;
 import com.google.api.gax.httpjson.longrunning.stub.HttpJsonOperationsStub;
 import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
@@ -40,6 +42,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.TypeRegistry;
 import com.google.showcase.v1beta1.Blurb;
+import com.google.showcase.v1beta1.ConnectRequest;
 import com.google.showcase.v1beta1.CreateBlurbRequest;
 import com.google.showcase.v1beta1.CreateRoomRequest;
 import com.google.showcase.v1beta1.DeleteBlurbRequest;
@@ -54,6 +57,7 @@ import com.google.showcase.v1beta1.Room;
 import com.google.showcase.v1beta1.SearchBlurbsMetadata;
 import com.google.showcase.v1beta1.SearchBlurbsRequest;
 import com.google.showcase.v1beta1.SearchBlurbsResponse;
+import com.google.showcase.v1beta1.SendBlurbsResponse;
 import com.google.showcase.v1beta1.StreamBlurbsRequest;
 import com.google.showcase.v1beta1.StreamBlurbsResponse;
 import com.google.showcase.v1beta1.UpdateBlurbRequest;
@@ -783,6 +787,18 @@ public class HttpJsonMessagingStub extends MessagingStub {
   @Override
   public ServerStreamingCallable<StreamBlurbsRequest, StreamBlurbsResponse> streamBlurbsCallable() {
     return streamBlurbsCallable;
+  }
+
+  @Override
+  public ClientStreamingCallable<CreateBlurbRequest, SendBlurbsResponse> sendBlurbsCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: sendBlurbsCallable(). CLIENT is not implemented for REST");
+  }
+
+  @Override
+  public BidiStreamingCallable<ConnectRequest, StreamBlurbsResponse> connectCallable() {
+    throw new UnsupportedOperationException(
+        "Not implemented: connectCallable(). BIDI is not implemented for REST");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -792,13 +792,13 @@ public class HttpJsonMessagingStub extends MessagingStub {
   @Override
   public ClientStreamingCallable<CreateBlurbRequest, SendBlurbsResponse> sendBlurbsCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: sendBlurbsCallable(). CLIENT streaming is not supported for REST");
+        "Not implemented: sendBlurbsCallable(). REST transport is not implemented for this method yet");
   }
 
   @Override
   public BidiStreamingCallable<ConnectRequest, StreamBlurbsResponse> connectCallable() {
     throw new UnsupportedOperationException(
-        "Not supported: connectCallable(). BIDI streaming is not supported for REST");
+        "Not implemented: connectCallable(). REST transport is not implemented for this method yet");
   }
 
   @Override

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -792,13 +792,13 @@ public class HttpJsonMessagingStub extends MessagingStub {
   @Override
   public ClientStreamingCallable<CreateBlurbRequest, SendBlurbsResponse> sendBlurbsCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: sendBlurbsCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
+        "Not implemented: sendBlurbsCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override
   public BidiStreamingCallable<ConnectRequest, StreamBlurbsResponse> connectCallable() {
     throw new UnsupportedOperationException(
-        "Not implemented: connectCallable(). REST transport is not implemented for this method yet. It is either not enabled or not supported (BIDI or Client Streaming)");
+        "Not implemented: connectCallable(). REST transport is not implemented for this method yet.");
   }
 
   @Override


### PR DESCRIPTION
This is a PR for Part 1 of #1117 (Override method with clearer exception messages for non-eligible and non-enabled Service RPCs). Opening this while I look at other possible approaches: 

Other approaches looked at/ to revisit:
- Override createCallableClassMembers to return Map<String, Expr> (Return either VariableExpr or ThrowExpr)
- Create a duplicate createCallableClassMembers (i.e. createInvalidCallableClassMembers) that copies functionality of createCallableClassMembers but returns Map<String, ThrowExpr>

Both approaches above had an issue when setting the return type for the callableGetter. ThrowExpr's type is always set as `UnsupportedOperationException` but the MethodDefinition's return type is not (i.e. for Streams it would be ServerStreamCallable or ClientStreamCallable/ Unary is UnaryCallable vs. Operation, etc.). Would need potentially need another mapping between callableName and method return type for ThrowExprs.

This PR's implementation is copied from: https://github.com/googleapis/gapic-generator-java/blob/8c5e17ba325b7711f9ba9501992ab48e736ffc18/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java#L284-L302
- Use getCallableType(protoMethod) to get the correct return type for the RPC
- ThrowExpr's return type is set to `UnsupportedOperationException`