### PR TITLE
chore: Update gapic-showcase to v0.26.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 name: ci
 env:
-  SHOWCASE_VERSION: 0.25.0
+  SHOWCASE_VERSION: 0.26.0
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/downstream-native-image.yaml
+++ b/.github/workflows/downstream-native-image.yaml
@@ -9,7 +9,7 @@ on:
 # compilation.
 name: downstream
 env:
-  SHOWCASE_VERSION: 0.25.0
+  SHOWCASE_VERSION: 0.26.0
 jobs:
   # GraalVM job ensures the compatibility of GraaVM version
   graalvm:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,9 +107,9 @@ http_archive(
 )
 
 # Showcase
-_showcase_commit = "90d73532a0cab753a85f45c158394f24fc21d91a"
+_showcase_commit = "656e5f46d125a69c82c0cb7edcfcd8b03ed77b89"
 
-_showcase_sha256 = "0f582541a379be0746e6b8bc5af3df511581d4b1f18f7dfb9ce203be1a64cef1"
+_showcase_sha256 = "26d4b71ac31cbca5e4ed4cdcb5bfeca185e405392d70d2020b4528b5b47c8022"
 
 http_archive(
     name = "com_google_gapic_showcase",

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -16,7 +16,7 @@ versions is not guaranteed. If changing the version of the server, it may also b
 update to a compatible client version in `./WORKSPACE`.
 
 ```shell
-$ GAPIC_SHOWCASE_VERSION=0.25.0
+$ GAPIC_SHOWCASE_VERSION=0.26.0
 $ go install github.com/googleapis/gapic-showcase/cmd/gapic-showcase@v"$GAPIC_SHOWCASE_VERSION"
 $ PATH=$PATH:`go env GOPATH`/bin
 $ gapic-showcase --help


### PR DESCRIPTION
Updating gapic-showcase to v0.26.0. 

For the REGAPIC testing efforts, it fixes an issue regarding PATCH requests: https://github.com/googleapis/gapic-showcase/pull/1262 