### PR TITLE
build: Update Bazel version to 6.0.0 in .bazeliskrc

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,2 @@
 # See https://github.com/bazelbuild/bazelisk
-USE_BAZEL_VERSION=5.2.0
+USE_BAZEL_VERSION=6.0.0


### PR DESCRIPTION
googleapis is using [6.0.0](https://github.com/googleapis/googleapis/blob/master/.bazeliskrc#L2) to build client libraries now, we should keep it in sync