### PR TITLE
chore: Update release please tag for gax httpjson

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>com.google.api</groupId>
                 <artifactId>gax-httpjson</artifactId>
-                <version>0.108.3-SNAPSHOT</version> <!-- {x-version-update:gax:current} -->
+                <version>0.108.3-SNAPSHOT</version> <!-- {x-version-update:gax-httpjson:current} -->
             </dependency>
         </dependencies>
 


### PR DESCRIPTION
In the release PR, release-please is updating this to the gax version (2.24.0) instead of the gax-httpjson version (0.109.0): https://github.com/googleapis/gapic-generator-java/pull/1511/files#diff-e3e7443565e17d958d343ea2d41a48776685beb09a47898764b92b37ce316685