### PR TITLE
feat(deps): add gapic-generator-java to bom

### DIFF
--- a/gapic-generator-java-bom/pom.xml
+++ b/gapic-generator-java-bom/pom.xml
@@ -70,6 +70,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gapic-generator-java</artifactId>
+        <version>2.17.1-SNAPSHOT</version><!-- {x-version-update:gapic-generator-java:current} -->
+      </dependency>
+      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-common-protos</artifactId>
         <version>2.16.1-SNAPSHOT</version><!-- {x-version-update:proto-google-common-protos:current} -->


### PR DESCRIPTION
This PR adds `gapic-generator-java` to the BOM For downstream use in the `spring-cloud-gcp` generator, per discussion in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1686#discussion_r1168802844.

(Side note: I'm not sure if this is the right conventional commit prefix to use, vs. `chore:`?)