### PR TITLE
chore: add client-side streaming showcase integration tests for gRPC support

### DIFF
--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITClientSideStreaming.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITClientSideStreaming.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.core.NoCredentialsProvider;
-import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.CancelledException;
 import com.google.api.gax.rpc.StatusCode;
@@ -50,7 +49,7 @@ public class ITClientSideStreaming {
         EchoSettings.newBuilder()
             .setCredentialsProvider(NoCredentialsProvider.create())
             .setTransportChannelProvider(
-                InstantiatingGrpcChannelProvider.newBuilder()
+                EchoSettings.defaultGrpcTransportProviderBuilder()
                     .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
                     .build())
             .build();

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITClientSideStreaming.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITClientSideStreaming.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.showcase.v1beta1.it;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.CancelledException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.rpc.Status;
+import com.google.showcase.v1beta1.EchoClient;
+import com.google.showcase.v1beta1.EchoRequest;
+import com.google.showcase.v1beta1.EchoResponse;
+import com.google.showcase.v1beta1.EchoSettings;
+import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ITClientSideStreaming {
+
+  private EchoClient grpcClient;
+
+  @Before
+  public void createClients() throws IOException, GeneralSecurityException {
+    // Create gRPC Echo Client
+    EchoSettings grpcEchoSettings =
+        EchoSettings.newBuilder()
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .setTransportChannelProvider(
+                InstantiatingGrpcChannelProvider.newBuilder()
+                    .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
+                    .build())
+            .build();
+    grpcClient = EchoClient.create(grpcEchoSettings);
+  }
+
+  @After
+  public void destroyClient() {
+    grpcClient.close();
+  }
+
+  @Test
+  public void testGrpc_sendStreamedContent_receiveConcatenatedResponse()
+      throws ExecutionException, InterruptedException {
+    CollectStreamObserver<EchoResponse> responseObserver = new CollectStreamObserver<>();
+    ApiStreamObserver<EchoRequest> requestObserver =
+        grpcClient.collectCallable().clientStreamingCall(responseObserver);
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("The").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("rain").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("in").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("Spain").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("stays").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("mainly").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("on").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("the").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("plain").build());
+    requestObserver.onCompleted();
+
+    List<EchoResponse> serverResponse = responseObserver.future().get();
+    assertThat(serverResponse).hasSize(1);
+    assertThat(serverResponse.get(0).getContent())
+        .isEqualTo("The rain in Spain stays mainly on the plain");
+  }
+
+  @Test
+  public void testGrpc_sendStreamedContent_handleServerError() {
+    CollectStreamObserver<EchoResponse> responseObserver = new CollectStreamObserver<>();
+    ApiStreamObserver<EchoRequest> requestObserver =
+        grpcClient.collectCallable().clientStreamingCall(responseObserver);
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("The").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("rain").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("in").build());
+    requestObserver.onNext(EchoRequest.newBuilder().setContent("Spain").build());
+    Status cancelledStatus =
+        Status.newBuilder().setCode(StatusCode.Code.CANCELLED.ordinal()).build();
+    requestObserver.onNext(EchoRequest.newBuilder().setError(cancelledStatus).build());
+    requestObserver.onCompleted();
+
+    ExecutionException exception =
+        assertThrows(ExecutionException.class, () -> responseObserver.future().get());
+    assertThat(exception.getCause()).isInstanceOf(CancelledException.class);
+    CancelledException cancelledException = (CancelledException) exception.getCause();
+    assertThat(cancelledException.getStatusCode().getCode()).isEqualTo(StatusCode.Code.CANCELLED);
+  }
+
+  private class CollectStreamObserver<T> implements ApiStreamObserver<T> {
+
+    private final SettableApiFuture<List<T>> future = SettableApiFuture.create();
+    private final List<T> messages = new ArrayList<>();
+
+    @Override
+    public void onNext(T message) {
+      this.messages.add(message);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      this.future.setException(throwable);
+    }
+
+    @Override
+    public void onCompleted() {
+      future.set(this.messages);
+    }
+
+    public SettableApiFuture<List<T>> future() {
+      return this.future;
+    }
+  }
+}

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITServerSideStreaming.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITServerSideStreaming.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.gax.core.NoCredentialsProvider;
-import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.CancelledException;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.StatusCode;
@@ -32,7 +31,6 @@ import com.google.showcase.v1beta1.EchoSettings;
 import com.google.showcase.v1beta1.ExpandRequest;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import org.junit.After;
@@ -44,13 +42,13 @@ public class ITServerSideStreaming {
   private EchoClient grpcClient;
 
   @Before
-  public void createClients() throws IOException, GeneralSecurityException {
+  public void createClients() throws IOException {
     // Create gRPC Echo Client
     EchoSettings grpcEchoSettings =
         EchoSettings.newBuilder()
             .setCredentialsProvider(NoCredentialsProvider.create())
             .setTransportChannelProvider(
-                InstantiatingGrpcChannelProvider.newBuilder()
+                EchoSettings.defaultGrpcTransportProviderBuilder()
                     .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
                     .build())
             .build();

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITUnaryCallable.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITUnaryCallable.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcStatusCode;
-import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.CancelledException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.rpc.Status;
@@ -50,7 +49,7 @@ public class ITUnaryCallable {
         EchoSettings.newBuilder()
             .setCredentialsProvider(NoCredentialsProvider.create())
             .setTransportChannelProvider(
-                InstantiatingGrpcChannelProvider.newBuilder()
+                EchoSettings.defaultGrpcTransportProviderBuilder()
                     .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
                     .build())
             .build();


### PR DESCRIPTION
Verifies:
- OK Server response when client sends streaming requests to server.
- Handling of Server Error response.