### PR TITLE
chore: handle FlowControllerTest thread start variation by polling

### DIFF
--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
@@ -34,7 +34,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.google.common.base.Stopwatch;
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Blocks the current thread to poll the given assertion until it's successful or the timeout is

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
@@ -36,13 +36,11 @@ import java.time.Duration;
 import java.util.Objects;
 
 /**
- * Blocks the current thread to poll the given assertion until it's successful or the timeout is
- * exceeded. Expected usage:
+ * Blocks the current thread to poll the given assertion every 10ms until it's successful or the
+ * timeout is exceeded. Expected usage:
  *
  * <pre>{@code
- * assertByPollingEvery(10, MILLISECONDS)
- *     .withTimeout(2, SECONDS)
- *     .thatEventually(() -> assertThat(...));
+ * assertByPolling(Duration.ofSeconds(2), () -> assertThat(...));
  * }</pre>
  */
 public class AssertByPolling {

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.google.api.gax.batching;
 
 import com.google.common.base.Preconditions;

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
@@ -1,0 +1,74 @@
+package com.google.api.gax.batching;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Blocks the current thread to poll the given assertion until it's successful or the timeout is
+ * exceeded. Expected usage:
+ *
+ * <pre>{@code
+ * assertByPollingEvery(10, MILLISECONDS)
+ *     .withTimeout(2, SECONDS)
+ *     .thatEventually(() -> assertThat(...));
+ * }</pre>
+ */
+public class AssertByPolling {
+  public static Builder assertByPollingEvery(long pollingInterval, TimeUnit timeUnit) {
+    Preconditions.checkArgument(pollingInterval > 0, "pollingTime must be greater than 0");
+    Objects.requireNonNull(timeUnit, "Polling TimeUnit must not be null");
+    return new Builder(pollingInterval, timeUnit);
+  }
+
+  public static class Builder {
+    private final long pollingInterval;
+    private final TimeUnit pollingUnit;
+
+    private Builder(long pollingInterval, TimeUnit pollingUnit) {
+      Preconditions.checkArgument(pollingInterval > 0, "pollingTime must be greater than 0");
+      this.pollingInterval = pollingInterval;
+      this.pollingUnit = Objects.requireNonNull(pollingUnit, "TimeUnit must not be null");
+    }
+
+    public PollingConfiguration withTimeout(long timeout, TimeUnit timeoutUnit) {
+      Preconditions.checkArgument(timeout > 0, "timeout must be greater than 0");
+      Objects.requireNonNull(timeoutUnit, "TimeUnit must not be null");
+      return new PollingConfiguration(pollingInterval, pollingUnit, timeout, timeoutUnit);
+    }
+  }
+
+  public static class PollingConfiguration {
+    private final long pollingInterval;
+    private final TimeUnit pollingUnit;
+    private final long timeout;
+    private final TimeUnit timeoutUnit;
+
+    private PollingConfiguration(
+        long pollingInterval, TimeUnit pollingUnit, long timeout, TimeUnit timeoutUnit) {
+      this.pollingInterval = pollingInterval;
+      this.pollingUnit = pollingUnit;
+      this.timeout = timeout;
+      this.timeoutUnit = timeoutUnit;
+    }
+
+    /** @param assertion must throw an AssertionError when indicating failure */
+    public void thatEventually(Runnable assertion) throws InterruptedException {
+      Stopwatch stopwatch = Stopwatch.createStarted();
+      while (true) {
+        try {
+          assertion.run();
+          return; // Success
+
+        } catch (AssertionError err) {
+          if (stopwatch.elapsed(timeoutUnit) < timeout) {
+            pollingUnit.sleep(pollingInterval);
+          } else {
+            throw new AssertionError("Timeout waiting for successful assertion.", err);
+          }
+        }
+      }
+    }
+  }
+}

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPolling.java
@@ -29,8 +29,10 @@
  */
 package com.google.api.gax.batching;
 
-import com.google.common.base.Preconditions;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import com.google.common.base.Stopwatch;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -45,57 +47,21 @@ import java.util.concurrent.TimeUnit;
  * }</pre>
  */
 public class AssertByPolling {
-  public static Builder assertByPollingEvery(long pollingInterval, TimeUnit timeUnit) {
-    Preconditions.checkArgument(pollingInterval > 0, "pollingTime must be greater than 0");
-    Objects.requireNonNull(timeUnit, "Polling TimeUnit must not be null");
-    return new Builder(pollingInterval, timeUnit);
-  }
 
-  public static class Builder {
-    private final long pollingInterval;
-    private final TimeUnit pollingUnit;
+  public static void assertByPolling(Duration timeout, Runnable assertion)
+      throws InterruptedException {
+    Objects.requireNonNull(timeout, "Timeout must not be null");
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    while (true) {
+      try {
+        assertion.run();
+        return; // Success
 
-    private Builder(long pollingInterval, TimeUnit pollingUnit) {
-      Preconditions.checkArgument(pollingInterval > 0, "pollingTime must be greater than 0");
-      this.pollingInterval = pollingInterval;
-      this.pollingUnit = Objects.requireNonNull(pollingUnit, "TimeUnit must not be null");
-    }
-
-    public PollingConfiguration withTimeout(long timeout, TimeUnit timeoutUnit) {
-      Preconditions.checkArgument(timeout > 0, "timeout must be greater than 0");
-      Objects.requireNonNull(timeoutUnit, "TimeUnit must not be null");
-      return new PollingConfiguration(pollingInterval, pollingUnit, timeout, timeoutUnit);
-    }
-  }
-
-  public static class PollingConfiguration {
-    private final long pollingInterval;
-    private final TimeUnit pollingUnit;
-    private final long timeout;
-    private final TimeUnit timeoutUnit;
-
-    private PollingConfiguration(
-        long pollingInterval, TimeUnit pollingUnit, long timeout, TimeUnit timeoutUnit) {
-      this.pollingInterval = pollingInterval;
-      this.pollingUnit = pollingUnit;
-      this.timeout = timeout;
-      this.timeoutUnit = timeoutUnit;
-    }
-
-    /** @param assertion must throw an AssertionError when indicating failure */
-    public void thatEventually(Runnable assertion) throws InterruptedException {
-      Stopwatch stopwatch = Stopwatch.createStarted();
-      while (true) {
-        try {
-          assertion.run();
-          return; // Success
-
-        } catch (AssertionError err) {
-          if (stopwatch.elapsed(timeoutUnit) < timeout) {
-            pollingUnit.sleep(pollingInterval);
-          } else {
-            throw new AssertionError("Timeout waiting for successful assertion.", err);
-          }
+      } catch (AssertionError err) {
+        if (stopwatch.elapsed(MILLISECONDS) < timeout.toMillis()) {
+          MILLISECONDS.sleep(10);
+        } else {
+          throw new AssertionError("Timeout waiting for successful assertion.", err);
         }
       }
     }

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.google.api.gax.batching;
 
 import static com.google.api.gax.batching.AssertByPolling.assertByPollingEvery;

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
@@ -29,9 +29,10 @@
  */
 package com.google.api.gax.batching;
 
-import static com.google.api.gax.batching.AssertByPolling.assertByPollingEvery;
+import static com.google.api.gax.batching.AssertByPolling.assertByPolling;
 
 import com.google.common.truth.Truth;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
@@ -44,10 +45,7 @@ public class AssertByPollingTest {
     AssertionError error =
         Assert.assertThrows(
             AssertionError.class,
-            () ->
-                assertByPollingEvery(1, TimeUnit.MILLISECONDS)
-                    .withTimeout(2, TimeUnit.NANOSECONDS)
-                    .thatEventually(() -> Truth.assertThat(1).isAtLeast(2)));
+            () -> assertByPolling(Duration.ofNanos(2), () -> Truth.assertThat(1).isAtLeast(2)));
 
     Throwable cause = error.getCause();
     Truth.assertThat(cause).isInstanceOf(AssertionError.class);
@@ -65,10 +63,8 @@ public class AssertByPollingTest {
             throw new RuntimeException(ex);
           }
         };
-
-    assertByPollingEvery(1, TimeUnit.MILLISECONDS)
-        .withTimeout(1, TimeUnit.NANOSECONDS)
-        .thatEventually(succeedsAfter1ms);
+    Duration timeout = Duration.ofNanos(0);
+    assertByPolling(timeout, succeedsAfter1ms);
   }
 
   @Test
@@ -83,10 +79,8 @@ public class AssertByPollingTest {
           }
         };
 
-    assertByPollingEvery(1, TimeUnit.NANOSECONDS)
-        .withTimeout(100, TimeUnit.MILLISECONDS)
-        .thatEventually(succeedsThirdTime);
-
+    Duration timeout = Duration.ofMillis(100);
+    assertByPolling(timeout, succeedsThirdTime);
     Truth.assertThat(numFailures.get()).isEqualTo(2);
   }
 }

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
@@ -39,11 +39,20 @@ import org.junit.Test;
 
 public class AssertByPollingTest {
 
-  @Test(expected = AssertionError.class)
-  public void testFailsWhenTimeoutExceeded() throws InterruptedException {
-    assertByPollingEvery(1, TimeUnit.MILLISECONDS)
-        .withTimeout(2, TimeUnit.NANOSECONDS)
-        .thatEventually(Assert::fail);
+  @Test
+  public void testFailsWhenTimeoutExceeded() {
+    AssertionError error =
+        Assert.assertThrows(
+            AssertionError.class,
+            () ->
+                assertByPollingEvery(1, TimeUnit.MILLISECONDS)
+                    .withTimeout(2, TimeUnit.NANOSECONDS)
+                    .thatEventually(() -> Truth.assertThat(1).isAtLeast(2)));
+
+    Throwable cause = error.getCause();
+    Truth.assertThat(cause).isInstanceOf(AssertionError.class);
+    // Error provides original assertion failure that never came true.
+    Truth.assertThat(cause.getMessage()).contains("expected to be at least");
   }
 
   @Test

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
@@ -1,0 +1,54 @@
+package com.google.api.gax.batching;
+
+import static com.google.api.gax.batching.AssertByPolling.assertByPollingEvery;
+
+import com.google.common.truth.Truth;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AssertByPollingTest {
+
+  @Test(expected = AssertionError.class)
+  public void testFailsWhenTimeoutExceeded() throws InterruptedException {
+    assertByPollingEvery(1, TimeUnit.MILLISECONDS)
+        .withTimeout(2, TimeUnit.NANOSECONDS)
+        .thatEventually(Assert::fail);
+  }
+
+  @Test
+  public void testImmediateSuccessSucceedsRegardlessOfTimeout() throws InterruptedException {
+    Runnable succeedsAfter1ms =
+        () -> {
+          try {
+            TimeUnit.MILLISECONDS.sleep(1);
+          } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+          }
+        };
+
+    assertByPollingEvery(1, TimeUnit.MILLISECONDS)
+        .withTimeout(1, TimeUnit.NANOSECONDS)
+        .thatEventually(succeedsAfter1ms);
+  }
+
+  @Test
+  public void testSucceedsThirdTime() throws InterruptedException {
+    AtomicInteger attempt = new AtomicInteger(1);
+    AtomicInteger numFailures = new AtomicInteger(0);
+    Runnable succeedsThirdTime =
+        () -> {
+          if (attempt.getAndIncrement() < 3) {
+            numFailures.incrementAndGet();
+            Assert.fail();
+          }
+        };
+
+    assertByPollingEvery(1, TimeUnit.NANOSECONDS)
+        .withTimeout(100, TimeUnit.MILLISECONDS)
+        .thatEventually(succeedsThirdTime);
+
+    Truth.assertThat(numFailures.get()).isEqualTo(2);
+  }
+}

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -29,7 +29,7 @@
  */
 package com.google.api.gax.batching;
 
-import static com.google.api.gax.batching.AssertByPolling.assertByPollingEvery;
+import static com.google.api.gax.batching.AssertByPolling.assertByPolling;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,6 +42,7 @@ import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
 import com.google.common.util.concurrent.SettableFuture;
 import java.lang.Thread.State;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -607,9 +608,7 @@ public class FlowControllerTest {
     t.start();
 
     // wait for thread to start, and check it should be blocked
-    assertByPollingEvery(10, TimeUnit.MILLISECONDS)
-        .withTimeout(200, TimeUnit.MILLISECONDS)
-        .thatEventually(() -> assertEquals(State.WAITING, t.getState()));
+    assertByPolling(Duration.ofMillis(200), () -> assertEquals(State.WAITING, t.getState()));
 
     // increase and decrease should not be blocked
     int increase = 5, decrease = 20;
@@ -653,9 +652,7 @@ public class FlowControllerTest {
     t.start();
 
     // wait for thread to start, and check it should be blocked
-    assertByPollingEvery(10, TimeUnit.MILLISECONDS)
-        .withTimeout(200, TimeUnit.MILLISECONDS)
-        .thatEventually(() -> assertEquals(State.WAITING, t.getState()));
+    assertByPolling(Duration.ofMillis(200), () -> assertEquals(State.WAITING, t.getState()));
 
     // increase and decrease should not be blocked
     int increase = 5, decrease = 20;

--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/FlowControllerTest.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.batching;
 
+import static com.google.api.gax.batching.AssertByPolling.assertByPollingEvery;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -522,10 +523,10 @@ public class FlowControllerTest {
     final AtomicInteger totalDecreased = new AtomicInteger(0);
     final AtomicInteger releasedCounter = new AtomicInteger(0);
 
-    List<Future> reserveThreads =
+    List<Future<?>> reserveThreads =
         testConcurrentUpdates(
             flowController, 100, 100, 10, totalIncreased, totalDecreased, releasedCounter);
-    for (Future t : reserveThreads) {
+    for (Future<?> t : reserveThreads) {
       t.get(200, TimeUnit.MILLISECONDS);
     }
     assertEquals(reserveThreads.size(), releasedCounter.get());
@@ -555,10 +556,10 @@ public class FlowControllerTest {
     AtomicInteger totalIncreased = new AtomicInteger(0);
     AtomicInteger totalDecreased = new AtomicInteger(0);
     AtomicInteger releasedCounter = new AtomicInteger(0);
-    List<Future> reserveThreads =
+    List<Future<?>> reserveThreads =
         testConcurrentUpdates(
             flowController, 100, 100, 100, totalIncreased, totalDecreased, releasedCounter);
-    for (Future t : reserveThreads) {
+    for (Future<?> t : reserveThreads) {
       t.get(200, TimeUnit.MILLISECONDS);
     }
     assertEquals(reserveThreads.size(), releasedCounter.get());
@@ -596,19 +597,20 @@ public class FlowControllerTest {
     // will be blocked by reserve 10
     Thread t =
         new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  flowController.reserve(0, 100);
-                } catch (FlowControlException e) {
-                }
+            () -> {
+              try {
+                flowController.reserve(0, 100);
+              } catch (FlowControlException e) {
+                throw new AssertionError(e);
               }
             });
     t.start();
+
     // wait for thread to start, and check it should be blocked
-    Thread.sleep(50);
-    assertEquals(State.WAITING, t.getState());
+    assertByPollingEvery(10, TimeUnit.MILLISECONDS)
+        .withTimeout(200, TimeUnit.MILLISECONDS)
+        .thatEventually(() -> assertEquals(State.WAITING, t.getState()));
+
     // increase and decrease should not be blocked
     int increase = 5, decrease = 20;
     flowController.decreaseThresholds(0, decrease);
@@ -641,19 +643,20 @@ public class FlowControllerTest {
                 .build());
     Thread t =
         new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  flowController.reserve(initial + 10, 10);
-                } catch (FlowControlException e) {
-                }
+            () -> {
+              try {
+                flowController.reserve(initial + 10, 10);
+              } catch (FlowControlException e) {
+                throw new AssertionError(e);
               }
             });
     t.start();
+
     // wait for thread to start, and check it should be blocked
-    Thread.sleep(50);
-    assertEquals(State.WAITING, t.getState());
+    assertByPollingEvery(10, TimeUnit.MILLISECONDS)
+        .withTimeout(200, TimeUnit.MILLISECONDS)
+        .thatEventually(() -> assertEquals(State.WAITING, t.getState()));
+
     // increase and decrease should not be blocked
     int increase = 5, decrease = 20;
     flowController.decreaseThresholds(decrease, 0);
@@ -734,7 +737,7 @@ public class FlowControllerTest {
         .isAtLeast(currentTime);
   }
 
-  private List<Future> testConcurrentUpdates(
+  private List<Future<?>> testConcurrentUpdates(
       final FlowController flowController,
       final int increaseStepRange,
       final int decreaseStepRange,
@@ -774,8 +777,8 @@ public class FlowControllerTest {
             }
           }
         };
-    List<Future> updateFuture = new ArrayList<>();
-    List<Future> reserveReleaseFuture = new ArrayList<>();
+    List<Future<?>> updateFuture = new ArrayList<>();
+    List<Future<?>> reserveReleaseFuture = new ArrayList<>();
     ExecutorService executors = Executors.newFixedThreadPool(10);
     ExecutorService reserveExecutor = Executors.newFixedThreadPool(10);
     for (int i = 0; i < 5; i++) {
@@ -783,7 +786,7 @@ public class FlowControllerTest {
       updateFuture.add(executors.submit(decreaseRunnable));
       reserveReleaseFuture.add(reserveExecutor.submit(reserveReleaseRunnable));
     }
-    for (Future t : updateFuture) {
+    for (Future<?> t : updateFuture) {
       t.get(50, TimeUnit.MILLISECONDS);
     }
     executors.shutdown();


### PR DESCRIPTION
Fixes #1286 

Issue: "Expected thread to be WAITING (blocked) but instead was RUNNABLE (had not been started yet, or had not yet reached the blocking logic.)"

This PR increases the amount of time spent waiting for the thread to be blocked, while also implementing a polling assertion mechanism to prevent waiting the maximum amount of time.

Also: Raw types fixed in this file.