### PR TITLE
fix: Unescape Java keyword field names when generating HttpJson unit tests.

### DIFF
--- a/gapic-generator-java/src/main/java/com/google/api/generator/engine/lexicon/Keyword.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/engine/lexicon/Keyword.java
@@ -14,6 +14,7 @@
 
 package com.google.api.generator.engine.lexicon;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 public class Keyword {
@@ -71,9 +72,25 @@ public class Keyword {
           "native",
           "super",
           "while");
+  private static final String ESCAPE_CHAR = "_";
 
   public static boolean isKeyword(String s) {
     return s.equals(CLASS_KEYWORD) || KEYWORDS.contains(s);
+  }
+
+  public static String unescapeKeyword(String str) {
+    if (Strings.isNullOrEmpty(str)) {
+      return str;
+    }
+    if (!str.endsWith(ESCAPE_CHAR)) {
+      return str;
+    }
+    String strWithoutEscapeChar = str.substring(0, str.lastIndexOf(ESCAPE_CHAR));
+    return isKeyword(strWithoutEscapeChar) ? strWithoutEscapeChar : str;
+  }
+
+  public static String escapeKeyword(String str) {
+    return Keyword.isKeyword(str) ? str + ESCAPE_CHAR : str;
   }
 
   public static boolean isInvalidFieldName(String s) {

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/defaultvalue/DefaultValueComposer.java
@@ -30,6 +30,7 @@ import com.google.api.generator.engine.ast.ValueExpr;
 import com.google.api.generator.engine.ast.VaporReference;
 import com.google.api.generator.engine.ast.Variable;
 import com.google.api.generator.engine.ast.VariableExpr;
+import com.google.api.generator.engine.lexicon.Keyword;
 import com.google.api.generator.gapic.composer.resourcename.ResourceNameTokenizer;
 import com.google.api.generator.gapic.model.Field;
 import com.google.api.generator.gapic.model.HttpBindings;
@@ -149,6 +150,7 @@ public class DefaultValueComposer {
       Map<String, String> nestedValuePatterns = new HashMap<>();
       for (Map.Entry<String, String> entry : valuePatterns.entrySet()) {
         String lowerCamelNestedFieldName = JavaStyle.toLowerCamelCase(nestedFieldName);
+        lowerCamelNestedFieldName = Keyword.unescapeKeyword(lowerCamelNestedFieldName);
         if (entry.getKey().startsWith(lowerCamelNestedFieldName + '.')) {
           nestedValuePatterns.put(
               entry.getKey().substring(lowerCamelNestedFieldName.length() + 1), entry.getValue());

--- a/gapic-generator-java/src/main/java/com/google/api/generator/gapic/utils/JavaStyle.java
+++ b/gapic-generator-java/src/main/java/com/google/api/generator/gapic/utils/JavaStyle.java
@@ -39,7 +39,7 @@ public class JavaStyle {
 
     // Some APIs use legit java keywords as method names. Both protobuf and gGRPC add an underscore
     // in generated stubs to resolve name conflict, so we need to do the same.
-    return Keyword.isKeyword(name) ? name + '_' : name;
+    return Keyword.escapeKeyword(name);
   }
 
   public static String toUpperCamelCase(String s) {

--- a/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/KeywordTest.java
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/engine/lexicon/KeywordTest.java
@@ -45,4 +45,34 @@ public class KeywordTest {
     assertThat(Keyword.isKeyword("class")).isTrue();
     assertThat(Keyword.isInvalidFieldName("class")).isFalse();
   }
+
+  @Test
+  public void unescapedKeyword_shouldReturnItselfIfEmpty() {
+    assertThat(Keyword.unescapeKeyword("")).isEqualTo("");
+  }
+
+  @Test
+  public void unescapedKeyword_shouldReturnItselfIfDoesNotEndWithEscapeChar() {
+    assertThat(Keyword.unescapeKeyword("hello")).isEqualTo("hello");
+  }
+
+  @Test
+  public void unescapedKeyword_shouldReturnItselfIfEndsWithEscapeCharButNotAKeyword() {
+    assertThat(Keyword.unescapeKeyword("important_")).isEqualTo("important_");
+  }
+
+  @Test
+  public void unescapedKeyword_shouldUnescapeIfEndsWithEscapeCharAndAKeyword() {
+    assertThat(Keyword.unescapeKeyword("import_")).isEqualTo("import");
+  }
+
+  @Test
+  public void escapeKeyword_shouldEscapeIfIsAKeyword() {
+    assertThat(Keyword.escapeKeyword("final")).isEqualTo("final_");
+  }
+
+  @Test
+  public void escapeKeyword_shouldNotEscapeIfIsNotAKeyword() {
+    assertThat(Keyword.escapeKeyword("fantasy")).isEqualTo("fantasy");
+  }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -18,6 +18,7 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import com.google.rpc.Status;
 import com.google.showcase.grpcrest.v1beta1.stub.EchoStub;
@@ -1043,6 +1044,80 @@ public class EchoClient implements BackgroundResource {
    */
   public final UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
     return stub.noBindingCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   Case case_ = Case.newBuilder().build();
+   *   FieldMask updateMask = FieldMask.newBuilder().build();
+   *   Case response = echoClient.updateCase(case_, updateMask);
+   * }
+   * }</pre>
+   *
+   * @param case_
+   * @param updateMask
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Case updateCase(Case case_, FieldMask updateMask) {
+    UpdateCaseRequest request =
+        UpdateCaseRequest.newBuilder().setCase(case_).setUpdateMask(updateMask).build();
+    return updateCase(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   UpdateCaseRequest request =
+   *       UpdateCaseRequest.newBuilder().setCase(Case.newBuilder().build()).build();
+   *   Case response = echoClient.updateCase(request);
+   * }
+   * }</pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  public final Case updateCase(UpdateCaseRequest request) {
+    return updateCaseCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD.
+  /**
+   * Sample code:
+   *
+   * <pre>{@code
+   * // This snippet has been automatically generated and should be regarded as a code template only.
+   * // It will require modifications to work:
+   * // - It may require correct/in-range values for request initialization.
+   * // - It may require specifying regional endpoints when creating the service client as shown in
+   * // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+   * try (EchoClient echoClient = EchoClient.create()) {
+   *   UpdateCaseRequest request =
+   *       UpdateCaseRequest.newBuilder().setCase(Case.newBuilder().build()).build();
+   *   ApiFuture<Case> future = echoClient.updateCaseCallable().futureCall(request);
+   *   // Do something.
+   *   Case response = future.get();
+   * }
+   * }</pre>
+   */
+  public final UnaryCallable<UpdateCaseRequest, Case> updateCaseCallable() {
+    return stub.updateCaseCallable();
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientHttpJsonTest.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientHttpJsonTest.golden
@@ -17,6 +17,7 @@ import com.google.common.collect.Lists;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.Value;
 import com.google.rpc.Status;
@@ -825,5 +826,63 @@ public class EchoClientHttpJsonTest {
   public void noBindingUnsupportedMethodTest() throws Exception {
     // The noBinding() method is not supported in REST transport.
     // This empty test is generated for technical reasons.
+  }
+
+  @Test
+  public void updateCaseTest() throws Exception {
+    Case expectedResponse =
+        Case.newBuilder()
+            .setName("name3373707")
+            .setDisplayName("displayName1714148973")
+            .setDescription("description-1724546052")
+            .build();
+    mockService.addResponse(expectedResponse);
+
+    Case case_ =
+        Case.newBuilder()
+            .setName("projects/project-3807/cases/case-3807")
+            .setDisplayName("displayName1714148973")
+            .setDescription("description-1724546052")
+            .build();
+    FieldMask updateMask = FieldMask.newBuilder().build();
+
+    Case actualResponse = client.updateCase(case_, updateMask);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+
+    String apiClientHeaderKey =
+        mockService
+            .getRequestHeaders()
+            .get(ApiClientHeaderProvider.getDefaultApiClientHeaderKey())
+            .iterator()
+            .next();
+    Assert.assertTrue(
+        GaxHttpJsonProperties.getDefaultApiClientHeaderPattern()
+            .matcher(apiClientHeaderKey)
+            .matches());
+  }
+
+  @Test
+  public void updateCaseExceptionTest() throws Exception {
+    ApiException exception =
+        ApiExceptionFactory.createException(
+            new Exception(), FakeStatusCode.of(StatusCode.Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      Case case_ =
+          Case.newBuilder()
+              .setName("projects/project-3807/cases/case-3807")
+              .setDisplayName("displayName1714148973")
+              .setDescription("description-1724546052")
+              .build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      client.updateCase(case_, updateMask);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
   }
 }

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClientTest.golden
@@ -21,6 +21,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.Value;
 import com.google.rpc.Status;
@@ -895,6 +896,49 @@ public class EchoClientTest {
               .setFooBar(Foobar.newBuilder().build())
               .build();
       client.noBinding(request);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception.
+    }
+  }
+
+  @Test
+  public void updateCaseTest() throws Exception {
+    Case expectedResponse =
+        Case.newBuilder()
+            .setName("name3373707")
+            .setDisplayName("displayName1714148973")
+            .setDescription("description-1724546052")
+            .build();
+    mockEcho.addResponse(expectedResponse);
+
+    Case case_ = Case.newBuilder().build();
+    FieldMask updateMask = FieldMask.newBuilder().build();
+
+    Case actualResponse = client.updateCase(case_, updateMask);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<AbstractMessage> actualRequests = mockEcho.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateCaseRequest actualRequest = ((UpdateCaseRequest) actualRequests.get(0));
+
+    Assert.assertEquals(case_, actualRequest.getCase());
+    Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
+    Assert.assertTrue(
+        channelProvider.isHeaderSent(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
+  }
+
+  @Test
+  public void updateCaseExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(io.grpc.Status.INVALID_ARGUMENT);
+    mockEcho.addException(exception);
+
+    try {
+      Case case_ = Case.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      client.updateCase(case_, updateMask);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception.

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
@@ -122,6 +122,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     return ((EchoStubSettings) getStubSettings()).noBindingSettings();
   }
 
+  /** Returns the object with the settings used for calls to updateCase. */
+  public UnaryCallSettings<UpdateCaseRequest, Case> updateCaseSettings() {
+    return ((EchoStubSettings) getStubSettings()).updateCaseSettings();
+  }
+
   public static final EchoSettings create(EchoStubSettings stub) throws IOException {
     return new EchoSettings.Builder(stub.toBuilder()).build();
   }
@@ -294,6 +299,11 @@ public class EchoSettings extends ClientSettings<EchoSettings> {
     /** Returns the builder for the settings used for calls to noBinding. */
     public UnaryCallSettings.Builder<EchoRequest, EchoResponse> noBindingSettings() {
       return getStubSettingsBuilder().noBindingSettings();
+    }
+
+    /** Returns the builder for the settings used for calls to updateCase. */
+    public UnaryCallSettings.Builder<UpdateCaseRequest, Case> updateCaseSettings() {
+      return getStubSettingsBuilder().updateCaseSettings();
     }
 
     @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -41,12 +41,14 @@ import com.google.common.collect.Lists;
 import com.google.longrunning.Operation;
 import com.google.showcase.grpcrest.v1beta1.BlockRequest;
 import com.google.showcase.grpcrest.v1beta1.BlockResponse;
+import com.google.showcase.grpcrest.v1beta1.Case;
 import com.google.showcase.grpcrest.v1beta1.EchoRequest;
 import com.google.showcase.grpcrest.v1beta1.EchoResponse;
 import com.google.showcase.grpcrest.v1beta1.ExpandRequest;
 import com.google.showcase.grpcrest.v1beta1.Object;
 import com.google.showcase.grpcrest.v1beta1.PagedExpandRequest;
 import com.google.showcase.grpcrest.v1beta1.PagedExpandResponse;
+import com.google.showcase.grpcrest.v1beta1.UpdateCaseRequest;
 import com.google.showcase.grpcrest.v1beta1.WaitMetadata;
 import com.google.showcase.grpcrest.v1beta1.WaitRequest;
 import com.google.showcase.grpcrest.v1beta1.WaitResponse;
@@ -113,6 +115,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   private final UnaryCallSettings<EchoRequest, Object> nestedBindingSettings;
   private final StreamingCallSettings<EchoRequest, EchoResponse> chatSettings;
   private final UnaryCallSettings<EchoRequest, EchoResponse> noBindingSettings;
+  private final UnaryCallSettings<UpdateCaseRequest, Case> updateCaseSettings;
 
   private static final PagedListDescriptor<PagedExpandRequest, PagedExpandResponse, EchoResponse>
       PAGED_EXPAND_PAGE_STR_DESC =
@@ -277,6 +280,11 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
     return noBindingSettings;
   }
 
+  /** Returns the object with the settings used for calls to updateCase. */
+  public UnaryCallSettings<UpdateCaseRequest, Case> updateCaseSettings() {
+    return updateCaseSettings;
+  }
+
   public EchoStub createStub() throws IOException {
     if (getTransportChannelProvider()
         .getTransportName()
@@ -392,6 +400,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
     nestedBindingSettings = settingsBuilder.nestedBindingSettings().build();
     chatSettings = settingsBuilder.chatSettings().build();
     noBindingSettings = settingsBuilder.noBindingSettings().build();
+    updateCaseSettings = settingsBuilder.updateCaseSettings().build();
   }
 
   /** Builder for EchoStubSettings. */
@@ -413,6 +422,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
     private final UnaryCallSettings.Builder<EchoRequest, Object> nestedBindingSettings;
     private final StreamingCallSettings.Builder<EchoRequest, EchoResponse> chatSettings;
     private final UnaryCallSettings.Builder<EchoRequest, EchoResponse> noBindingSettings;
+    private final UnaryCallSettings.Builder<UpdateCaseRequest, Case> updateCaseSettings;
     private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>>
         RETRYABLE_CODE_DEFINITIONS;
 
@@ -451,6 +461,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
       nestedBindingSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       chatSettings = StreamingCallSettings.newBuilder();
       noBindingSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+      updateCaseSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -461,7 +472,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
               blockSettings,
               collideNameSettings,
               nestedBindingSettings,
-              noBindingSettings);
+              noBindingSettings,
+              updateCaseSettings);
       initDefaults(this);
     }
 
@@ -479,6 +491,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
       nestedBindingSettings = settings.nestedBindingSettings.toBuilder();
       chatSettings = settings.chatSettings.toBuilder();
       noBindingSettings = settings.noBindingSettings.toBuilder();
+      updateCaseSettings = settings.updateCaseSettings.toBuilder();
 
       unaryMethodSettingsBuilders =
           ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
@@ -489,7 +502,8 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
               blockSettings,
               collideNameSettings,
               nestedBindingSettings,
-              noBindingSettings);
+              noBindingSettings,
+              updateCaseSettings);
     }
 
     private static Builder createDefault() {
@@ -561,6 +575,11 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
 
       builder
           .noBindingSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
+
+      builder
+          .updateCaseSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("no_retry_codes"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("no_retry_params"));
 
@@ -665,6 +684,11 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
     /** Returns the builder for the settings used for calls to noBinding. */
     public UnaryCallSettings.Builder<EchoRequest, EchoResponse> noBindingSettings() {
       return noBindingSettings;
+    }
+
+    /** Returns the builder for the settings used for calls to updateCase. */
+    public UnaryCallSettings.Builder<UpdateCaseRequest, Case> updateCaseSettings() {
+      return updateCaseSettings;
     }
 
     @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
@@ -18,12 +18,14 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.GrpcOperationsStub;
 import com.google.showcase.grpcrest.v1beta1.BlockRequest;
 import com.google.showcase.grpcrest.v1beta1.BlockResponse;
+import com.google.showcase.grpcrest.v1beta1.Case;
 import com.google.showcase.grpcrest.v1beta1.EchoRequest;
 import com.google.showcase.grpcrest.v1beta1.EchoResponse;
 import com.google.showcase.grpcrest.v1beta1.ExpandRequest;
 import com.google.showcase.grpcrest.v1beta1.Object;
 import com.google.showcase.grpcrest.v1beta1.PagedExpandRequest;
 import com.google.showcase.grpcrest.v1beta1.PagedExpandResponse;
+import com.google.showcase.grpcrest.v1beta1.UpdateCaseRequest;
 import com.google.showcase.grpcrest.v1beta1.WaitMetadata;
 import com.google.showcase.grpcrest.v1beta1.WaitRequest;
 import com.google.showcase.grpcrest.v1beta1.WaitResponse;
@@ -127,6 +129,14 @@ public class GrpcEchoStub extends EchoStub {
           .setResponseMarshaller(ProtoUtils.marshaller(EchoResponse.getDefaultInstance()))
           .build();
 
+  private static final MethodDescriptor<UpdateCaseRequest, Case> updateCaseMethodDescriptor =
+      MethodDescriptor.<UpdateCaseRequest, Case>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/UpdateCase")
+          .setRequestMarshaller(ProtoUtils.marshaller(UpdateCaseRequest.getDefaultInstance()))
+          .setResponseMarshaller(ProtoUtils.marshaller(Case.getDefaultInstance()))
+          .build();
+
   private final UnaryCallable<EchoRequest, EchoResponse> echoCallable;
   private final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable;
   private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable;
@@ -142,6 +152,7 @@ public class GrpcEchoStub extends EchoStub {
   private final UnaryCallable<EchoRequest, Object> nestedBindingCallable;
   private final BidiStreamingCallable<EchoRequest, EchoResponse> chatCallable;
   private final UnaryCallable<EchoRequest, EchoResponse> noBindingCallable;
+  private final UnaryCallable<UpdateCaseRequest, Case> updateCaseCallable;
 
   private final BackgroundResource backgroundResources;
   private final GrpcOperationsStub operationsStub;
@@ -227,6 +238,16 @@ public class GrpcEchoStub extends EchoStub {
         GrpcCallSettings.<EchoRequest, EchoResponse>newBuilder()
             .setMethodDescriptor(noBindingMethodDescriptor)
             .build();
+    GrpcCallSettings<UpdateCaseRequest, Case> updateCaseTransportSettings =
+        GrpcCallSettings.<UpdateCaseRequest, Case>newBuilder()
+            .setMethodDescriptor(updateCaseMethodDescriptor)
+            .setParamsExtractor(
+                request -> {
+                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                  params.put("case.name", String.valueOf(request.getCase().getName()));
+                  return params.build();
+                })
+            .build();
 
     this.echoCallable =
         callableFactory.createUnaryCallable(
@@ -271,6 +292,9 @@ public class GrpcEchoStub extends EchoStub {
     this.noBindingCallable =
         callableFactory.createUnaryCallable(
             noBindingTransportSettings, settings.noBindingSettings(), clientContext);
+    this.updateCaseCallable =
+        callableFactory.createUnaryCallable(
+            updateCaseTransportSettings, settings.updateCaseSettings(), clientContext);
 
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -344,6 +368,11 @@ public class GrpcEchoStub extends EchoStub {
   @Override
   public UnaryCallable<EchoRequest, EchoResponse> noBindingCallable() {
     return noBindingCallable;
+  }
+
+  @Override
+  public UnaryCallable<UpdateCaseRequest, Case> updateCaseCallable() {
+    return updateCaseCallable;
   }
 
   @Override

--- a/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -27,12 +27,14 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.TypeRegistry;
 import com.google.showcase.grpcrest.v1beta1.BlockRequest;
 import com.google.showcase.grpcrest.v1beta1.BlockResponse;
+import com.google.showcase.grpcrest.v1beta1.Case;
 import com.google.showcase.grpcrest.v1beta1.EchoRequest;
 import com.google.showcase.grpcrest.v1beta1.EchoResponse;
 import com.google.showcase.grpcrest.v1beta1.ExpandRequest;
 import com.google.showcase.grpcrest.v1beta1.Object;
 import com.google.showcase.grpcrest.v1beta1.PagedExpandRequest;
 import com.google.showcase.grpcrest.v1beta1.PagedExpandResponse;
+import com.google.showcase.grpcrest.v1beta1.UpdateCaseRequest;
 import com.google.showcase.grpcrest.v1beta1.WaitMetadata;
 import com.google.showcase.grpcrest.v1beta1.WaitRequest;
 import com.google.showcase.grpcrest.v1beta1.WaitResponse;
@@ -332,6 +334,42 @@ public class HttpJsonEchoStub extends EchoStub {
                   .build())
           .build();
 
+  private static final ApiMethodDescriptor<UpdateCaseRequest, Case> updateCaseMethodDescriptor =
+      ApiMethodDescriptor.<UpdateCaseRequest, Case>newBuilder()
+          .setFullMethodName("google.showcase.grpcrest.v1beta1.Echo/UpdateCase")
+          .setHttpMethod("PATCH")
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              ProtoMessageRequestFormatter.<UpdateCaseRequest>newBuilder()
+                  .setPath(
+                      "/v2beta/{case.name=projects/*/cases/*}",
+                      request -> {
+                        Map<String, String> fields = new HashMap<>();
+                        ProtoRestSerializer<UpdateCaseRequest> serializer =
+                            ProtoRestSerializer.create();
+                        serializer.putPathParam(fields, "case.name", request.getCase().getName());
+                        return fields;
+                      })
+                  .setAdditionalPaths("/v2beta/{case.name=organizations/*/cases/*}")
+                  .setQueryParamsExtractor(
+                      request -> {
+                        Map<String, List<String>> fields = new HashMap<>();
+                        ProtoRestSerializer<UpdateCaseRequest> serializer =
+                            ProtoRestSerializer.create();
+                        serializer.putQueryParam(fields, "updateMask", request.getUpdateMask());
+                        return fields;
+                      })
+                  .setRequestBodyExtractor(
+                      request ->
+                          ProtoRestSerializer.create().toBody("case_", request.getCase(), false))
+                  .build())
+          .setResponseParser(
+              ProtoMessageResponseParser.<Case>newBuilder()
+                  .setDefaultInstance(Case.getDefaultInstance())
+                  .setDefaultTypeRegistry(typeRegistry)
+                  .build())
+          .build();
+
   private final UnaryCallable<EchoRequest, EchoResponse> echoCallable;
   private final ServerStreamingCallable<ExpandRequest, EchoResponse> expandCallable;
   private final UnaryCallable<PagedExpandRequest, PagedExpandResponse> pagedExpandCallable;
@@ -345,6 +383,7 @@ public class HttpJsonEchoStub extends EchoStub {
   private final UnaryCallable<BlockRequest, BlockResponse> blockCallable;
   private final UnaryCallable<EchoRequest, Object> collideNameCallable;
   private final UnaryCallable<EchoRequest, Object> nestedBindingCallable;
+  private final UnaryCallable<UpdateCaseRequest, Case> updateCaseCallable;
 
   private final BackgroundResource backgroundResources;
   private final HttpJsonOperationsStub httpJsonOperationsStub;
@@ -476,6 +515,11 @@ public class HttpJsonEchoStub extends EchoStub {
             .setMethodDescriptor(nestedBindingMethodDescriptor)
             .setTypeRegistry(typeRegistry)
             .build();
+    HttpJsonCallSettings<UpdateCaseRequest, Case> updateCaseTransportSettings =
+        HttpJsonCallSettings.<UpdateCaseRequest, Case>newBuilder()
+            .setMethodDescriptor(updateCaseMethodDescriptor)
+            .setTypeRegistry(typeRegistry)
+            .build();
 
     this.echoCallable =
         callableFactory.createUnaryCallable(
@@ -517,6 +561,9 @@ public class HttpJsonEchoStub extends EchoStub {
     this.nestedBindingCallable =
         callableFactory.createUnaryCallable(
             nestedBindingTransportSettings, settings.nestedBindingSettings(), clientContext);
+    this.updateCaseCallable =
+        callableFactory.createUnaryCallable(
+            updateCaseTransportSettings, settings.updateCaseSettings(), clientContext);
 
     this.backgroundResources =
         new BackgroundResourceAggregation(clientContext.getBackgroundResources());
@@ -533,6 +580,7 @@ public class HttpJsonEchoStub extends EchoStub {
     methodDescriptors.add(blockMethodDescriptor);
     methodDescriptors.add(collideNameMethodDescriptor);
     methodDescriptors.add(nestedBindingMethodDescriptor);
+    methodDescriptors.add(updateCaseMethodDescriptor);
     return methodDescriptors;
   }
 
@@ -594,6 +642,11 @@ public class HttpJsonEchoStub extends EchoStub {
   @Override
   public UnaryCallable<EchoRequest, Object> nestedBindingCallable() {
     return nestedBindingCallable;
+  }
+
+  @Override
+  public UnaryCallable<UpdateCaseRequest, Case> updateCaseCallable() {
+    return updateCaseCallable;
   }
 
   @Override

--- a/gapic-generator-java/src/test/proto/echo_grpcrest.proto
+++ b/gapic-generator-java/src/test/proto/echo_grpcrest.proto
@@ -23,6 +23,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
+import "google/protobuf/field_mask.proto";
 
 package google.showcase.grpcrest.v1beta1;
 
@@ -145,6 +146,20 @@ service Echo {
   }
 
   rpc NoBinding(EchoRequest) returns (EchoResponse);
+
+  //The request message contains a field name that is a Java keyword(case),
+  //the field is also a resource and used in http annotations
+  rpc UpdateCase(UpdateCaseRequest) returns (Case) {
+    option (google.api.http) = {
+      patch: "/v2beta/{case.name=projects/*/cases/*}"
+      body: "case"
+      additional_bindings {
+        patch: "/v2beta/{case.name=organizations/*/cases/*}"
+        body: "case"
+      }
+    };
+    option (google.api.method_signature) = "case,update_mask";
+  }
 }
 
 // Generator should not fail when encounter a service without methods
@@ -158,6 +173,27 @@ enum Severity {
   NECESSARY = 1;
   URGENT = 2;
   CRITICAL = 3;
+}
+
+message UpdateCaseRequest {
+  Case case = 1 [(google.api.field_behavior) = REQUIRED];
+
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+message Case {
+  option (google.api.resource) = {
+    type: "cloudsupport.googleapis.com/Case"
+    pattern: "organizations/{organization}/cases/{case}"
+    pattern: "projects/{project}/cases/{case}"
+  };
+
+  // The resource name for the case.
+  string name = 1;
+
+  string display_name = 2;
+
+  string description = 3;
 }
 
 message Foobar {


### PR DESCRIPTION
Unescape Java keyword field names when generating HttpJson unit tests, if the field is also a resource and used for http annotations. Otherwise we would not be able to populate default values for the field when generating HttpJson unit tests.

fixes: #1652