### PR TITLE
chore: coverage-report/pom.xml to have api-common annotation

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -45,8 +45,8 @@
             </dependency>
             <dependency>
                 <groupId>com.google.api</groupId>
-                <artifactId>api-common</artifactId> <!-- {x-version-update:api-common:current} -->
-                <version>2.6.4-SNAPSHOT</version>
+                <artifactId>api-common</artifactId>
+                <version>2.6.4-SNAPSHOT</version> <!-- {x-version-update:api-common:current} -->
             </dependency>
         </dependencies>
 


### PR DESCRIPTION
This will fix https://github.com/googleapis/gapic-generator-java/pull/1511#issuecomment-1483254025