### PR TITLE
chore: add showcase coverage to full project coverage report

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,26 +32,28 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
+      - name: Install showcase server
+        run: |
+            sudo mkdir -p /usr/src/showcase
+            sudo chown -R ${USER} /usr/src/
+            curl --location https://github.com/googleapis/gapic-showcase/releases/download/v${SHOWCASE_VERSION}/gapic-showcase-${SHOWCASE_VERSION}-linux-amd64.tar.gz --output /usr/src/showcase/showcase-${SHOWCASE_VERSION}-linux-amd64.tar.gz
+            cd /usr/src/showcase/
+            tar -xf showcase-*
+            ./gapic-showcase run &
+            cd -
+      - name: Build and analyze for full test coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           mvn -B verify -Dcheckstyle.skip \
+              -DenableFullTestCoverage \
+              -Penable-integration-tests \
               org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
               -Dsonar.projectKey=googleapis_gapic-generator-java \
               -Dsonar.organization=googleapis \
               -Dsonar.host.url=https://sonarcloud.io
 
-      - name: Install showcase server
-        run: |
-          sudo mkdir -p /usr/src/showcase
-          sudo chown -R ${USER} /usr/src/
-          curl --location https://github.com/googleapis/gapic-showcase/releases/download/v${SHOWCASE_VERSION}/gapic-showcase-${SHOWCASE_VERSION}-linux-amd64.tar.gz --output /usr/src/showcase/showcase-${SHOWCASE_VERSION}-linux-amd64.tar.gz
-          cd /usr/src/showcase/
-          tar -xf showcase-*
-          ./gapic-showcase run &
-          cd -
       - name: Build and analyze Showcase Integration Tests Coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
@@ -60,7 +62,7 @@ jobs:
           mvn -B clean verify -Dcheckstyle.skip \
               -DskipUnitTests \
               -Penable-integration-tests \
-              -DenableTestCoverage \
+              -DenableShowcaseTestCoverage \
               org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
               -Dsonar.projectKey=googleapis_gapic-generator-java_integration_tests \
               -Dsonar.organization=googleapis \
@@ -72,7 +74,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           mvn -B clean test -Dcheckstyle.skip \
-              -DenableTestCoverage \
+              -DenableShowcaseTestCoverage \
               org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
               -Dsonar.projectKey=googleapis_gapic-generator-java_unit_tests \
               -Dsonar.organization=googleapis \

--- a/coverage-report/README.md
+++ b/coverage-report/README.md
@@ -7,7 +7,7 @@ the metrics is to provide insights into how much of api-common and GAX code is b
 ### Unit Test Coverage
 In order to view aggregate unit test coverage of api-common and GAX in `api-common`, `gax-java` and `showcase`:
 
-1. At the root of the repository, run `mvn clean test -DenableTestCoverage`.
+1. At the root of the repository, run `mvn clean test -DenableShowcaseTestCoverage`.
 2. The metrics can be found at `gapic-generator-java/coverage-report/target/site/jacoco-aggregate/index.html`
 
 ![Screenshot 2023-03-23 at 4 29 36 PM](https://user-images.githubusercontent.com/66699525/227346653-b50ec440-71f9-49f4-be21-3976c7f995c7.png)
@@ -16,7 +16,7 @@ In order to view aggregate unit test coverage of api-common and GAX in `api-comm
 
 In order to view aggregate integration test coverage of api-common and GAX in `api-common`, `gax-java` and `showcase`:
 
-1. At the root of the repository, run `mvn clean verify -DskipUnitTests -DenableTestCoverage -Penable-integration-tests`.
+1. At the root of the repository, run `mvn clean verify -DskipUnitTests -DenableShowcaseTestCoverage -Penable-integration-tests`.
 2. The metrics can be found at `gapic-generator-java/coverage-report/target/site/jacoco-aggregate/index.html`
 
 ![Screenshot 2023-03-23 at 4 33 11 PM](https://user-images.githubusercontent.com/66699525/227348487-f1ba2bb8-7577-4280-a1a1-7aa78e242f12.png)

--- a/gapic-generator-java-pom-parent/pom.xml
+++ b/gapic-generator-java-pom-parent/pom.xml
@@ -100,7 +100,7 @@
       <id>test-coverage</id>
       <activation>
         <property>
-          <name>enableTestCoverage</name>
+          <name>enableShowcaseTestCoverage</name>
         </property>
       </activation>
       <build>

--- a/gapic-generator-java/pom.xml
+++ b/gapic-generator-java/pom.xml
@@ -82,7 +82,7 @@
       <id>showcase-sonar-analysis</id>
       <activation>
         <property>
-          <name>enableTestCoverage</name>
+          <name>enableShowcaseTestCoverage</name>
         </property>
       </activation>
       <properties>

--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -181,7 +181,7 @@
       <id>showcase-sonar-analysis</id>
       <activation>
         <property>
-          <name>enableTestCoverage</name>
+          <name>enableShowcaseTestCoverage</name>
         </property>
       </activation>
       <properties>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -220,7 +220,7 @@
       <id>showcase-sonar-analysis</id>
       <activation>
         <property>
-          <name>enableTestCoverage</name>
+          <name>enableShowcaseTestCoverage</name>
         </property>
       </activation>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,22 @@
     </profile>
 
     <profile>
-      <id>activate-test-coverage</id>
+      <id>full-project-coverage</id>
       <activation>
         <property>
-          <name>enableTestCoverage</name>
+          <name>enableFullTestCoverage</name>
+        </property>
+      </activation>
+      <modules>
+        <module>showcase</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>activate-showcase-coverage</id>
+      <activation>
+        <property>
+          <name>enableShowcaseTestCoverage</name>
         </property>
       </activation>
       <modules>


### PR DESCRIPTION
This PR adds showcase coverage to the gapic-generator-java-root sonarcloud project.

Verified with 

```
mvn clean verify -Penable-integration-tests -Dcheckstyle.skip -DenableTestCoverage -Denforcer.skip org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=mpeddada1_gapic-generator-java -Dsonar.organization=mpeddada1 -Dsonar.projectName=gapic-generaator-java-root
```

![Screenshot 2023-04-03 at 1 59 02 PM](https://user-images.githubusercontent.com/66699525/229589671-348cb4da-53e8-41c6-ad09-6e82dc6c0741.png)


