### PR TITLE
chore: add issue templates for repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Thanks for stopping by to let us know something could be better!
+
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
+Please run down the following list and make sure you've tried the usual "quick fixes":
+
+  - Search the issues already opened: https://github.com/googleapis/gapic-generator-java/issues
+  - Check for answers on StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform
+
+If you are still having issues, please include as much information as possible:
+
+#### Environment details
+
+1. Specify the API at the beginning of the title. For example, "BigQuery: ...").
+   General, Core, and Other are also allowed as types
+2. OS type and version:
+3. Java version:
+4.  version(s):
+
+#### Steps to reproduce
+
+  1. ?
+  2. ?
+
+#### Code example
+
+```java
+// example
+```
+
+#### Stack trace
+```
+Any relevant stacktrace here.
+```
+
+#### External references such as API reference guides
+
+- ?
+
+#### Any additional information below
+
+
+Following these steps guarantees the quickest resolution possible.
+
+Thanks!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this library
+
+---
+
+Thanks for stopping by to let us know something could be better!
+
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
+
+**Is your feature request related to a problem? Please describe.**
+What the problem is. Example: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+What you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Additional context**
+Any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,7 @@
+---
+name: Support request
+about: If you have a support contract with Google, please create an issue in the Google Cloud Support console.
+
+---
+
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.


### PR DESCRIPTION
Overwrites the issue templates found in https://github.com/googleapis/.github/tree/main/.github/ISSUE_TEMPLATE.