### PR TITLE
feat: remove directpath enable env

### DIFF
--- a/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
+++ b/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java
@@ -305,9 +305,7 @@ public final class InstantiatingGrpcChannelProvider implements TransportChannelP
 
     // Check DirectPath traffic.
     boolean isDirectPathXdsEnabled = false;
-    if (isDirectPathEnabled()
-        && isNonDefaultServiceAccountAllowed()
-        && isOnComputeEngine()) {
+    if (isDirectPathEnabled() && isNonDefaultServiceAccountAllowed() && isOnComputeEngine()) {
       CallCredentials callCreds = MoreCallCredentials.from(credentials);
       ChannelCredentials channelCreds =
           GoogleDefaultChannelCredentials.newBuilder().callCredentials(callCreds).build();


### PR DESCRIPTION
Remove DirectPath env GOOGLE_CLOUD_ENABLE_DIRECT_PATH. This env is not used by anyone. People who want to use DirectPath should use the `setAttemptDirectPath` option instead.