### PR TITLE
fix(deps): remove unnecessary auto-value in api-common-java

### DIFF
--- a/api-common-java/pom.xml
+++ b/api-common-java/pom.xml
@@ -52,11 +52,6 @@
             <version>${auto-value.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>${auto-value.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-java/issues/1618


https://github.com/google/auto/blob/main/value/userguide/index.md#with-maven says

> You will need auto-value-annotations-${auto-value.version}.jar in your compile-time classpath, and you will need auto-value-${auto-value.version}.jar in your annotation-processor classpath.

- auto-value-annotations is declared as compile-time class path in 3 lines above this change.

- The annotation-processor class path is set in https://github.com/googleapis/gapic-generator-java/blob/main/api-common-java/pom.xml#L97, which this PR does not touch.
