### PR TITLE
chore: rename ci-maven workflow to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   pull_request:
-name: ci-maven
+name: ci
 env:
   SHOWCASE_VERSION: 0.25.0
 jobs:


### PR DESCRIPTION
As follow-up to monitoring dashboard still pointing to [ci.yaml](https://github.com/googleapis/gapic-generator-java/actions/workflows/ci.yaml):
- Renames `ci-maven.yaml` workflow to the former name of `ci.yaml` (previous bazel-based workflow, now removed), also to reflect that bazel is still used for running the integration tests.