### PR TITLE
fix(spring): update hasRestOption to exclude services with no rest-supported methods

### DIFF
--- a/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
+++ b/src/main/java/com/google/api/generator/spring/composer/SpringAutoConfigClassComposer.java
@@ -110,7 +110,17 @@ public class SpringAutoConfigClassComposer implements ClassComposer {
 
     Expr thisExpr = ValueExpr.withValue(ThisObjectValue.withType(dynamicTypes.get(className)));
     Transport transport = context.transport();
-    boolean hasRestOption = transport.equals(Transport.GRPC_REST);
+    // TODO(emmwang): this condition is adapted from latest gapic-generator-java changes as part of
+    // https://github.com/googleapis/gapic-generator-java/issues/1117, but should be updated to use
+    // the gapic-implemented helpers once spring generator code is migrated.
+    boolean hasRestSupportedMethod =
+        service.methods().stream()
+            .anyMatch(
+                x ->
+                    x.httpBindings() != null
+                        && x.stream() != Method.Stream.BIDI
+                        && x.stream() != Method.Stream.CLIENT);
+    boolean hasRestOption = transport.equals(Transport.GRPC_REST) && hasRestSupportedMethod;
     String serviceSettingsMethodName = JavaStyle.toLowerCamelCase(service.name()) + "Settings";
 
     ClassDefinition classDef =


### PR DESCRIPTION
This PR aligns the spring generator with main branch changes from https://github.com/googleapis/gapic-generator-java/issues/1117. I copied the relevant `isSupportedByTransport(Transport.REST)` logic as a quick fix instead of cherry-picking the commits, since the branches have diverged a bit since the monorepo migration. 

Future note: as part of migrating this spring generator code away from its separate branch and depending on the gapic generator jar, I'd like to revisit this logic to call the corresponding helpers in gapic-generator-java main.