### PR TITLE
chore: importing gax-java's Renovate configuration with regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,31 @@
   ],
   "ignorePaths": [".kokoro/requirements.txt"],
   "ignoreDeps": ["rules_pkg"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^gax-java/dependencies\\.properties$"],
+      "matchStrings": ["=(?<depName>.+\\:.+?):(?<currentValue>.+?)\\n"],
+      "datasourceTemplate": "maven"
+    },
+    {
+      "fileMatch": ["^gax-java/dependencies\\.properties$"],
+      "matchStrings": ["version\\.com_google_protobuf=(?<currentValue>.+?)\\n"],
+      "depNameTemplate": "com.google.protobuf:protobuf-java",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "fileMatch": ["^gax-java/dependencies\\.properties$"],
+      "matchStrings": ["version\\.google_java_format=(?<currentValue>.+?)\\n"],
+      "depNameTemplate": "com.google.googlejavaformat:google-java-format",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "fileMatch": ["^gax-java/dependencies\\.properties$"],
+      "matchStrings": ["version\\.io_grpc=(?<currentValue>.+?)\\n"],
+      "depNameTemplate": "io.grpc:grpc-core",
+      "datasourceTemplate": "maven"
+    }
+  ],
   "packageRules": [
      {
       "matchUpdateTypes": ["major"],
@@ -72,6 +97,30 @@
         "^com.google.protobuf"
       ],
       "groupName": "Protobuf dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^io.grpc"
+      ],
+      "groupName": "gRPC dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.auth"
+      ],
+      "groupName": "Google Auth Library dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^io.opencensus"
+      ],
+      "groupName": "OpenCensus dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^io.netty"
+      ],
+      "groupName": "Netty dependencies"
     }
   ]
 }


### PR DESCRIPTION
Importing gax-java repository's renovate.json rule to this repository https://github.com/googleapis/gax-java/blob/main/renovate.json#L7.

As per the documentation (https://docs.renovatebot.com/modules/manager/regex/#regular-expression-capture-groups) I confirmed the regex `"=(?<depName>.+\\:.+?):(?<currentValue>.+?)\\n"` works in https://regex101.com/r/01eHFC/1
