### PR TITLE
chore: Renovate bot should not update this dependency.

### DIFF
--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -96,11 +96,6 @@
         <version>1.10.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-iam-v2:current} -->
       </dependency>
       <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-iam-policy</artifactId>
-        <version>1.10.1-SNAPSHOT</version><!-- {x-version-update:google-iam-policy:current} -->
-      </dependency>
-      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
         <version>2.15.1-SNAPSHOT</version><!-- {x-version-update:proto-google-common-protos:current} -->


### PR DESCRIPTION
Removing google-iam-policy from java-iam/pom.xml dependency management section.
Reference [comment](https://github.com/googleapis/gapic-generator-java/pull/1429#discussion_r1137564797).