### PR TITLE
fix: Rename gapic-parent-pom to groupId to google.cloud.api

### DIFF
--- a/api-common-java/pom.xml
+++ b/api-common-java/pom.xml
@@ -10,7 +10,7 @@
     <description>Common utilities for Google APIs in Java</description>
 
     <parent>
-        <groupId>com.google.cloud</groupId>
+        <groupId>com.google.api</groupId>
         <artifactId>gapic-generator-java-pom-parent</artifactId>
         <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
         <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -13,7 +13,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.cloud</groupId>
+    <groupId>com.google.api</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.cloud</groupId>
+  <groupId>com.google.api</groupId>
   <artifactId>gapic-generator-java-pom-parent</artifactId>
   <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
   <packaging>pom</packaging>

--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -21,7 +21,7 @@
   </properties>
 
   <parent>
-    <groupId>com.google.cloud</groupId>
+    <groupId>com.google.api</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/gax-java/pom.xml
+++ b/gax-java/pom.xml
@@ -9,7 +9,7 @@
   <description>Google Api eXtensions for Java (Parent)</description>
 
   <parent>
-    <groupId>com.google.cloud</groupId>
+    <groupId>com.google.api</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -11,7 +11,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.cloud</groupId>
+    <groupId>com.google.api</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -11,7 +11,7 @@
   </description>
 
   <parent>
-    <groupId>com.google.cloud</groupId>
+    <groupId>com.google.api</groupId>
     <artifactId>gapic-generator-java-pom-parent</artifactId>
     <version>2.13.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
     <relativePath>../gapic-generator-java-pom-parent</relativePath>


### PR DESCRIPTION
The gapic-generator powers non-Cloud code generation. It may make sense for the groupId to be under `com.google.api` instead of `com.google.cloud` and for the gapic monorepo related modules to have a consistent groupId.