### PR TITLE
chore: Pin Bazel version to 5.2.0

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,2 @@
 # See https://github.com/bazelbuild/bazelisk
-USE_BAZEL_VERSION=4.2.2
+USE_BAZEL_VERSION=5.2.0


### PR DESCRIPTION
Pin Bazel version to 5.2.0 as googleapis already [updated](https://github.com/googleapis/googleapis/blob/ebf47e25ff363de57a6036562504db6caf3d8b89/.bazeliskrc#L2) to 5.2.0