### PR TITLE
chore: Remove Identity gRPC client

### DIFF
--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITCrud.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITCrud.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+// This test does is for HttpJson. gRPC Identity Client is not created for this test.
 public class ITCrud {
 
   private static final User DEFAULT_USER =
@@ -44,13 +45,10 @@ public class ITCrud {
           .setAge(25)
           .build();
 
-  private IdentityClient grpcClient;
   private IdentityClient httpJsonClient;
 
   @Before
   public void setup() throws Exception {
-    // Create gRPC IdentityClient
-    grpcClient = TestClientInitializer.createGrpcIdentityClient();
     // Create HttpJson IdentityClient
     httpJsonClient = TestClientInitializer.createHttpJsonIdentityClient();
 

--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/util/TestClientInitializer.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/util/TestClientInitializer.java
@@ -52,18 +52,6 @@ public class TestClientInitializer {
     return EchoClient.create(httpJsonEchoSettings);
   }
 
-  public static IdentityClient createGrpcIdentityClient() throws Exception {
-    IdentitySettings grpcIdentitySettings =
-        IdentitySettings.newHttpJsonBuilder()
-            .setCredentialsProvider(NoCredentialsProvider.create())
-            .setTransportChannelProvider(
-                IdentitySettings.defaultGrpcTransportProviderBuilder()
-                    .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
-                    .build())
-            .build();
-    return IdentityClient.create(grpcIdentitySettings);
-  }
-
   public static IdentityClient createHttpJsonIdentityClient() throws Exception {
     IdentitySettings httpjsonIdentitySettings =
         IdentitySettings.newHttpJsonBuilder()


### PR DESCRIPTION
Running into this issue in the CIs:
```
Apr 14, 2023 4:21:13 PM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
SEVERE: *~*~*~ Previous channel ManagedChannelImpl{logId=23, target=localhost:7469} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
```