### PR TITLE
ci(showcase): disable rest_numeric_enum for showcase testing

### DIFF
--- a/showcase/BUILD.bazel
+++ b/showcase/BUILD.bazel
@@ -49,7 +49,7 @@ java_gapic_library(
     srcs = [":showcase_proto_with_info"],
     gapic_yaml = None,
     grpc_service_config = "@com_google_gapic_showcase//schema/google/showcase/v1beta1:showcase_grpc_service_config.json",
-    rest_numeric_enums = True,
+    rest_numeric_enums = False,
     service_yaml = "@com_google_gapic_showcase//schema/google/showcase/v1beta1:showcase_v1beta1.yaml",
     test_deps = [
         ":showcase_java_grpc",

--- a/showcase/BUILD.bazel
+++ b/showcase/BUILD.bazel
@@ -49,6 +49,8 @@ java_gapic_library(
     srcs = [":showcase_proto_with_info"],
     gapic_yaml = None,
     grpc_service_config = "@com_google_gapic_showcase//schema/google/showcase/v1beta1:showcase_grpc_service_config.json",
+    # TODO(#1285): Enable rest_numeric_enums once https://github.com/googleapis/gapic-showcase/issues/1255 is
+    # fixed.
     rest_numeric_enums = False,
     service_yaml = "@com_google_gapic_showcase//schema/google/showcase/v1beta1:showcase_v1beta1.yaml",
     test_deps = [

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
@@ -73,13 +73,12 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<RepeatRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -128,12 +127,11 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             }
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
-                              ProtoRestSerializer.create().toBody("info", request.getInfo(), true))
+                              ProtoRestSerializer.create().toBody("info", request.getInfo(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -183,7 +181,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             }
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -246,7 +243,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             }
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -309,7 +305,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             }
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -369,7 +364,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             }
                             serializer.putQueryParam(
                                 fields, "serverVerify", request.getServerVerify());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -402,13 +396,12 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<RepeatRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -438,13 +431,12 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<RepeatRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<RepeatResponse>newBuilder()
@@ -472,7 +464,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<EnumRequest> serializer = ProtoRestSerializer.create();
                         serializer.putQueryParam(fields, "unknownEnum", request.getUnknownEnum());
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -504,7 +495,6 @@ public class HttpJsonComplianceStub extends ComplianceStub {
                         ProtoRestSerializer<EnumResponse> serializer = ProtoRestSerializer.create();
                         serializer.putQueryParam(fields, "continent", request.getContinentValue());
                         serializer.putQueryParam(fields, "request", request.getRequest());
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -93,13 +93,12 @@ public class HttpJsonEchoStub extends EchoStub {
                       request -> {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<EchoRequest> serializer = ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().build(), true))
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()
@@ -128,13 +127,12 @@ public class HttpJsonEchoStub extends EchoStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<ExpandRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().build(), true))
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<EchoResponse>newBuilder()
@@ -164,13 +162,12 @@ public class HttpJsonEchoStub extends EchoStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<PagedExpandRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
@@ -200,13 +197,12 @@ public class HttpJsonEchoStub extends EchoStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<PagedExpandLegacyRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandResponse>newBuilder()
@@ -236,13 +232,12 @@ public class HttpJsonEchoStub extends EchoStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<PagedExpandRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().build(), true))
+                                  .toBody("*", request.toBuilder().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<PagedExpandLegacyMappedResponse>newBuilder()
@@ -269,13 +264,12 @@ public class HttpJsonEchoStub extends EchoStub {
                       request -> {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<WaitRequest> serializer = ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().build(), true))
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Operation>newBuilder()
@@ -305,13 +299,12 @@ public class HttpJsonEchoStub extends EchoStub {
                       request -> {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<BlockRequest> serializer = ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().build(), true))
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<BlockResponse>newBuilder()

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
@@ -78,13 +78,12 @@ public class HttpJsonIdentityStub extends IdentityStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<CreateUserRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().build(), true))
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<User>newBuilder()
@@ -114,7 +113,6 @@ public class HttpJsonIdentityStub extends IdentityStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<GetUserRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -148,12 +146,11 @@ public class HttpJsonIdentityStub extends IdentityStub {
                         ProtoRestSerializer<UpdateUserRequest> serializer =
                             ProtoRestSerializer.create();
                         serializer.putQueryParam(fields, "updateMask", request.getUpdateMask());
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("user", request.getUser(), true))
+                          ProtoRestSerializer.create().toBody("user", request.getUser(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<User>newBuilder()
@@ -183,7 +180,6 @@ public class HttpJsonIdentityStub extends IdentityStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<DeleteUserRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -218,7 +214,6 @@ public class HttpJsonIdentityStub extends IdentityStub {
                                 ProtoRestSerializer.create();
                             serializer.putQueryParam(fields, "pageSize", request.getPageSize());
                             serializer.putQueryParam(fields, "pageToken", request.getPageToken());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -105,13 +105,12 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<CreateRoomRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().build(), true))
+                              .toBody("*", request.toBuilder().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Room>newBuilder()
@@ -141,7 +140,6 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<GetRoomRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -175,12 +173,11 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         ProtoRestSerializer<UpdateRoomRequest> serializer =
                             ProtoRestSerializer.create();
                         serializer.putQueryParam(fields, "updateMask", request.getUpdateMask());
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("room", request.getRoom(), true))
+                          ProtoRestSerializer.create().toBody("room", request.getRoom(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Room>newBuilder()
@@ -210,7 +207,6 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<DeleteRoomRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -245,7 +241,6 @@ public class HttpJsonMessagingStub extends MessagingStub {
                                 ProtoRestSerializer.create();
                             serializer.putQueryParam(fields, "pageSize", request.getPageSize());
                             serializer.putQueryParam(fields, "pageToken", request.getPageToken());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -279,13 +274,12 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<CreateBlurbRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
                           ProtoRestSerializer.create()
-                              .toBody("*", request.toBuilder().clearParent().build(), true))
+                              .toBody("*", request.toBuilder().clearParent().build(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Blurb>newBuilder()
@@ -316,7 +310,6 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<GetBlurbRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -351,12 +344,11 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         ProtoRestSerializer<UpdateBlurbRequest> serializer =
                             ProtoRestSerializer.create();
                         serializer.putQueryParam(fields, "updateMask", request.getUpdateMask());
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(
                       request ->
-                          ProtoRestSerializer.create().toBody("blurb", request.getBlurb(), true))
+                          ProtoRestSerializer.create().toBody("blurb", request.getBlurb(), false))
                   .build())
           .setResponseParser(
               ProtoMessageResponseParser.<Blurb>newBuilder()
@@ -387,7 +379,6 @@ public class HttpJsonMessagingStub extends MessagingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<DeleteBlurbRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -424,7 +415,6 @@ public class HttpJsonMessagingStub extends MessagingStub {
                                 ProtoRestSerializer.create();
                             serializer.putQueryParam(fields, "pageSize", request.getPageSize());
                             serializer.putQueryParam(fields, "pageToken", request.getPageToken());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -459,13 +449,12 @@ public class HttpJsonMessagingStub extends MessagingStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<SearchBlurbsRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().clearParent().build(), true))
+                                  .toBody("*", request.toBuilder().clearParent().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<Operation>newBuilder()
@@ -500,13 +489,12 @@ public class HttpJsonMessagingStub extends MessagingStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<StreamBlurbsRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().clearName().build(), true))
+                                  .toBody("*", request.toBuilder().clearName().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<StreamBlurbsResponse>newBuilder()

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
@@ -75,13 +75,12 @@ public class HttpJsonSequenceServiceStub extends SequenceServiceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<CreateSequenceRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("sequence", request.getSequence(), true))
+                                  .toBody("sequence", request.getSequence(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<Sequence>newBuilder()
@@ -112,7 +111,6 @@ public class HttpJsonSequenceServiceStub extends SequenceServiceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<GetSequenceReportRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -146,13 +144,12 @@ public class HttpJsonSequenceServiceStub extends SequenceServiceStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<AttemptSequenceRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("*", request.toBuilder().clearName().build(), true))
+                                  .toBody("*", request.toBuilder().clearName().build(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<Empty>newBuilder()

--- a/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
+++ b/showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
@@ -86,13 +86,12 @@ public class HttpJsonTestingStub extends TestingStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<CreateSessionRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(
                           request ->
                               ProtoRestSerializer.create()
-                                  .toBody("session", request.getSession(), true))
+                                  .toBody("session", request.getSession(), false))
                       .build())
               .setResponseParser(
                   ProtoMessageResponseParser.<Session>newBuilder()
@@ -122,7 +121,6 @@ public class HttpJsonTestingStub extends TestingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<GetSessionRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -157,7 +155,6 @@ public class HttpJsonTestingStub extends TestingStub {
                                 ProtoRestSerializer.create();
                             serializer.putQueryParam(fields, "pageSize", request.getPageSize());
                             serializer.putQueryParam(fields, "pageToken", request.getPageToken());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -191,7 +188,6 @@ public class HttpJsonTestingStub extends TestingStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<DeleteSessionRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -225,7 +221,6 @@ public class HttpJsonTestingStub extends TestingStub {
                             Map<String, List<String>> fields = new HashMap<>();
                             ProtoRestSerializer<ReportSessionRequest> serializer =
                                 ProtoRestSerializer.create();
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -261,7 +256,6 @@ public class HttpJsonTestingStub extends TestingStub {
                                 ProtoRestSerializer.create();
                             serializer.putQueryParam(fields, "pageSize", request.getPageSize());
                             serializer.putQueryParam(fields, "pageToken", request.getPageToken());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)
@@ -294,7 +288,6 @@ public class HttpJsonTestingStub extends TestingStub {
                         Map<String, List<String>> fields = new HashMap<>();
                         ProtoRestSerializer<DeleteTestRequest> serializer =
                             ProtoRestSerializer.create();
-                        serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                         return fields;
                       })
                   .setRequestBodyExtractor(request -> null)
@@ -330,7 +323,6 @@ public class HttpJsonTestingStub extends TestingStub {
                                 ProtoRestSerializer.create();
                             serializer.putQueryParam(fields, "answer", request.getAnswer());
                             serializer.putQueryParam(fields, "answers", request.getAnswersList());
-                            serializer.putQueryParam(fields, "$alt", "json;enum-encoding=int");
                             return fields;
                           })
                       .setRequestBodyExtractor(request -> null)

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITFirstHttp.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITFirstHttp.java
@@ -17,11 +17,9 @@
 package com.google.showcase.v1beta1.it;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.gax.core.NoCredentialsProvider;
-import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.showcase.v1beta1.EchoClient;
 import com.google.showcase.v1beta1.EchoRequest;
 import com.google.showcase.v1beta1.EchoResponse;
@@ -39,7 +37,7 @@ public class ITFirstHttp {
   @BeforeClass
   public static void createClient() throws IOException, GeneralSecurityException {
     EchoSettings echoSettings =
-        EchoSettings.newBuilder()
+        EchoSettings.newHttpJsonBuilder()
             .setCredentialsProvider(NoCredentialsProvider.create())
             .setTransportChannelProvider(
                 EchoSettings.defaultHttpJsonTransportProviderBuilder()
@@ -57,17 +55,10 @@ public class ITFirstHttp {
     client.close();
   }
 
-  // TODO(#1187): For 'throws' explanation, see
-  // https://github.com/googleapis/gapic-showcase/blob/v0.25.0/util/genrest/resttools/systemparam.go#L37-L46
   @Test
   public void testEcho() {
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> assertEquals("http-echo?", echo("http-echo?")));
-
-    assertThrows(
-        InvalidArgumentException.class,
-        () -> assertEquals("http-echo!", echo("http-echo!")));
+    assertEquals("http-echo?", echo("http-echo?"));
+    assertEquals("http-echo!", echo("http-echo!"));
   }
 
   private String echo(String value) {

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITNumericEnums.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITNumericEnums.java
@@ -16,16 +16,19 @@
 
 package com.google.showcase.v1beta1.it;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.gax.core.NoCredentialsProvider;
-import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.showcase.v1beta1.ComplianceClient;
 import com.google.showcase.v1beta1.ComplianceSettings;
 import com.google.showcase.v1beta1.EnumRequest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+
+import com.google.showcase.v1beta1.EnumResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,18 +57,11 @@ public class ITNumericEnums {
     client.close();
   }
 
-  // TODO(#1187): For 'throws' explanation, see
-  // https://github.com/googleapis/gapic-showcase/blob/v0.25.0/util/genrest/resttools/systemparam.go#L37-L46
   @Test
   public void verifyEnums() {
     EnumRequest request = EnumRequest.newBuilder().setUnknownEnum(true).build();
-
-    // EnumResponse initialResponse =
-    assertThrows(InvalidArgumentException.class, () -> client.getEnum(request));
-
-    //    EnumResponse verifiedResponse = client.verifyEnum(initialResponse);
-    //
-    //    Assert.assertNotNull(initialResponse);
-    //    Assert.assertEquals(initialResponse, verifiedResponse);
+    EnumResponse initialResponse = client.getEnum(request);
+    EnumResponse verifiedResponse = client.verifyEnum(initialResponse);
+    assertEquals(initialResponse, verifiedResponse);
   }
 }

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITNumericEnums.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITNumericEnums.java
@@ -17,8 +17,6 @@
 package com.google.showcase.v1beta1.it;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.gax.core.NoCredentialsProvider;
@@ -61,7 +59,6 @@ public class ITNumericEnums {
   public void verifyEnums() {
     EnumRequest request = EnumRequest.newBuilder().setUnknownEnum(true).build();
     EnumResponse initialResponse = client.getEnum(request);
-    EnumResponse verifiedResponse = client.verifyEnum(initialResponse);
-    assertEquals(initialResponse, verifiedResponse);
+    assertEquals(initialResponse, client.verifyEnum(initialResponse));
   }
 }


### PR DESCRIPTION
Disabling this feature until https://github.com/googleapis/gapic-showcase/issues/1255 is addressed to unblock showcase testing development. 

Created a follow up issue to track enabling of numeric enum feature for showcase. 