### PR TITLE
fix(java): initialize netty-shaded at run-time and add reflection configurations for netty classes

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/GrpcNettyFeature.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/GrpcNettyFeature.java
@@ -86,27 +86,25 @@ final class GrpcNettyFeature implements Feature {
       registerClassForReflection(
           access, "io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline");
+          access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.grpc.netty.WriteBufferingAndExceptionHandler");
+          access, "io.grpc.netty.shaded.io.grpc.netty.WriteBufferingAndExceptionHandler");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.netty.channel.ProtocolNegotiators");
+          access, "io.grpc.netty.shaded.io.netty.channel.ProtocolNegotiators");
+      registerClassForReflection(access, "io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler");
+      registerClassForReflection(access, "io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler");
+          access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler");
+          access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$TailContext");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext");
+          access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$WaitUntilActiveHandler");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$TailContext");
+          access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$ClientTlsHandler");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$WaitUntilActiveHandler");
+          access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$GrpcNegotiationHandler");
       registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$ClientTlsHandler");
-      registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$GrpcNegotiationHandler");
-      registerClassForReflection(
-              access, "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerMask");
+          access, "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerMask");
 
       // Epoll Libraries
       registerClassForReflection(access, "io.grpc.netty.shaded.io.netty.channel.epoll.Epoll");

--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/GrpcNettyFeature.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/nativeimage/GrpcNettyFeature.java
@@ -85,6 +85,28 @@ final class GrpcNettyFeature implements Feature {
       registerClassForReflection(access, "io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion");
       registerClassForReflection(
           access, "io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.grpc.netty.WriteBufferingAndExceptionHandler");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.netty.channel.ProtocolNegotiators");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$TailContext");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$WaitUntilActiveHandler");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$ClientTlsHandler");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$GrpcNegotiationHandler");
+      registerClassForReflection(
+              access, "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerMask");
 
       // Epoll Libraries
       registerClassForReflection(access, "io.grpc.netty.shaded.io.netty.channel.epoll.Epoll");

--- a/gax-java/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
+++ b/gax-java/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties
@@ -9,7 +9,8 @@ Args=--add-opens=java.base/java.time=ALL-UNNAMED \
     io.grpc.netty.shaded.io.netty.channel.epoll,\
     io.grpc.netty.shaded.io.netty.channel.unix,\
     io.grpc.netty.shaded.io.netty.handler.ssl,\
-    io.grpc.internal.RetriableStream \
+    io.grpc.internal.RetriableStream,\
+    io.grpc.netty.shaded.io.netty \
   --features=com.google.api.gax.grpc.nativeimage.ProtobufMessageFeature,\
   com.google.api.gax.grpc.nativeimage.GrpcNettyFeature \
   -H:-RunReachabilityHandlersConcurrently

--- a/gax-java/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/reflect-config.json
+++ b/gax-java/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/reflect-config.json
@@ -283,5 +283,44 @@
         "name": "selectedKeys"
       }
     ]
+  },
+  {
+    "name" : "com.google.auth.oauth2.ServiceAccountCredentials",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "queryAllPublicConstructors" : true,
+    "queryAllDeclaredConstructors" : true,
+    "queryAllPublicMethods" : true,
+    "queryAllDeclaredMethods" : true
+  },
+  {
+    "name" : "org.apache.commons.pool2.impl.DefaultEvictionPolicy",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "queryAllPublicConstructors" : true,
+    "queryAllDeclaredConstructors" : true,
+    "queryAllPublicMethods" : true,
+    "queryAllDeclaredMethods" : true
+  },
+  {
+    "name" : "java.nio.channels.spi.SelectorProvider",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "queryAllPublicConstructors" : true,
+    "queryAllDeclaredConstructors" : true,
+    "queryAllPublicMethods" : true,
+    "queryAllDeclaredMethods" : true
   }
 ]


### PR DESCRIPTION
Build initialization of netty causes inconsistent behavior when an application is run locally versus on Cloud Run. One such case as discovered in https://github.com/mutianf/graalvm-test is when a bigtable application works fine with native image compilation locally but times out on Cloud Run. 

More details:
Netty `System.nanoTime()` [as a memoized static start_time variable](https://github.com/netty/netty/pull/12459) when the native image is being build. `System.nanoTime()` is an arbitrary value and platform specific so when the start_time compared against another `System.nanoTime()` at run time on the container, the comparison may not always be consistent. Netty is initialized at native image build time by default for netty 4.x but we can adjust this by setting `--initialize-at-run-time=io.grpc.netty.shaded.io.netty` in a `META-INF/native-image/native-image.properties` file. 

Additionally, build time initialization of netty also causes build time issues when third party logging libraries like SLF4J are used:
```
Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing io.grpc.netty.shaded.io.netty.util.internal.SystemPropertyUtil.getBoolean(java.lang.String, boolean)
Parsing context:
   at io.grpc.netty.shaded.io.netty.util.internal.SystemPropertyUtil.getBoolean(SystemPropertyUtil.java:96)
   at io.grpc.netty.shaded.io.netty.channel.epoll.Epoll.<clinit>(Epoll.java:33)
   at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:153)
...
java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: No instances of org.slf4j.jul.JDK14LoggerAdapter are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=org.slf4j.jul.JDK14LoggerAdapter.
```


It is important to note that this may result in a performance cost depending on the code path the application follows but given the persistence of these issues as a result of build-time netty initialization, run-time initialization of netty provides a more out-of-the-box experience. 