### PR TITLE
chore: add rules_pkg to renovate bot ignoreDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,4 +3,5 @@
     "config:base"
   ],
   "ignorePaths": [".kokoro/requirements.txt"]
+  "ignoreDeps": ["rules_pkg"]
 }


### PR DESCRIPTION
Following up on https://github.com/googleapis/gapic-generator-java/pull/1338, suppressing renovate PRs for the `rules_pkg` dependency since it will need to align with version used in googleapis.