### PR TITLE
chore: Close gRPC Identity client

### DIFF
--- a/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITCrud.java
+++ b/showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITCrud.java
@@ -60,6 +60,7 @@ public class ITCrud {
 
   @After
   public void cleanup() {
+    grpcClient.close();
     httpJsonClient.close();
   }
 


### PR DESCRIPTION
Seeing this error in the CIs:
```
Apr 14, 2023 4:21:13 PM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
SEVERE: *~*~*~ Previous channel ManagedChannelImpl{logId=23, target=localhost:7469} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
```

Forgot to close the gRPC client.