### PR TITLE
chore: README.md to explain service_config.proto

### DIFF
--- a/gapic-generator-java/README.md
+++ b/gapic-generator-java/README.md
@@ -6,3 +6,15 @@ Replaces the Java parts of the
 [older monolithic generator](https://github.com/googleapis/gapic-generator).
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for setting up development environment.
+
+## service_config.proto
+
+We use the `src/main/proto/service_config.proto` file to generate corresponding
+Java class files.
+They are needed to generate client libraries for gRPC-based Google services.
+
+The source of `src/main/proto/service_config.proto` is the
+https://github.com/grpc/grpc-proto repository.
+We copy the file from the repository when a new enhancement is made in the file
+and the service team asks us to incorporate the enhancement into the code
+generator.

--- a/gapic-generator-java/README.md
+++ b/gapic-generator-java/README.md
@@ -14,7 +14,8 @@ Java class files.
 They are needed to generate client libraries for gRPC-based Google services.
 
 The source of `src/main/proto/service_config.proto` is the
-https://github.com/grpc/grpc-proto repository.
+[https://github.com/grpc/grpc-proto repository](
+https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto).
 We copy the file from the repository when a new enhancement is made in the file
 and the service team asks us to incorporate the enhancement into the code
 generator.


### PR DESCRIPTION
Talked with Blake. Because the file is seldom updated, it's better to add a section in README.md rather than setting up automation. I closed https://github.com/googleapis/gapic-generator-java/pull/1359 for that reason (this pull request 1359 relied on master branch, not a released version, which may contain temporary changes there.)