### PR TITLE
fix(spring): fix client and settings class names in comments

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -119,7 +119,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
             .setName(className)
             .setScope(ScopeNode.PUBLIC)
             .setHeaderCommentStatements(
-                SpringAutoconfigCommentComposer.createClassHeaderComments(className, serviceName))
+                SpringAutoconfigCommentComposer.createClassHeaderComments(service))
             .setStatements(
                 createMemberVariables(service, packageName, dynamicTypes, gapicServiceConfig))
             .setAnnotations(createClassAnnotations(service, dynamicTypes))
@@ -844,7 +844,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     return MethodDefinition.builder()
         .setHeaderCommentStatements(
             SpringAutoconfigCommentComposer.createSettingsBeanComment(
-                service.name(),
+                service,
                 Utils.getServicePropertiesClassName(service),
                 transportChannelProviderName))
         .setName(serviceSettingsMethodName)
@@ -945,7 +945,7 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     String methodName = JavaStyle.toLowerCamelCase(service.name()) + "Client";
     return MethodDefinition.builder()
         .setHeaderCommentStatements(
-            SpringAutoconfigCommentComposer.createClientBeanComment(service.name()))
+            SpringAutoconfigCommentComposer.createClientBeanComment(service))
         .setName(methodName)
         .setScope(ScopeNode.PUBLIC)
         .setReturnType(types.get("ServiceClient"))

--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -945,7 +945,8 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
     String methodName = JavaStyle.toLowerCamelCase(service.name()) + "Client";
     return MethodDefinition.builder()
         .setHeaderCommentStatements(
-            SpringAutoconfigCommentComposer.createClientBeanComment(service))
+            SpringAutoconfigCommentComposer.createClientBeanComment(
+                service, serviceSettingsMethodName))
         .setName(methodName)
         .setScope(ScopeNode.PUBLIC)
         .setReturnType(types.get("ServiceClient"))

--- a/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
@@ -19,7 +19,6 @@ import com.google.api.generator.engine.ast.JavaDocComment;
 import com.google.api.generator.gapic.composer.comment.CommentComposer;
 import com.google.api.generator.gapic.composer.utils.ClassNames;
 import com.google.api.generator.gapic.model.Service;
-import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 import java.util.List;
 
@@ -47,11 +46,9 @@ public class SpringAutoconfigCommentComposer {
   public static final String TRANSPORT_CHANNEL_PROVIDER_RETURN =
       "a default transport channel provider.";
   public static final String CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION =
-      "Provides a %s bean configured to "
-          + "use the default credentials provider (obtained with %sCredentials()) and its default "
-          + "transport channel provider (%s()). It also configures the quota project ID if provided. It "
-          + "will configure an executor provider in case there is more than one thread configured "
-          + "in the client ";
+      "Provides a %s bean configured to use a DefaultCredentialsProvider "
+          + "and the client library's default transport channel provider (%s()). "
+          + "It also configures the quota project ID and executor thread count, if provided through properties.";
 
   public static final String CLIENT_SETTINGS_BEAN_RETRY_SETTINGS_DESCRIPTION =
       "Retry settings are also configured from service-level and method-level properties specified in %s. "
@@ -102,14 +99,12 @@ public class SpringAutoconfigCommentComposer {
 
   public static CommentStatement createSettingsBeanComment(
       Service service, String propertiesClazzName, String channelProviderName) {
-    String credentialsBaseName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name());
     return CommentStatement.withComment(
         JavaDocComment.builder()
             .addParagraph(
                 String.format(
                     CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION,
                     ClassNames.getServiceSettingsClassName(service),
-                    credentialsBaseName,
                     channelProviderName))
             .addParagraph(
                 String.format(CLIENT_SETTINGS_BEAN_RETRY_SETTINGS_DESCRIPTION, propertiesClazzName))
@@ -123,8 +118,8 @@ public class SpringAutoconfigCommentComposer {
             .build());
   }
 
-  public static CommentStatement createClientBeanComment(Service service) {
-    String lowerServiceName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name());
+  public static CommentStatement createClientBeanComment(
+      Service service, String serviceSettingsMethodName) {
     return CommentStatement.withComment(
         JavaDocComment.builder()
             .addParagraph(
@@ -133,8 +128,7 @@ public class SpringAutoconfigCommentComposer {
                     ClassNames.getServiceClientClassName(service),
                     ClassNames.getServiceSettingsClassName(service)))
             .addParam(
-                String.format("%sSettings", lowerServiceName),
-                "settings to configure an instance of client bean.")
+                serviceSettingsMethodName, "settings to configure an instance of client bean.")
             .setReturn(
                 String.format(
                     CLIENT_BEAN_RETURN_STATEMENT,

--- a/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/comment/SpringAutoconfigCommentComposer.java
@@ -17,14 +17,15 @@ package com.google.api.generator.spring.composer.comment;
 import com.google.api.generator.engine.ast.CommentStatement;
 import com.google.api.generator.engine.ast.JavaDocComment;
 import com.google.api.generator.gapic.composer.comment.CommentComposer;
+import com.google.api.generator.gapic.composer.utils.ClassNames;
+import com.google.api.generator.gapic.model.Service;
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 import java.util.List;
 
 public class SpringAutoconfigCommentComposer {
 
-  private static final String CLASS_HEADER_SUMMARY_PATTERN =
-      "Auto-configuration for {@link %sClient}.";
+  private static final String CLASS_HEADER_SUMMARY_PATTERN = "Auto-configuration for {@link %s}.";
   private static final String CLASS_HEADER_GENERAL_DESCRIPTION =
       "Provides auto-configuration for Spring Boot";
   private static final String CLASS_HEADER_DEFAULTS_DESCRIPTION =
@@ -46,7 +47,7 @@ public class SpringAutoconfigCommentComposer {
   public static final String TRANSPORT_CHANNEL_PROVIDER_RETURN =
       "a default transport channel provider.";
   public static final String CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION =
-      "Provides a %sSettings bean configured to "
+      "Provides a %s bean configured to "
           + "use the default credentials provider (obtained with %sCredentials()) and its default "
           + "transport channel provider (%s()). It also configures the quota project ID if provided. It "
           + "will configure an executor provider in case there is more than one thread configured "
@@ -57,21 +58,22 @@ public class SpringAutoconfigCommentComposer {
           + "Method-level properties will take precedence over service-level properties if available, "
           + "and client library defaults will be used if neither are specified.";
   public static final String CLIENT_SETTINGS_BEAN_RETURN_STATEMENT =
-      "a {@link %sSettings} bean configured with {@link TransportChannelProvider} bean.";
+      "a {@link %s} bean configured with {@link TransportChannelProvider} bean.";
 
   public static final String CLIENT_BEAN_GENERAL_DESCRIPTION =
-      "Provides a %sClient bean configured with %sSettings.";
+      "Provides a %s bean configured with %s.";
   public static final String CLIENT_BEAN_RETURN_STATEMENT =
-      "a {@link %sClient} bean configured with {@link %sSettings}";
+      "a {@link %s} bean configured with {@link %s}";
 
   public SpringAutoconfigCommentComposer() {}
 
-  public static List<CommentStatement> createClassHeaderComments(
-      String configuredClassName, String serviceName) {
+  public static List<CommentStatement> createClassHeaderComments(Service service) {
 
     JavaDocComment.Builder javaDocCommentBuilder =
         JavaDocComment.builder()
-            .addUnescapedComment(String.format(CLASS_HEADER_SUMMARY_PATTERN, serviceName))
+            .addUnescapedComment(
+                String.format(
+                    CLASS_HEADER_SUMMARY_PATTERN, ClassNames.getServiceClientClassName(service)))
             .addParagraph(CLASS_HEADER_GENERAL_DESCRIPTION)
             .addParagraph(CLASS_HEADER_DEFAULTS_DESCRIPTION)
             .addUnorderedList(
@@ -99,14 +101,14 @@ public class SpringAutoconfigCommentComposer {
   }
 
   public static CommentStatement createSettingsBeanComment(
-      String serviceName, String propertiesClazzName, String channelProviderName) {
-    String credentialsBaseName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceName);
+      Service service, String propertiesClazzName, String channelProviderName) {
+    String credentialsBaseName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name());
     return CommentStatement.withComment(
         JavaDocComment.builder()
             .addParagraph(
                 String.format(
                     CLIENT_SETTINGS_BEAN_GENERAL_DESCRIPTION,
-                    serviceName,
+                    ClassNames.getServiceSettingsClassName(service),
                     credentialsBaseName,
                     channelProviderName))
             .addParagraph(
@@ -114,19 +116,30 @@ public class SpringAutoconfigCommentComposer {
             .addParam(
                 "defaultTransportChannelProvider",
                 "TransportChannelProvider to use in the settings.")
-            .setReturn(String.format(CLIENT_SETTINGS_BEAN_RETURN_STATEMENT, serviceName))
+            .setReturn(
+                String.format(
+                    CLIENT_SETTINGS_BEAN_RETURN_STATEMENT,
+                    ClassNames.getServiceSettingsClassName(service)))
             .build());
   }
 
-  public static CommentStatement createClientBeanComment(String serviceName) {
-    String lowerServiceName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceName);
+  public static CommentStatement createClientBeanComment(Service service) {
+    String lowerServiceName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, service.name());
     return CommentStatement.withComment(
         JavaDocComment.builder()
-            .addParagraph(String.format(CLIENT_BEAN_GENERAL_DESCRIPTION, serviceName, serviceName))
+            .addParagraph(
+                String.format(
+                    CLIENT_BEAN_GENERAL_DESCRIPTION,
+                    ClassNames.getServiceClientClassName(service),
+                    ClassNames.getServiceSettingsClassName(service)))
             .addParam(
                 String.format("%sSettings", lowerServiceName),
                 "settings to configure an instance of client bean.")
-            .setReturn(String.format(CLIENT_BEAN_RETURN_STATEMENT, serviceName, serviceName))
+            .setReturn(
+                String.format(
+                    CLIENT_BEAN_RETURN_STATEMENT,
+                    ClassNames.getServiceClientClassName(service),
+                    ClassNames.getServiceSettingsClassName(service)))
             .build());
   }
 }

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -97,11 +97,9 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a EchoSettings bean configured to use the default credentials provider (obtained with
-   * echoCredentials()) and its default transport channel provider
-   * (defaultEchoTransportChannelProvider()). It also configures the quota project ID if provided.
-   * It will configure an executor provider in case there is more than one thread configured in the
-   * client
+   * Provides a EchoSettings bean configured to use a DefaultCredentialsProvider and the client
+   * library's default transport channel provider (defaultEchoTransportChannelProvider()). It also
+   * configures the quota project ID and executor thread count, if provided through properties.
    *
    * <p>Retry settings are also configured from service-level and method-level properties specified
    * in EchoSpringProperties. Method-level properties will take precedence over service-level

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpc.golden
@@ -77,11 +77,9 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a EchoSettings bean configured to use the default credentials provider (obtained with
-   * echoCredentials()) and its default transport channel provider
-   * (defaultEchoTransportChannelProvider()). It also configures the quota project ID if provided.
-   * It will configure an executor provider in case there is more than one thread configured in the
-   * client
+   * Provides a EchoSettings bean configured to use a DefaultCredentialsProvider and the client
+   * library's default transport channel provider (defaultEchoTransportChannelProvider()). It also
+   * configures the quota project ID and executor thread count, if provided through properties.
    *
    * <p>Retry settings are also configured from service-level and method-level properties specified
    * in EchoSpringProperties. Method-level properties will take precedence over service-level

--- a/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
+++ b/src/test/java/com/google/api/generator/spring/composer/goldens/EchoSpringAutoConfigurationGrpcRest.golden
@@ -81,11 +81,9 @@ public class EchoSpringAutoConfiguration {
   }
 
   /**
-   * Provides a EchoSettings bean configured to use the default credentials provider (obtained with
-   * echoCredentials()) and its default transport channel provider
-   * (defaultEchoTransportChannelProvider()). It also configures the quota project ID if provided.
-   * It will configure an executor provider in case there is more than one thread configured in the
-   * client
+   * Provides a EchoSettings bean configured to use a DefaultCredentialsProvider and the client
+   * library's default transport channel provider (defaultEchoTransportChannelProvider()). It also
+   * configures the quota project ID and executor thread count, if provided through properties.
    *
    * <p>Retry settings are also configured from service-level and method-level properties specified
    * in EchoSpringProperties. Method-level properties will take precedence over service-level


### PR DESCRIPTION
This PR addresses the [javadoc error](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4009223364/jobs/6884435843) observed in our attempt to set up `spring-cloud-previews` for release.

Cause of javadoc error: few exceptions of incorrect client library `<service>Client` and `<service>Settings` class names
- Misalignment: [`service.name()`](https://github.com/googleapis/gapic-generator-java/blob/c96a2e7cf647cf245199c33ad989c8050208646e/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Service.java#L28) vs. [`service.overridenName()`](https://github.com/googleapis/gapic-generator-java/blob/c96a2e7cf647cf245199c33ad989c8050208646e/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Service.java#L42) can be different
- This did not raise compilation issues in the generated code, because we used gapic-generator-java’s [`ClassNames.getServiceClientClassName(service)`](https://github.com/googleapis/gapic-generator-java/blob/c96a2e7cf647cf245199c33ad989c8050208646e/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/utils/ClassNames.java#L47), which correctly aligns with the client library class name. 
- `service.name() + “Client”` was used in other places such as javadoc comments and spring-specific methods and classnames. Turns out this assumption does not hold true.