### PR TITLE
fix(spring): limit retry settings configuration by method type

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -659,10 +659,13 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     List<Statement> updateRetrySettingsStatementBody = new ArrayList<>();
 
     for (Method method : service.methods()) {
-      List<Statement> updateMethodWithServiceRetryStatments =
+      if (!method.stream().equals(Method.Stream.NONE)) {
+        continue;
+      }
+      List<Statement> updateMethodWithServiceRetryStatements =
           createUpdateRetrySettingsStatements(
               method.name(), settingBuilderVariable, serviceRetryPropertiesVar, types);
-      updateRetrySettingsStatementBody.addAll(updateMethodWithServiceRetryStatments);
+      updateRetrySettingsStatementBody.addAll(updateMethodWithServiceRetryStatements);
       updateRetrySettingsStatementBody.add(EMPTY_LINE_STATEMENT);
     }
 
@@ -680,6 +683,9 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     // If-blocks to update with method-level properties
     for (Method method : service.methods()) {
+      if (!method.stream().equals(Method.Stream.NONE)) {
+        continue;
+      }
       String methodName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name());
 
       Variable methodRetryPropertiesVar =

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -658,10 +658,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     List<Statement> updateRetrySettingsStatementBody = new ArrayList<>();
 
-    for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
-        continue;
-      }
+    for (Method method : Utils.getMethodsForRetryConfiguration(service)) {
       List<Statement> updateMethodWithServiceRetryStatements =
           createUpdateRetrySettingsStatements(
               method.name(), settingBuilderVariable, serviceRetryPropertiesVar, types);
@@ -682,10 +679,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     bodyStatements.add(setRetrySettingsStatement);
 
     // If-blocks to update with method-level properties
-    for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
-        continue;
-      }
+    for (Method method : Utils.getMethodsForRetryConfiguration(service)) {
       String methodName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name());
 
       Variable methodRetryPropertiesVar =

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -659,7 +659,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     List<Statement> updateRetrySettingsStatementBody = new ArrayList<>();
 
     for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE)) {
+      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
         continue;
       }
       List<Statement> updateMethodWithServiceRetryStatements =
@@ -683,7 +683,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     // If-blocks to update with method-level properties
     for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE)) {
+      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
         continue;
       }
       String methodName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name());

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -172,7 +172,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     statements.add(retryPropertiesStatement);
 
     for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE)) {
+      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
         continue;
       }
       String methodNameLowerCamel =
@@ -220,7 +220,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     methodDefinitions.add(createSetterMethod(thisClassType, "retry", types.get("Retry")));
 
     for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE)) {
+      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
         continue;
       }
       String methodPropertiesVarName =

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -172,6 +172,9 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     statements.add(retryPropertiesStatement);
 
     for (Method method : service.methods()) {
+      if (!method.stream().equals(Method.Stream.NONE)) {
+        continue;
+      }
       String methodNameLowerCamel =
           CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name());
       String methodPropertiesVarName = methodNameLowerCamel + "Retry";
@@ -217,6 +220,9 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     methodDefinitions.add(createSetterMethod(thisClassType, "retry", types.get("Retry")));
 
     for (Method method : service.methods()) {
+      if (!method.stream().equals(Method.Stream.NONE)) {
+        continue;
+      }
       String methodPropertiesVarName =
           CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name()) + "Retry";
       methodDefinitions.add(

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -171,10 +171,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     statements.add(SpringPropertiesCommentComposer.createServiceRetryPropertyComment());
     statements.add(retryPropertiesStatement);
 
-    for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
-        continue;
-      }
+    for (Method method : Utils.getMethodsForRetryConfiguration(service)) {
       String methodNameLowerCamel =
           CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name());
       String methodPropertiesVarName = methodNameLowerCamel + "Retry";
@@ -219,10 +216,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     methodDefinitions.add(createGetterMethod(thisClassType, "retry", types.get("Retry"), null));
     methodDefinitions.add(createSetterMethod(thisClassType, "retry", types.get("Retry")));
 
-    for (Method method : service.methods()) {
-      if (!method.stream().equals(Method.Stream.NONE) || method.hasLro()) {
-        continue;
-      }
+    for (Method method : Utils.getMethodsForRetryConfiguration(service)) {
       String methodPropertiesVarName =
           CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name()) + "Retry";
       methodDefinitions.add(

--- a/src/main/java/com/google/api/generator/spring/utils/Utils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/Utils.java
@@ -16,10 +16,12 @@ package com.google.api.generator.spring.utils;
 
 import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.api.generator.gapic.model.GapicContext;
+import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Utils {
 
@@ -79,6 +81,14 @@ public class Utils {
     // Service name is converted to lower hyphen as required by ConfigurationPropertyName
     // https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/context/properties/source/ConfigurationPropertyName.html
     return packageName + "." + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, serviceName);
+  }
+
+  public static List<Method> getMethodsForRetryConfiguration(Service service) {
+    // Returns list of methods with retry configuration support
+    // This currently excludes streaming and LRO methods
+    return service.methods().stream()
+        .filter(m -> m.stream().equals(Method.Stream.NONE) && !m.hasLro())
+        .collect(Collectors.toList());
   }
 
   private static TypeStore createStaticTypes() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -141,26 +141,6 @@ public class EchoSpringAutoConfiguration {
               clientSettingsBuilder.echoSettings().getRetrySettings(), serviceRetry);
       clientSettingsBuilder.echoSettings().setRetrySettings(echoRetrySettings);
 
-      RetrySettings expandRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.expandSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.expandSettings().setRetrySettings(expandRetrySettings);
-
-      RetrySettings collectRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.collectSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.collectSettings().setRetrySettings(collectRetrySettings);
-
-      RetrySettings chatRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.chatSettings().setRetrySettings(chatRetrySettings);
-
-      RetrySettings chatAgainRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatAgainSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.chatAgainSettings().setRetrySettings(chatAgainRetrySettings);
-
       RetrySettings pagedExpandRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.pagedExpandSettings().getRetrySettings(), serviceRetry);
@@ -200,46 +180,6 @@ public class EchoSpringAutoConfiguration {
       clientSettingsBuilder.echoSettings().setRetrySettings(echoRetrySettings);
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Configured method-level retry settings for echo from properties.");
-      }
-    }
-    Retry expandRetry = clientProperties.getExpandRetry();
-    if (expandRetry != null) {
-      RetrySettings expandRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.expandSettings().getRetrySettings(), expandRetry);
-      clientSettingsBuilder.expandSettings().setRetrySettings(expandRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for expand from properties.");
-      }
-    }
-    Retry collectRetry = clientProperties.getCollectRetry();
-    if (collectRetry != null) {
-      RetrySettings collectRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.collectSettings().getRetrySettings(), collectRetry);
-      clientSettingsBuilder.collectSettings().setRetrySettings(collectRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for collect from properties.");
-      }
-    }
-    Retry chatRetry = clientProperties.getChatRetry();
-    if (chatRetry != null) {
-      RetrySettings chatRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatSettings().getRetrySettings(), chatRetry);
-      clientSettingsBuilder.chatSettings().setRetrySettings(chatRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for chat from properties.");
-      }
-    }
-    Retry chatAgainRetry = clientProperties.getChatAgainRetry();
-    if (chatAgainRetry != null) {
-      RetrySettings chatAgainRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatAgainSettings().getRetrySettings(), chatAgainRetry);
-      clientSettingsBuilder.chatAgainSettings().setRetrySettings(chatAgainRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for chatAgain from properties.");
       }
     }
     Retry pagedExpandRetry = clientProperties.getPagedExpandRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -153,11 +153,6 @@ public class EchoSpringAutoConfiguration {
           .simplePagedExpandSettings()
           .setRetrySettings(simplePagedExpandRetrySettings);
 
-      RetrySettings waitRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.waitSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.waitSettings().setRetrySettings(waitRetrySettings);
-
       RetrySettings blockRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.blockSettings().getRetrySettings(), serviceRetry);
@@ -204,16 +199,6 @@ public class EchoSpringAutoConfiguration {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace(
             "Configured method-level retry settings for simplePagedExpand from properties.");
-      }
-    }
-    Retry waitRetry = clientProperties.getWaitRetry();
-    if (waitRetry != null) {
-      RetrySettings waitRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.waitSettings().getRetrySettings(), waitRetry);
-      clientSettingsBuilder.waitSettings().setRetrySettings(waitRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for wait from properties.");
       }
     }
     Retry blockRetry = clientProperties.getBlockRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -133,11 +133,6 @@ public class EchoSpringAutoConfiguration {
           .simplePagedExpandSettings()
           .setRetrySettings(simplePagedExpandRetrySettings);
 
-      RetrySettings waitRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.waitSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.waitSettings().setRetrySettings(waitRetrySettings);
-
       RetrySettings blockRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.blockSettings().getRetrySettings(), serviceRetry);
@@ -184,16 +179,6 @@ public class EchoSpringAutoConfiguration {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace(
             "Configured method-level retry settings for simplePagedExpand from properties.");
-      }
-    }
-    Retry waitRetry = clientProperties.getWaitRetry();
-    if (waitRetry != null) {
-      RetrySettings waitRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.waitSettings().getRetrySettings(), waitRetry);
-      clientSettingsBuilder.waitSettings().setRetrySettings(waitRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for wait from properties.");
       }
     }
     Retry blockRetry = clientProperties.getBlockRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -121,26 +121,6 @@ public class EchoSpringAutoConfiguration {
               clientSettingsBuilder.echoSettings().getRetrySettings(), serviceRetry);
       clientSettingsBuilder.echoSettings().setRetrySettings(echoRetrySettings);
 
-      RetrySettings expandRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.expandSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.expandSettings().setRetrySettings(expandRetrySettings);
-
-      RetrySettings collectRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.collectSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.collectSettings().setRetrySettings(collectRetrySettings);
-
-      RetrySettings chatRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.chatSettings().setRetrySettings(chatRetrySettings);
-
-      RetrySettings chatAgainRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatAgainSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.chatAgainSettings().setRetrySettings(chatAgainRetrySettings);
-
       RetrySettings pagedExpandRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.pagedExpandSettings().getRetrySettings(), serviceRetry);
@@ -180,46 +160,6 @@ public class EchoSpringAutoConfiguration {
       clientSettingsBuilder.echoSettings().setRetrySettings(echoRetrySettings);
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Configured method-level retry settings for echo from properties.");
-      }
-    }
-    Retry expandRetry = clientProperties.getExpandRetry();
-    if (expandRetry != null) {
-      RetrySettings expandRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.expandSettings().getRetrySettings(), expandRetry);
-      clientSettingsBuilder.expandSettings().setRetrySettings(expandRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for expand from properties.");
-      }
-    }
-    Retry collectRetry = clientProperties.getCollectRetry();
-    if (collectRetry != null) {
-      RetrySettings collectRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.collectSettings().getRetrySettings(), collectRetry);
-      clientSettingsBuilder.collectSettings().setRetrySettings(collectRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for collect from properties.");
-      }
-    }
-    Retry chatRetry = clientProperties.getChatRetry();
-    if (chatRetry != null) {
-      RetrySettings chatRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatSettings().getRetrySettings(), chatRetry);
-      clientSettingsBuilder.chatSettings().setRetrySettings(chatRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for chat from properties.");
-      }
-    }
-    Retry chatAgainRetry = clientProperties.getChatAgainRetry();
-    if (chatAgainRetry != null) {
-      RetrySettings chatAgainRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatAgainSettings().getRetrySettings(), chatAgainRetry);
-      clientSettingsBuilder.chatAgainSettings().setRetrySettings(chatAgainRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for chatAgain from properties.");
       }
     }
     Retry pagedExpandRetry = clientProperties.getPagedExpandRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -141,11 +141,6 @@ public class EchoSpringAutoConfiguration {
           .simplePagedExpandSettings()
           .setRetrySettings(simplePagedExpandRetrySettings);
 
-      RetrySettings waitRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.waitSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.waitSettings().setRetrySettings(waitRetrySettings);
-
       RetrySettings blockRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.blockSettings().getRetrySettings(), serviceRetry);
@@ -192,16 +187,6 @@ public class EchoSpringAutoConfiguration {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace(
             "Configured method-level retry settings for simplePagedExpand from properties.");
-      }
-    }
-    Retry waitRetry = clientProperties.getWaitRetry();
-    if (waitRetry != null) {
-      RetrySettings waitRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.waitSettings().getRetrySettings(), waitRetry);
-      clientSettingsBuilder.waitSettings().setRetrySettings(waitRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for wait from properties.");
       }
     }
     Retry blockRetry = clientProperties.getBlockRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -129,26 +129,6 @@ public class EchoSpringAutoConfiguration {
               clientSettingsBuilder.echoSettings().getRetrySettings(), serviceRetry);
       clientSettingsBuilder.echoSettings().setRetrySettings(echoRetrySettings);
 
-      RetrySettings expandRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.expandSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.expandSettings().setRetrySettings(expandRetrySettings);
-
-      RetrySettings collectRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.collectSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.collectSettings().setRetrySettings(collectRetrySettings);
-
-      RetrySettings chatRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.chatSettings().setRetrySettings(chatRetrySettings);
-
-      RetrySettings chatAgainRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatAgainSettings().getRetrySettings(), serviceRetry);
-      clientSettingsBuilder.chatAgainSettings().setRetrySettings(chatAgainRetrySettings);
-
       RetrySettings pagedExpandRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.pagedExpandSettings().getRetrySettings(), serviceRetry);
@@ -188,46 +168,6 @@ public class EchoSpringAutoConfiguration {
       clientSettingsBuilder.echoSettings().setRetrySettings(echoRetrySettings);
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("Configured method-level retry settings for echo from properties.");
-      }
-    }
-    Retry expandRetry = clientProperties.getExpandRetry();
-    if (expandRetry != null) {
-      RetrySettings expandRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.expandSettings().getRetrySettings(), expandRetry);
-      clientSettingsBuilder.expandSettings().setRetrySettings(expandRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for expand from properties.");
-      }
-    }
-    Retry collectRetry = clientProperties.getCollectRetry();
-    if (collectRetry != null) {
-      RetrySettings collectRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.collectSettings().getRetrySettings(), collectRetry);
-      clientSettingsBuilder.collectSettings().setRetrySettings(collectRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for collect from properties.");
-      }
-    }
-    Retry chatRetry = clientProperties.getChatRetry();
-    if (chatRetry != null) {
-      RetrySettings chatRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatSettings().getRetrySettings(), chatRetry);
-      clientSettingsBuilder.chatSettings().setRetrySettings(chatRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for chat from properties.");
-      }
-    }
-    Retry chatAgainRetry = clientProperties.getChatAgainRetry();
-    if (chatAgainRetry != null) {
-      RetrySettings chatAgainRetrySettings =
-          RetryUtil.updateRetrySettings(
-              clientSettingsBuilder.chatAgainSettings().getRetrySettings(), chatAgainRetry);
-      clientSettingsBuilder.chatAgainSettings().setRetrySettings(chatAgainRetrySettings);
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Configured method-level retry settings for chatAgain from properties.");
       }
     }
     Retry pagedExpandRetry = clientProperties.getPagedExpandRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
@@ -46,26 +46,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry echoRetry;
   /**
-   * Allow override of retry settings at method-level for expand. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry expandRetry;
-  /**
-   * Allow override of retry settings at method-level for collect. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry collectRetry;
-  /**
-   * Allow override of retry settings at method-level for chat. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry chatRetry;
-  /**
-   * Allow override of retry settings at method-level for chatAgain. If defined, this takes
-   * precedence over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry chatAgainRetry;
-  /**
    * Allow override of retry settings at method-level for pagedExpand. If defined, this takes
    * precedence over service-level retry configurations for that RPC method.
    */
@@ -126,38 +106,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setEchoRetry(Retry echoRetry) {
     this.echoRetry = echoRetry;
-  }
-
-  public Retry getExpandRetry() {
-    return this.expandRetry;
-  }
-
-  public void setExpandRetry(Retry expandRetry) {
-    this.expandRetry = expandRetry;
-  }
-
-  public Retry getCollectRetry() {
-    return this.collectRetry;
-  }
-
-  public void setCollectRetry(Retry collectRetry) {
-    this.collectRetry = collectRetry;
-  }
-
-  public Retry getChatRetry() {
-    return this.chatRetry;
-  }
-
-  public void setChatRetry(Retry chatRetry) {
-    this.chatRetry = chatRetry;
-  }
-
-  public Retry getChatAgainRetry() {
-    return this.chatAgainRetry;
-  }
-
-  public void setChatAgainRetry(Retry chatAgainRetry) {
-    this.chatAgainRetry = chatAgainRetry;
   }
 
   public Retry getPagedExpandRetry() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
@@ -56,11 +56,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry simplePagedExpandRetry;
   /**
-   * Allow override of retry settings at method-level for wait. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry waitRetry;
-  /**
    * Allow override of retry settings at method-level for block. If defined, this takes precedence
    * over service-level retry configurations for that RPC method.
    */
@@ -122,14 +117,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setSimplePagedExpandRetry(Retry simplePagedExpandRetry) {
     this.simplePagedExpandRetry = simplePagedExpandRetry;
-  }
-
-  public Retry getWaitRetry() {
-    return this.waitRetry;
-  }
-
-  public void setWaitRetry(Retry waitRetry) {
-    this.waitRetry = waitRetry;
   }
 
   public Retry getBlockRetry() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpc.golden
@@ -26,26 +26,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry echoRetry;
   /**
-   * Allow override of retry settings at method-level for expand. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry expandRetry;
-  /**
-   * Allow override of retry settings at method-level for collect. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry collectRetry;
-  /**
-   * Allow override of retry settings at method-level for chat. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry chatRetry;
-  /**
-   * Allow override of retry settings at method-level for chatAgain. If defined, this takes
-   * precedence over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry chatAgainRetry;
-  /**
    * Allow override of retry settings at method-level for pagedExpand. If defined, this takes
    * precedence over service-level retry configurations for that RPC method.
    */
@@ -106,38 +86,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setEchoRetry(Retry echoRetry) {
     this.echoRetry = echoRetry;
-  }
-
-  public Retry getExpandRetry() {
-    return this.expandRetry;
-  }
-
-  public void setExpandRetry(Retry expandRetry) {
-    this.expandRetry = expandRetry;
-  }
-
-  public Retry getCollectRetry() {
-    return this.collectRetry;
-  }
-
-  public void setCollectRetry(Retry collectRetry) {
-    this.collectRetry = collectRetry;
-  }
-
-  public Retry getChatRetry() {
-    return this.chatRetry;
-  }
-
-  public void setChatRetry(Retry chatRetry) {
-    this.chatRetry = chatRetry;
-  }
-
-  public Retry getChatAgainRetry() {
-    return this.chatAgainRetry;
-  }
-
-  public void setChatAgainRetry(Retry chatAgainRetry) {
-    this.chatAgainRetry = chatAgainRetry;
   }
 
   public Retry getPagedExpandRetry() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpc.golden
@@ -36,11 +36,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry simplePagedExpandRetry;
   /**
-   * Allow override of retry settings at method-level for wait. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry waitRetry;
-  /**
    * Allow override of retry settings at method-level for block. If defined, this takes precedence
    * over service-level retry configurations for that RPC method.
    */
@@ -102,14 +97,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setSimplePagedExpandRetry(Retry simplePagedExpandRetry) {
     this.simplePagedExpandRetry = simplePagedExpandRetry;
-  }
-
-  public Retry getWaitRetry() {
-    return this.waitRetry;
-  }
-
-  public void setWaitRetry(Retry waitRetry) {
-    this.waitRetry = waitRetry;
   }
 
   public Retry getBlockRetry() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpcRest.golden
@@ -28,26 +28,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry echoRetry;
   /**
-   * Allow override of retry settings at method-level for expand. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry expandRetry;
-  /**
-   * Allow override of retry settings at method-level for collect. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry collectRetry;
-  /**
-   * Allow override of retry settings at method-level for chat. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry chatRetry;
-  /**
-   * Allow override of retry settings at method-level for chatAgain. If defined, this takes
-   * precedence over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry chatAgainRetry;
-  /**
    * Allow override of retry settings at method-level for pagedExpand. If defined, this takes
    * precedence over service-level retry configurations for that RPC method.
    */
@@ -116,38 +96,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setEchoRetry(Retry echoRetry) {
     this.echoRetry = echoRetry;
-  }
-
-  public Retry getExpandRetry() {
-    return this.expandRetry;
-  }
-
-  public void setExpandRetry(Retry expandRetry) {
-    this.expandRetry = expandRetry;
-  }
-
-  public Retry getCollectRetry() {
-    return this.collectRetry;
-  }
-
-  public void setCollectRetry(Retry collectRetry) {
-    this.collectRetry = collectRetry;
-  }
-
-  public Retry getChatRetry() {
-    return this.chatRetry;
-  }
-
-  public void setChatRetry(Retry chatRetry) {
-    this.chatRetry = chatRetry;
-  }
-
-  public Retry getChatAgainRetry() {
-    return this.chatAgainRetry;
-  }
-
-  public void setChatAgainRetry(Retry chatAgainRetry) {
-    this.chatAgainRetry = chatAgainRetry;
   }
 
   public Retry getPagedExpandRetry() {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringPropertiesGrpcRest.golden
@@ -38,11 +38,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry simplePagedExpandRetry;
   /**
-   * Allow override of retry settings at method-level for wait. If defined, this takes precedence
-   * over service-level retry configurations for that RPC method.
-   */
-  @NestedConfigurationProperty private Retry waitRetry;
-  /**
    * Allow override of retry settings at method-level for block. If defined, this takes precedence
    * over service-level retry configurations for that RPC method.
    */
@@ -112,14 +107,6 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setSimplePagedExpandRetry(Retry simplePagedExpandRetry) {
     this.simplePagedExpandRetry = simplePagedExpandRetry;
-  }
-
-  public Retry getWaitRetry() {
-    return this.waitRetry;
-  }
-
-  public void setWaitRetry(Retry waitRetry) {
-    this.waitRetry = waitRetry;
   }
 
   public Retry getBlockRetry() {


### PR DESCRIPTION
This PR is a patch for the `RetrySettings` configuration issue discovered in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1407#issuecomment-1363280649. It excludes streaming and LRO methods from retry configuration through spring properties for now. 
- Ref: [UnaryCallSettings](https://github.com/googleapis/gax-java/blob/main/gax/src/main/java/com/google/api/gax/rpc/UnaryCallSettings.java) vs. [StreamingCallSettings](https://github.com/googleapis/gax-java/blob/main/gax/src/main/java/com/google/api/gax/rpc/StreamingCallSettings.java); how gapic-generator [configures default retry settings per-method](https://github.com/googleapis/gapic-generator-java/blob/0fb58e0b459a5dea109afd8b41da57e48728deb3/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java#L1447-L1497)
 - Future method type investigation/support needed to align with gapic generator logic: 
      - LRO methods (through [OperationCallSettings](https://github.com/googleapis/gax-java/blob/main/gax/src/main/java/com/google/api/gax/rpc/OperationCallSettings.java))
      - Server streaming methods (through [ServerStreamingCallSettings](https://github.com/googleapis/gax-java/blob/main/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingCallSettings.java))