### PR TITLE
chore: update protobuf dependency to match workspace

### DIFF
--- a/gax-java/dependencies.properties
+++ b/gax-java/dependencies.properties
@@ -23,7 +23,7 @@ version.gax_httpjson=0.111.1-SNAPSHOT
 # Versions for dependencies which actual artifacts differ between Bazel and Gradle.
 # Gradle build depends on prebuilt maven artifacts, while Bazel build depends on Bazel workspaces
 # with the sources.
-version.com_google_protobuf=3.21.10
+version.com_google_protobuf=3.21.12
 version.google_java_format=1.15.0
 version.io_grpc=1.54.0
 


### PR DESCRIPTION
Updating dependencies.properties protobuf version to match workspace version. Looks like renovate-bot doesn't update these automatically.

parent-pom is updated to match workspace: https://github.com/googleapis/gapic-generator-java/blob/main/gapic-generator-java-pom-parent/pom.xml#LL33C24-L33C24