### PR TITLE
test: use a tag in validating gapic-generator-java-bom

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,6 +231,6 @@ jobs:
       run: |
         mvn install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip
     - name: Validate gapic-generator-java-bom
-      uses: googleapis/java-cloud-bom/tests/validate-bom@main
+      uses: googleapis/java-cloud-bom/tests/validate-bom@v26.13.0
       with:
         bom-path: gapic-generator-java-bom/pom.xml


### PR DESCRIPTION
The java-cloud-bom was released today. The tag is "v26.13.0". This includes the recent change in validate-bom action that checks the dependency tree. https://github.com/googleapis/java-cloud-bom/blob/v26.13.0/tests/validate-bom/action.yml