### PR TITLE
chore: FlowControllerTest uses TestableThread to efficiently wait for thread to start

### DIFF
--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -612,8 +612,7 @@ public class FlowControllerTest {
             });
     t.start();
     t.assertStartsWithin(200, TimeUnit.MILLISECONDS);
-    // wait for thread to start, and check it should be blocked
-    Thread.sleep(50);
+    // thread should be blocked
     assertEquals(State.WAITING, t.getState());
     // increase and decrease should not be blocked
     int increase = 5, decrease = 20;

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -524,10 +524,10 @@ public class FlowControllerTest {
     final AtomicInteger totalDecreased = new AtomicInteger(0);
     final AtomicInteger releasedCounter = new AtomicInteger(0);
 
-    List<Future> reserveThreads =
+    List<Future<?>> reserveThreads =
         testConcurrentUpdates(
             flowController, 100, 100, 10, totalIncreased, totalDecreased, releasedCounter);
-    for (Future t : reserveThreads) {
+    for (Future<?> t : reserveThreads) {
       t.get(200, TimeUnit.MILLISECONDS);
     }
     assertEquals(reserveThreads.size(), releasedCounter.get());
@@ -557,10 +557,10 @@ public class FlowControllerTest {
     AtomicInteger totalIncreased = new AtomicInteger(0);
     AtomicInteger totalDecreased = new AtomicInteger(0);
     AtomicInteger releasedCounter = new AtomicInteger(0);
-    List<Future> reserveThreads =
+    List<Future<?>> reserveThreads =
         testConcurrentUpdates(
             flowController, 100, 100, 100, totalIncreased, totalDecreased, releasedCounter);
-    for (Future t : reserveThreads) {
+    for (Future<?> t : reserveThreads) {
       t.get(200, TimeUnit.MILLISECONDS);
     }
     assertEquals(reserveThreads.size(), releasedCounter.get());
@@ -732,7 +732,7 @@ public class FlowControllerTest {
         .isAtLeast(currentTime);
   }
 
-  private List<Future> testConcurrentUpdates(
+  private List<Future<?>> testConcurrentUpdates(
       final FlowController flowController,
       final int increaseStepRange,
       final int decreaseStepRange,
@@ -772,8 +772,8 @@ public class FlowControllerTest {
             }
           }
         };
-    List<Future> updateFuture = new ArrayList<>();
-    List<Future> reserveReleaseFuture = new ArrayList<>();
+    List<Future<?>> updateFuture = new ArrayList<>();
+    List<Future<?>> reserveReleaseFuture = new ArrayList<>();
     ExecutorService executors = Executors.newFixedThreadPool(10);
     ExecutorService reserveExecutor = Executors.newFixedThreadPool(10);
     for (int i = 0; i < 5; i++) {
@@ -781,7 +781,7 @@ public class FlowControllerTest {
       updateFuture.add(executors.submit(decreaseRunnable));
       reserveReleaseFuture.add(reserveExecutor.submit(reserveReleaseRunnable));
     }
-    for (Future t : updateFuture) {
+    for (Future<?> t : updateFuture) {
       t.get(50, TimeUnit.MILLISECONDS);
     }
     executors.shutdown();

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -606,6 +606,7 @@ public class FlowControllerTest {
                 try {
                   flowController.reserve(0, 100);
                 } catch (FlowControlException e) {
+                  throw new AssertionError(e);
                 }
               }
             });
@@ -652,6 +653,7 @@ public class FlowControllerTest {
                 try {
                   flowController.reserve(initial + 10, 10);
                 } catch (FlowControlException e) {
+                  throw new AssertionError(e);
                 }
               }
             });

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -57,9 +57,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for {@link FlowController}.
- */
+/** Tests for {@link FlowController}. */
 @RunWith(JUnit4.class)
 public class FlowControllerTest {
 
@@ -600,14 +598,11 @@ public class FlowControllerTest {
     // will be blocked by reserve 10
     TestableThread t =
         new TestableThread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  flowController.reserve(0, 100);
-                } catch (FlowControlException e) {
-                  throw new AssertionError(e);
-                }
+            () -> {
+              try {
+                flowController.reserve(0, 100);
+              } catch (FlowControlException e) {
+                throw new AssertionError(e);
               }
             });
     t.start();
@@ -646,14 +641,11 @@ public class FlowControllerTest {
                 .build());
     TestableThread t =
         new TestableThread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  flowController.reserve(initial + 10, 10);
-                } catch (FlowControlException e) {
-                  throw new AssertionError(e);
-                }
+            () -> {
+              try {
+                flowController.reserve(initial + 10, 10);
+              } catch (FlowControlException e) {
+                throw new AssertionError(e);
               }
             });
     t.start();
@@ -802,7 +794,6 @@ public class FlowControllerTest {
    * timeout.
    */
   private static class TestableThread {
-
     private final Thread thread;
     private final ArrayBlockingQueue<Boolean> hasStarted = new ArrayBlockingQueue<>(1);
 
@@ -815,23 +806,17 @@ public class FlowControllerTest {
               });
     }
 
-    /**
-     * @see Thread#start()
-     */
+    /** @see Thread#start() */
     public void start() {
       thread.start();
     }
 
-    /**
-     * @see Thread#getState()
-     */
+    /** @see Thread#getState() */
     public State getState() {
       return thread.getState();
     }
 
-    /**
-     * @see Thread#join(long)
-     */
+    /** @see Thread#join(long) */
     public void join(long millis) throws InterruptedException {
       thread.join(millis);
     }


### PR DESCRIPTION
Fixes #1286 

The issue says, "Expected WAITING but was RUNNABLE." Translation: the thread is not blocked, instead it has not yet started executing.

This adjustment creates a longer delay (50ms --> 200ms) while also doing two things:
* Adding a BlockingQueue poll to ensure we don't wait any longer than necessary. Once the thread has started, we continue with the test.
* If we fail on this test again due to a timeout (after 200ms), we'll now wait an additional 2 seconds to see if the thread ever starts. We'll fail regardless, but the failure message will tell us if an increase in time would have helped or whether the thread still has not started even after 2 seconds.

Plus: General fixes to raw types and simplified formatting using lambdas on modified functions.