### PR TITLE
ci: installing shared dependencies BOM upper-bound check

### DIFF
--- a/.github/workflows/shared_dependencies.yaml
+++ b/.github/workflows/shared_dependencies.yaml
@@ -4,6 +4,8 @@ on:
     - main
   pull_request:
     paths:
+    - 'gapic-generator-java-bom/**'
+    - 'gapic-generator-java-pom-parent/**'
     - 'java-shared-dependencies/**'
 name: shared-dependencies version check
 jobs:

--- a/.github/workflows/shared_dependencies.yaml
+++ b/.github/workflows/shared_dependencies.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    paths:
+    - 'java-shared-dependencies/**'
+name: shared-dependencies version check
+jobs:
+  upper-bound-check:
+    name: Shared Dependencies BOM upper-bound check
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'googleapis'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - run: java -version
+    - name: Install maven modules
+      run: |
+        mvn install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip
+    - name: Check the BOM content satisfies the upper-bound-check test case
+      run: mvn -B -V -ntp verify -Dcheckstyle.skip
+      working-directory: java-shared-dependencies/upper-bound-check

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -23,7 +23,7 @@
     <skipUnitTests>false</skipUnitTests>
     <checkstyle.header.file>java.header</checkstyle.header.file>
 
-    <!-- External dependencies, expecially gRPC and Protobuf version, should be
+    <!-- External dependencies, especially gRPC and Protobuf version, should be
         consistent across modules in this repository -->
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <grpc.version>1.53.0</grpc.version>

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -29,8 +29,8 @@
     <grpc.version>1.53.0</grpc.version>
     <google.auth.version>1.16.0</google.auth.version>
     <gson.version>2.10.1</gson.version>
-    <guava.version>31.1-jre</guava.version>
-    <protobuf.version>3.15.0</protobuf.version>
+    <guava.version>30.1-jre</guava.version>
+    <protobuf.version>3.21.12</protobuf.version>
     <maven.compiler.release>8</maven.compiler.release>
   </properties>
 

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -30,7 +30,7 @@
     <google.auth.version>1.16.0</google.auth.version>
     <gson.version>2.10.1</gson.version>
     <guava.version>31.1-jre</guava.version>
-    <protobuf.version>3.21.12</protobuf.version>
+    <protobuf.version>3.15.0</protobuf.version>
     <maven.compiler.release>8</maven.compiler.release>
   </properties>
 

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -29,7 +29,7 @@
     <grpc.version>1.53.0</grpc.version>
     <google.auth.version>1.16.0</google.auth.version>
     <gson.version>2.10.1</gson.version>
-    <guava.version>30.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.21.12</protobuf.version>
     <maven.compiler.release>8</maven.compiler.release>
   </properties>


### PR DESCRIPTION
Moving the removed job from https://github.com/googleapis/google-cloud-java/pull/9266/files#r1145267872 to gapic-generator-java.