### PR TITLE
chore(spring): add release-please annotations to pom template

### DIFF
--- a/src/main/java/com/google/api/generator/spring/SpringWriter.java
+++ b/src/main/java/com/google/api/generator/spring/SpringWriter.java
@@ -224,7 +224,7 @@ public class SpringWriter {
                 + "  <parent>\n"
                 + "    <groupId>com.google.cloud</groupId>\n"
                 + "    <artifactId>spring-cloud-gcp-starters</artifactId>\n"
-                + "    <version>%s</version>\n"
+                + "    <version>%s</version><!-- {x-version-update:spring-cloud-gcp:current} -->\n"
                 + "    <relativePath>../../spring-cloud-gcp-starters/pom.xml</relativePath>\n"
                 + "  </parent>\n"
                 + "  <artifactId>%s</artifactId>\n"

--- a/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
+++ b/src/test/java/com/google/api/generator/spring/goldens/SpringPackagePom.golden
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>spring-cloud-gcp-starters</artifactId>
-    <version>{{parent-version}}</version>
+    <version>{{parent-version}}</version><!-- {x-version-update:spring-cloud-gcp:current} -->
     <relativePath>../../spring-cloud-gcp-starters/pom.xml</relativePath>
   </parent>
   <artifactId>{{client-library-artifact-id}}-spring-starter</artifactId>


### PR DESCRIPTION
This enables release-please setup in `spring-cloud-gcp` to update version as needed. (Ref: [parent pom](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/0caa9b6245cb4281b8d8da7ccb9f8fa993b0b9c4/spring-cloud-gcp-starters/pom.xml#L9))