### PR TITLE
fix(spring): fix method javadoc missing @param and @return

### DIFF
--- a/src/main/java/com/google/api/generator/engine/ast/JavaDocComment.java
+++ b/src/main/java/com/google/api/generator/engine/ast/JavaDocComment.java
@@ -52,6 +52,7 @@ public abstract class JavaDocComment implements Comment {
     String throwsDescription = null;
     String deprecated = null;
     List<String> paramsList = new ArrayList<>();
+    String returnText = null;
     List<String> componentsList = new ArrayList<>();
     // Private accessor, set complete and consolidated comment.
     abstract Builder setComment(String comment);
@@ -66,6 +67,11 @@ public abstract class JavaDocComment implements Comment {
 
     public Builder setDeprecated(String deprecatedText) {
       deprecated = deprecatedText;
+      return this;
+    }
+
+    public Builder setReturn(String returnDescription) {
+      returnText = returnDescription;
       return this;
     }
 
@@ -130,12 +136,16 @@ public abstract class JavaDocComment implements Comment {
           && Strings.isNullOrEmpty(throwsDescription)
           && Strings.isNullOrEmpty(deprecated)
           && paramsList.isEmpty()
+          && Strings.isNullOrEmpty(returnText)
           && componentsList.isEmpty();
     }
 
     public JavaDocComment build() {
-      // @param, @throws and @deprecated should always get printed at the end.
+      // @param, @return, @throws and @deprecated should always get printed at the end.
       componentsList.addAll(paramsList);
+      if (!Strings.isNullOrEmpty(returnText)) {
+        componentsList.add(String.format("@return %s", returnText));
+      }
       if (!Strings.isNullOrEmpty(throwsType)) {
         componentsList.add(
             String.format("@throws %s %s", throwsType, HtmlEscaper.process(throwsDescription)));

--- a/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
@@ -41,8 +41,10 @@ public class SpringAutoconfigCommentComposer {
           + "configuration data files.";
 
   public static final String TRANSPORT_CHANNEL_PROVIDER_GENERAL_DESCRIPTION =
-      "Returns the default channel provider. The default is gRPC and will default to it unless the "
+      "Provides a default channel provider bean. The default is gRPC and will default to it unless the "
           + "useRest option is provided to use HTTP transport instead";
+  public static final String TRANSPORT_CHANNEL_PROVIDER_RETURN =
+      "Returns the default channel provider.";
   public static final String CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION =
       "Provides a %sSettings bean configured to "
           + "use the default credentials provider (obtained with %sCredentials()) and its default "
@@ -54,9 +56,13 @@ public class SpringAutoconfigCommentComposer {
       "Retry settings are also configured from service-level and method-level properties specified in %s. "
           + "Method-level properties will take precedence over service-level properties if available, "
           + "and client library defaults will be used if neither are specified.";
+  public static final String CLIENT_SETTINGS_BEAN_RETURN_STATEMENT =
+      "a {@link %sSettings} bean configured with {@link TransportChannelProvider} bean.";
 
   public static final String CLIENT_BEAN_GENERAL_DESCRIPTION =
       "Provides a %sClient bean configured with %sSettings.";
+  public static final String CLIENT_BEAN_RETURN_STATEMENT =
+      "a {@link %sClient} bean configured with {@link %sSettings}";
 
   public SpringAutoconfigCommentComposer() {}
 
@@ -88,6 +94,7 @@ public class SpringAutoconfigCommentComposer {
     return CommentStatement.withComment(
         JavaDocComment.builder()
             .addParagraph(TRANSPORT_CHANNEL_PROVIDER_GENERAL_DESCRIPTION)
+            .setReturn(TRANSPORT_CHANNEL_PROVIDER_RETURN)
             .build());
   }
 
@@ -104,13 +111,22 @@ public class SpringAutoconfigCommentComposer {
                     channelProviderName))
             .addParagraph(
                 String.format(CLIENT_SETTINGS_BEAN_RETRY_SETTINGS_DESCRIPTION, propertiesClazzName))
+            .addParam(
+                "defaultTransportChannelProvider",
+                "TransportChannelProvider to use in the settings.")
+            .setReturn(String.format(CLIENT_SETTINGS_BEAN_RETURN_STATEMENT, serviceName))
             .build());
   }
 
   public static CommentStatement createClientBeanComment(String serviceName) {
+    String lowerServiceName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceName);
     return CommentStatement.withComment(
         JavaDocComment.builder()
             .addParagraph(String.format(CLIENT_BEAN_GENERAL_DESCRIPTION, serviceName, serviceName))
+            .addParam(
+                String.format("%sSettings", lowerServiceName),
+                "settings to configure an instance of client bean.")
+            .setReturn(String.format(CLIENT_BEAN_RETURN_STATEMENT, serviceName, serviceName))
             .build());
   }
 }

--- a/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
@@ -41,10 +41,10 @@ public class SpringAutoconfigCommentComposer {
           + "configuration data files.";
 
   public static final String TRANSPORT_CHANNEL_PROVIDER_GENERAL_DESCRIPTION =
-      "Provides a default channel provider bean. The default is gRPC and will default to it unless the "
+      "Provides a default transport channel provider bean. The default is gRPC and will default to it unless the "
           + "useRest option is provided to use HTTP transport instead";
   public static final String TRANSPORT_CHANNEL_PROVIDER_RETURN =
-      "Returns the default channel provider.";
+      "a default transport channel provider.";
   public static final String CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION =
       "Provides a %sSettings bean configured to "
           + "use the default credentials provider (obtained with %sCredentials()) and its default "

--- a/src/test/java/com/google/api/generator/engine/ast/JavaDocCommentTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/JavaDocCommentTest.java
@@ -179,6 +179,30 @@ public class JavaDocCommentTest {
   }
 
   @Test
+  public void createJavaDocComment_paramsAndReturn() {
+    // No matter how many times or order `setThrows` and `setDeprecated` are called,
+    // only one @throws and @deprecated will be printed.
+    String paramName1 = "shelfName";
+    String paramDescription1 = "The name of the shelf where books are published to.";
+    String paramName2 = "shelf";
+    String paramDescription2 = "The shelf to create.";
+    String returnText = "This is the method return text.";
+
+    JavaDocComment javaDocComment =
+        JavaDocComment.builder()
+            .addParam(paramName1, paramDescription1)
+            .addParam(paramName2, paramDescription2)
+            .setReturn(returnText)
+            .build();
+    String expected =
+        LineFormatter.lines(
+            "@param shelfName The name of the shelf where books are published to.\n",
+            "@param shelf The shelf to create.\n",
+            "@return This is the method return text.");
+    assertEquals(expected, javaDocComment.comment());
+  }
+
+  @Test
   public void createJavaDocComment_allComponents() {
     // No matter what order `setThrows`, `setDeprecated` are called,
     // They will be printed at the end. And `@param` should be grouped,
@@ -190,6 +214,7 @@ public class JavaDocCommentTest {
     String paramDescription1 = "The name of the shelf where books are published to.";
     String paramName2 = "shelf";
     String paramDescription2 = "The shelf to create.";
+    String returnText = "This is the method return text.";
     String paragraph1 =
         "This class provides the ability to make remote calls to the backing service through"
             + " method calls that map to API methods. Sample code to get started:";
@@ -210,6 +235,7 @@ public class JavaDocCommentTest {
             .addParagraph(paragraph2)
             .addOrderedList(orderedList)
             .addParam(paramName2, paramDescription2)
+            .setReturn(returnText)
             .build();
     String expected =
         LineFormatter.lines(
@@ -225,6 +251,7 @@ public class JavaDocCommentTest {
             "</ol>\n",
             "@param shelfName The name of the shelf where books are published to.\n",
             "@param shelf The shelf to create.\n",
+            "@return This is the method return text.\n",
             "@throws com.google.api.gax.rpc.ApiException if the remote call fails.\n",
             "@deprecated Use the {@link ArchivedBookName} class instead.");
     assertEquals(expected, javaDocComment.comment());

--- a/src/test/java/com/google/api/generator/engine/ast/JavaDocCommentTest.java
+++ b/src/test/java/com/google/api/generator/engine/ast/JavaDocCommentTest.java
@@ -180,8 +180,6 @@ public class JavaDocCommentTest {
 
   @Test
   public void createJavaDocComment_paramsAndReturn() {
-    // No matter how many times or order `setThrows` and `setDeprecated` are called,
-    // only one @throws and @deprecated will be printed.
     String paramName1 = "shelfName";
     String paramDescription1 = "The name of the shelf where books are published to.";
     String paramName2 = "shelf";

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -85,10 +85,10 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a default channel provider bean. The default is gRPC and will default to it unless the
-   * useRest option is provided to use HTTP transport instead
+   * Provides a default transport channel provider bean. The default is gRPC and will default to it
+   * unless the useRest option is provided to use HTTP transport instead
    *
-   * @return Returns the default channel provider.
+   * @return a default transport channel provider.
    */
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -85,8 +85,10 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Returns the default channel provider. The default is gRPC and will default to it unless the
+   * Provides a default channel provider bean. The default is gRPC and will default to it unless the
    * useRest option is provided to use HTTP transport instead
+   *
+   * @return Returns the default channel provider.
    */
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
@@ -104,6 +106,9 @@ public class EchoSpringAutoConfiguration {
    * <p>Retry settings are also configured from service-level and method-level properties specified
    * in EchoSpringProperties. Method-level properties will take precedence over service-level
    * properties if available, and client library defaults will be used if neither are specified.
+   *
+   * @param defaultTransportChannelProvider TransportChannelProvider to use in the settings.
+   * @return a {@link EchoSettings} bean configured with {@link TransportChannelProvider} bean.
    */
   @Bean
   @ConditionalOnMissingBean
@@ -302,7 +307,12 @@ public class EchoSpringAutoConfiguration {
     return clientSettingsBuilder.build();
   }
 
-  /** Provides a EchoClient bean configured with EchoSettings. */
+  /**
+   * Provides a EchoClient bean configured with EchoSettings.
+   *
+   * @param echoSettings settings to configure an instance of client bean.
+   * @return a {@link EchoClient} bean configured with {@link EchoSettings}
+   */
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(EchoSettings echoSettings) throws IOException {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -65,10 +65,10 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a default channel provider bean. The default is gRPC and will default to it unless the
-   * useRest option is provided to use HTTP transport instead
+   * Provides a default transport channel provider bean. The default is gRPC and will default to it
+   * unless the useRest option is provided to use HTTP transport instead
    *
-   * @return Returns the default channel provider.
+   * @return a default transport channel provider.
    */
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -65,8 +65,10 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Returns the default channel provider. The default is gRPC and will default to it unless the
+   * Provides a default channel provider bean. The default is gRPC and will default to it unless the
    * useRest option is provided to use HTTP transport instead
+   *
+   * @return Returns the default channel provider.
    */
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
@@ -84,6 +86,9 @@ public class EchoSpringAutoConfiguration {
    * <p>Retry settings are also configured from service-level and method-level properties specified
    * in EchoSpringProperties. Method-level properties will take precedence over service-level
    * properties if available, and client library defaults will be used if neither are specified.
+   *
+   * @param defaultTransportChannelProvider TransportChannelProvider to use in the settings.
+   * @return a {@link EchoSettings} bean configured with {@link TransportChannelProvider} bean.
    */
   @Bean
   @ConditionalOnMissingBean
@@ -282,7 +287,12 @@ public class EchoSpringAutoConfiguration {
     return clientSettingsBuilder.build();
   }
 
-  /** Provides a EchoClient bean configured with EchoSettings. */
+  /**
+   * Provides a EchoClient bean configured with EchoSettings.
+   *
+   * @param echoSettings settings to configure an instance of client bean.
+   * @return a {@link EchoClient} bean configured with {@link EchoSettings}
+   */
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(EchoSettings echoSettings) throws IOException {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -66,8 +66,10 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Returns the default channel provider. The default is gRPC and will default to it unless the
+   * Provides a default channel provider bean. The default is gRPC and will default to it unless the
    * useRest option is provided to use HTTP transport instead
+   *
+   * @return Returns the default channel provider.
    */
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
@@ -85,6 +87,9 @@ public class EchoSpringAutoConfiguration {
    * <p>Retry settings are also configured from service-level and method-level properties specified
    * in EchoSpringProperties. Method-level properties will take precedence over service-level
    * properties if available, and client library defaults will be used if neither are specified.
+   *
+   * @param defaultTransportChannelProvider TransportChannelProvider to use in the settings.
+   * @return a {@link EchoSettings} bean configured with {@link TransportChannelProvider} bean.
    */
   @Bean
   @ConditionalOnMissingBean
@@ -290,7 +295,12 @@ public class EchoSpringAutoConfiguration {
     return clientSettingsBuilder.build();
   }
 
-  /** Provides a EchoClient bean configured with EchoSettings. */
+  /**
+   * Provides a EchoClient bean configured with EchoSettings.
+   *
+   * @param echoSettings settings to configure an instance of client bean.
+   * @return a {@link EchoClient} bean configured with {@link EchoSettings}
+   */
   @Bean
   @ConditionalOnMissingBean
   public EchoClient echoClient(EchoSettings echoSettings) throws IOException {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -66,10 +66,10 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a default channel provider bean. The default is gRPC and will default to it unless the
-   * useRest option is provided to use HTTP transport instead
+   * Provides a default transport channel provider bean. The default is gRPC and will default to it
+   * unless the useRest option is provided to use HTTP transport instead
    *
-   * @return Returns the default channel provider.
+   * @return a default transport channel provider.
    */
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")


### PR DESCRIPTION
Adds `@param` and `@return` to method javadoc comments in generated autoconfiguration classes. 
Also adding a change to `JavaDocComment` to enable `@return` in comment. (this change in 537e33c2cdaf5e79d29f12fe12d372e1f75a525d can be copied to main branch of `gapic-generator-java` if useful.)