### PR TITLE
fix: Watchdog wait for the current run to complete on shutdown.

### DIFF
--- a/gax-java/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/rpc/WatchdogTest.java
@@ -155,6 +155,26 @@ public class WatchdogTest {
   }
 
   @Test
+  public void awaitTermination_shouldReturnFalseIfShutDownIsNotCalledFirst() throws Exception {
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    boolean awaitTermination = watchdog.awaitTermination(1000, TimeUnit.MILLISECONDS);
+    assertThat(awaitTermination).isFalse();
+  }
+
+  @Test
+  public void awaitTermination_shouldReturnTrue() throws Exception {
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    watchdog.watch(new AccumulatingObserver<>(), waitTime, idleTime);
+    // Make sure the run() method is run before calling shutdown()
+    Thread.sleep(2000);
+    watchdog.shutdown();
+    boolean awaitTermination = watchdog.awaitTermination(1000, TimeUnit.MILLISECONDS);
+    assertThat(awaitTermination).isTrue();
+    assertThat(watchdog.isTerminated()).isTrue();
+  }
+
+  @Test
   public void testMultiple() throws Exception {
     // Start stream1
     AccumulatingObserver<String> downstreamObserver1 = new AccumulatingObserver<>();


### PR DESCRIPTION
This is an enhancement to https://github.com/googleapis/gax-java/pull/1890. Watchdog wait for the current run to complete on shutdown. Using Phaser to track the lifecycle of each run() execution, wait for the Phaser to proceed to next phase(which is terminated phase in our case) in awaitTermination and use phaser.isTerminated() to determine if Watchdog is terminated or not.