### PR TITLE
fix(spring): switch camelcase conversion logic to use JavaStyle

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -111,7 +111,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     Expr thisExpr = ValueExpr.withValue(ThisObjectValue.withType(dynamicTypes.get(className)));
     Transport transport = context.transport();
     boolean hasRestOption = transport.equals(Transport.GRPC_REST);
-    String serviceSettingsMethodName = JavaStyle.toLowerCamelCase(service.name() + "Settings");
+    String serviceSettingsMethodName = JavaStyle.toLowerCamelCase(service.name()) + "Settings";
 
     ClassDefinition classDef =
         ClassDefinition.builder()

--- a/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringPropertiesClassComposer.java
@@ -43,6 +43,7 @@ import com.google.api.generator.gapic.model.GapicServiceConfig;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
 import com.google.api.generator.gapic.model.Transport;
+import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.api.generator.spring.composer.comment.SpringPropertiesCommentComposer;
 import com.google.api.generator.spring.utils.ComposerUtils;
 import com.google.api.generator.spring.utils.Utils;
@@ -172,8 +173,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     statements.add(retryPropertiesStatement);
 
     for (Method method : Utils.getMethodsForRetryConfiguration(service)) {
-      String methodNameLowerCamel =
-          CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name());
+      String methodNameLowerCamel = JavaStyle.toLowerCamelCase(method.name());
       String methodPropertiesVarName = methodNameLowerCamel + "Retry";
       ExprStatement methodRetryPropertiesStatement =
           ComposerUtils.createMemberVarStatement(
@@ -217,8 +217,7 @@ public class SpringPropertiesClassComposer implements ClassComposer {
     methodDefinitions.add(createSetterMethod(thisClassType, "retry", types.get("Retry")));
 
     for (Method method : Utils.getMethodsForRetryConfiguration(service)) {
-      String methodPropertiesVarName =
-          CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, method.name()) + "Retry";
+      String methodPropertiesVarName = JavaStyle.toLowerCamelCase(method.name()) + "Retry";
       methodDefinitions.add(
           createGetterMethod(thisClassType, methodPropertiesVarName, types.get("Retry"), null));
       methodDefinitions.add(

--- a/src/main/java/com/google/api/generator/spring/utils/Utils.java
+++ b/src/main/java/com/google/api/generator/spring/utils/Utils.java
@@ -18,6 +18,7 @@ import com.google.api.generator.gapic.composer.store.TypeStore;
 import com.google.api.generator.gapic.model.GapicContext;
 import com.google.api.generator.gapic.model.Method;
 import com.google.api.generator.gapic.model.Service;
+import com.google.api.generator.gapic.utils.JavaStyle;
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 import java.util.List;
@@ -30,11 +31,11 @@ public class Utils {
   private static final String BRAND_NAME = "spring.cloud.gcp";
 
   public static String getServiceAutoConfigurationClassName(Service service) {
-    return service.name() + "SpringAutoConfiguration";
+    return JavaStyle.toUpperCamelCase(service.name()) + "SpringAutoConfiguration";
   }
 
   public static String getServicePropertiesClassName(Service service) {
-    return service.name() + "SpringProperties";
+    return JavaStyle.toUpperCamelCase(service.name()) + "SpringProperties";
   }
 
   public static String getLibName(GapicContext context) {


### PR DESCRIPTION
This PR switches camelcase handling to use align with logic used in generating client libraries, e.g. [here](https://github.com/googleapis/gapic-generator-java/blob/8c1facf7a2ad2e42d6de490aebbb671439d4f1f2/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java#L254). However, it introduces no updates to golden tests for the spring composers, and my local test to regenerate https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1449 using this branch also showed no diff.

I think `spring-cloud-gcp` enforces stricter checkstyle rules ([fail on warning](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/a5a346600e4b123643d9a507144d9167280c8870/pom.xml#L273-L274)) than what is used for the client libraries, so a corresponding change has been made on that side to suppress this for a number of files with abbreviation handling edge cases: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1455
- Some examples of edge cases observed: [getOSPolicyAssignmentSettings](https://github.com/googleapis/google-cloud-java/blob/dedef71f600e85b1c38e7110f5ffd44bf2ba32b4/java-os-config/google-cloud-os-config/src/main/java/com/google/cloud/osconfig/v1/OsConfigZonalServiceSettings.java#L118),  [IDSSettings](https://github.com/googleapis/google-cloud-java/blob/main/java-ids/google-cloud-ids/src/main/java/com/google/cloud/ids/v1/IDSSettings.java)