### PR TITLE
chore: fix renovate bot ignoreDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "ignorePaths": [".kokoro/requirements.txt"]
+  "ignorePaths": [".kokoro/requirements.txt"],
   "ignoreDeps": ["rules_pkg"]
 }


### PR DESCRIPTION
Fixes #1352, from missed separator in #1349's changes.