### PR TITLE
chore: renovate to group Protobuf artifacts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,70 @@
     "config:base"
   ],
   "ignorePaths": [".kokoro/requirements.txt"],
-  "ignoreDeps": ["rules_pkg"]
+  "ignoreDeps": ["rules_pkg"],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "^com.google.guava:"
+      ],
+      "versionScheme": "docker"
+    },
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
+    },
+    {
+      "packagePatterns": [
+        "^org.apache.maven",
+        "^org.jacoco:",
+        "^org.codehaus.mojo:",
+        "^org.sonatype.plugins:",
+        "^com.coveo:",
+        "^com.google.cloud:google-cloud-shared-config"
+      ],
+      "semanticCommitType": "build",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^{{metadata['repo']['distribution_name']}}",
+        "^com.google.cloud:libraries-bom",
+        "^com.google.cloud.samples:shared-configuration"
+      ],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^junit:junit",
+        "^com.google.truth:truth",
+        "^org.mockito:mockito-core",
+        "^org.objenesis:objenesis",
+        "^com.google.cloud:google-cloud-conformance-tests"
+      ],
+      "semanticCommitType": "test",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.cloud:google-cloud-"
+      ],
+      "ignoreUnstable": false
+    },
+    {
+      "packagePatterns": [
+        "^com.fasterxml.jackson.core"
+      ],
+      "groupName": "jackson dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.protobuf"
+      ],
+      "groupName": "Protobuf dependencies"
+    }
+  ],
 }


### PR DESCRIPTION
Copying packageGroup configuration from https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/java_library/renovate.json

This should avoid separate pull requests for Protobuf: https://github.com/googleapis/gapic-generator-java/pull/1155 and https://github.com/googleapis/gapic-generator-java/pull/1154