### PR TITLE
fix(spring): use newHttpJsonBuilder in settings bean for REST transport option

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -484,7 +484,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     if (hasRestOption) {
       // For GRPC+REST libraries
       // LanguageServiceSettings.Builder clientSettingsBuilder;
-      //    if (clientProperties.isUseRest()) {
+      //    if (this.clientProperties.isUseRest()) {
       //      clientSettingsBuilder = LanguageServiceSettings.newHttpJsonBuilder();
       //    } else {
       //      clientSettingsBuilder = LanguageServiceSettings.newBuilder();

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -369,19 +369,6 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .setReturnType(STATIC_TYPES.get("TransportChannelProvider"))
             .build();
 
-    // LanguageServiceSettings.defaultHttpJsonTransportProviderBuilder().build()
-    Expr defaultTransportProviderExprChain =
-        MethodInvocationExpr.builder()
-            .setStaticReferenceType(types.get("ServiceSettings"))
-            .setMethodName("defaultHttpJsonTransportProviderBuilder")
-            .build();
-    MethodInvocationExpr defaultHttpJsonTransportProviderExpr =
-        MethodInvocationExpr.builder()
-            .setExprReferenceExpr(defaultTransportProviderExprChain)
-            .setMethodName("build")
-            .setReturnType(STATIC_TYPES.get("InstantiatingHttpJsonChannelProvider"))
-            .build();
-
     if (hasRestOption) {
       //      if (this.clientProperties.isUseRest()) {
       //        return LanguageServiceSettings.defaultHttpJsonTransportProviderBuilder().build();
@@ -402,6 +389,19 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
               .setMethodName("getUseRest")
               .setReturnType(TypeNode.BOOLEAN)
               .setExprReferenceExpr(thisClientPropertiesVarExpr)
+              .build();
+
+      // LanguageServiceSettings.defaultHttpJsonTransportProviderBuilder().build()
+      Expr defaultTransportProviderExprChain =
+          MethodInvocationExpr.builder()
+              .setStaticReferenceType(types.get("ServiceSettings"))
+              .setMethodName("defaultHttpJsonTransportProviderBuilder")
+              .build();
+      MethodInvocationExpr defaultHttpJsonTransportProviderExpr =
+          MethodInvocationExpr.builder()
+              .setExprReferenceExpr(defaultTransportProviderExprChain)
+              .setMethodName("build")
+              .setReturnType(STATIC_TYPES.get("InstantiatingHttpJsonChannelProvider"))
               .build();
 
       IfStatement returnHttpJsonTransportChannelProviderStatement =

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -108,11 +108,19 @@ public class EchoSpringAutoConfiguration {
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
-    EchoSettings.Builder clientSettingsBuilder =
-        EchoSettings.newBuilder()
-            .setCredentialsProvider(this.credentialsProvider)
-            .setTransportChannelProvider(defaultTransportChannelProvider)
-            .setHeaderProvider(this.userAgentHeaderProvider());
+    EchoSettings.Builder clientSettingsBuilder;
+    if (this.clientProperties.getUseRest()) {
+      clientSettingsBuilder = EchoSettings.newHttpJsonBuilder();
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("Using REST (HTTP/JSON) transport.");
+      }
+    } else {
+      clientSettingsBuilder = EchoSettings.newBuilder();
+    }
+    clientSettingsBuilder
+        .setCredentialsProvider(this.credentialsProvider)
+        .setTransportChannelProvider(defaultTransportChannelProvider)
+        .setHeaderProvider(this.userAgentHeaderProvider());
     if (this.clientProperties.getQuotaProjectId() != null) {
       clientSettingsBuilder.setQuotaProjectId(this.clientProperties.getQuotaProjectId());
       if (LOGGER.isTraceEnabled()) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -108,15 +108,7 @@ public class EchoSpringAutoConfiguration {
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
-    EchoSettings.Builder clientSettingsBuilder;
-    if (this.clientProperties.getUseRest()) {
-      clientSettingsBuilder = EchoSettings.newHttpJsonBuilder();
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Using REST (HTTP/JSON) transport.");
-      }
-    } else {
-      clientSettingsBuilder = EchoSettings.newBuilder();
-    }
+    EchoSettings.Builder clientSettingsBuilder = EchoSettings.newBuilder();
     clientSettingsBuilder
         .setCredentialsProvider(this.credentialsProvider)
         .setTransportChannelProvider(defaultTransportChannelProvider)

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -88,11 +88,19 @@ public class EchoSpringAutoConfiguration {
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
-    EchoSettings.Builder clientSettingsBuilder =
-        EchoSettings.newBuilder()
-            .setCredentialsProvider(this.credentialsProvider)
-            .setTransportChannelProvider(defaultTransportChannelProvider)
-            .setHeaderProvider(this.userAgentHeaderProvider());
+    EchoSettings.Builder clientSettingsBuilder;
+    if (this.clientProperties.getUseRest()) {
+      clientSettingsBuilder = EchoSettings.newHttpJsonBuilder();
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("Using REST (HTTP/JSON) transport.");
+      }
+    } else {
+      clientSettingsBuilder = EchoSettings.newBuilder();
+    }
+    clientSettingsBuilder
+        .setCredentialsProvider(this.credentialsProvider)
+        .setTransportChannelProvider(defaultTransportChannelProvider)
+        .setHeaderProvider(this.userAgentHeaderProvider());
     if (this.clientProperties.getQuotaProjectId() != null) {
       clientSettingsBuilder.setQuotaProjectId(this.clientProperties.getQuotaProjectId());
       if (LOGGER.isTraceEnabled()) {

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -88,15 +88,7 @@ public class EchoSpringAutoConfiguration {
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
-    EchoSettings.Builder clientSettingsBuilder;
-    if (this.clientProperties.getUseRest()) {
-      clientSettingsBuilder = EchoSettings.newHttpJsonBuilder();
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Using REST (HTTP/JSON) transport.");
-      }
-    } else {
-      clientSettingsBuilder = EchoSettings.newBuilder();
-    }
+    EchoSettings.Builder clientSettingsBuilder = EchoSettings.newBuilder();
     clientSettingsBuilder
         .setCredentialsProvider(this.credentialsProvider)
         .setTransportChannelProvider(defaultTransportChannelProvider)

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -69,6 +69,10 @@ public class EchoSpringAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
+    if (this.clientProperties.getUseRest()) {
+      clientSettingsBuilder.setTransportChannelProvider(
+          EchoSettings.defaultHttpJsonTransportProviderBuilder().build());
+    }
     return EchoSettings.defaultTransportChannelProvider();
   }
 

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -93,11 +93,19 @@ public class EchoSpringAutoConfiguration {
       @Qualifier("defaultEchoTransportChannelProvider")
           TransportChannelProvider defaultTransportChannelProvider)
       throws IOException {
-    EchoSettings.Builder clientSettingsBuilder =
-        EchoSettings.newBuilder()
-            .setCredentialsProvider(this.credentialsProvider)
-            .setTransportChannelProvider(defaultTransportChannelProvider)
-            .setHeaderProvider(this.userAgentHeaderProvider());
+    EchoSettings.Builder clientSettingsBuilder;
+    if (this.clientProperties.getUseRest()) {
+      clientSettingsBuilder = EchoSettings.newHttpJsonBuilder();
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("Using REST (HTTP/JSON) transport.");
+      }
+    } else {
+      clientSettingsBuilder = EchoSettings.newBuilder();
+    }
+    clientSettingsBuilder
+        .setCredentialsProvider(this.credentialsProvider)
+        .setTransportChannelProvider(defaultTransportChannelProvider)
+        .setHeaderProvider(this.userAgentHeaderProvider());
     if (this.clientProperties.getQuotaProjectId() != null) {
       clientSettingsBuilder.setQuotaProjectId(this.clientProperties.getQuotaProjectId());
       if (LOGGER.isTraceEnabled()) {
@@ -117,13 +125,6 @@ public class EchoSpringAutoConfiguration {
         LOGGER.trace(
             "Background executor thread count is "
                 + this.clientProperties.getExecutorThreadCount());
-      }
-    }
-    if (this.clientProperties.getUseRest()) {
-      clientSettingsBuilder.setTransportChannelProvider(
-          EchoSettings.defaultHttpJsonTransportProviderBuilder().build());
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Using HTTP transport channel");
       }
     }
     Retry serviceRetry = clientProperties.getRetry();

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -70,8 +70,7 @@ public class EchoSpringAutoConfiguration {
   @ConditionalOnMissingBean(name = "defaultEchoTransportChannelProvider")
   public TransportChannelProvider defaultEchoTransportChannelProvider() {
     if (this.clientProperties.getUseRest()) {
-      clientSettingsBuilder.setTransportChannelProvider(
-          EchoSettings.defaultHttpJsonTransportProviderBuilder().build());
+      return EchoSettings.defaultHttpJsonTransportProviderBuilder().build();
     }
     return EchoSettings.defaultTransportChannelProvider();
   }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1364#discussion_r1062017855. 

Updated behaviour (see #1078) for when `Transport.REST_GRPC` and `useRest = true` (through properties):
- The `ServiceSettings` bean uses `newHttpJsonBuilder`
- The `TransportChannelProvider` bean definition returns `defaultHttpJsonTransportProviderBuilder`
