### PR TITLE
chore: api-common-java and gax-java use SPDX identifier for BSD-3-Clause license

### DIFF
--- a/api-common-java/LICENSE
+++ b/api-common-java/LICENSE
@@ -1,4 +1,5 @@
-Copyright 2016, Google Inc.
+Copyright 2016 Google LLC
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
@@ -9,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/api-common-java/pom.xml
+++ b/api-common-java/pom.xml
@@ -28,7 +28,7 @@
 
     <licenses>
         <license>
-            <name>BSD</name>
+            <name>BSD-3-Clause</name>
             <url>https://github.com/googleapis/api-common-java/blob/main/LICENSE</url>
         </license>
     </licenses>

--- a/gax-java/LICENSE
+++ b/gax-java/LICENSE
@@ -1,16 +1,16 @@
-Copyright 2016, Google Inc. All rights reserved.
+Copyright 2016 Google LLC
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-    * Redistributions of source code must retain the above copyright
+   * Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
+   * Redistributions in binary form must reproduce the above
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-    * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/gax-java/gax-bom/pom.xml
+++ b/gax-java/gax-bom/pom.xml
@@ -33,7 +33,7 @@
 
   <licenses>
     <license>
-      <name>BSD</name>
+      <name>BSD-3-Clause</name>
       <url>https://github.com/googleapis/gax-java/blob/master/LICENSE</url>
     </license>
   </licenses>

--- a/gax-java/pom.xml
+++ b/gax-java/pom.xml
@@ -27,7 +27,7 @@
 
   <licenses>
     <license>
-      <name>BSD</name>
+      <name>BSD-3-Clause</name>
       <url>https://github.com/googleapis/gax-java/blob/master/LICENSE</url>
     </license>
   </licenses>


### PR DESCRIPTION
Fixes #1335 

Now uses the compliant [SPDX License Identifier](https://spdx.org/licenses/) as recommended by [Maven](https://maven.apache.org/pom.html#Licenses).

Both `LICENSE` files now also follow "Google LLC" guidance.