### PR TITLE
chore: reduce sleep count in AssertByPollingTest

### DIFF
--- a/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
+++ b/gax-java/gax/src/test/java/com/google/api/gax/batching/AssertByPollingTest.java
@@ -68,19 +68,19 @@ public class AssertByPollingTest {
   }
 
   @Test
-  public void testSucceedsThirdTime() throws InterruptedException {
+  public void testSucceedsAfterInitialFailure() throws InterruptedException {
     AtomicInteger attempt = new AtomicInteger(1);
     AtomicInteger numFailures = new AtomicInteger(0);
-    Runnable succeedsThirdTime =
+    Runnable succeedsSecondTime =
         () -> {
-          if (attempt.getAndIncrement() < 3) {
+          if (attempt.getAndIncrement() < 2) {
             numFailures.incrementAndGet();
             Assert.fail();
           }
         };
 
     Duration timeout = Duration.ofMillis(300);
-    assertByPolling(timeout, succeedsThirdTime);
-    Truth.assertThat(numFailures.get()).isEqualTo(2);
+    assertByPolling(timeout, succeedsSecondTime);
+    Truth.assertThat(numFailures.get()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
In response to flake: https://github.com/googleapis/gapic-generator-java/actions/runs/4781551520/jobs/8500121748

This test previous had its duration increased from 100ms to 300ms. To reduce flakiness without increasing max test time, this PR reduces the number of sleeps that occur from 2 to 1, thus reducing the chance of flakiness to allow the timeout to occur.